### PR TITLE
🔧 Protect main branch and polish example gallery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,8 @@ repos:
       - id: check-ast
       - id: check-added-large-files
       - id: debug-statements
-      # - id: no-commit-to-branch
-      #   args: [--branch, main, --branch, master]
+      - id: no-commit-to-branch
+        args: [--branch, main]
       - id: requirements-txt-fixer
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Explore our comprehensive [examples gallery](https://cnsplots.farid.one/examples
 
 ## Documentation
 
-Full documentation is available at [farid.one/cnsplots](https://cnsplots.farid.one/)
+Full documentation is available at [cnsplots.farid.one](https://cnsplots.farid.one/)
 
 - [Installation Guide](https://cnsplots.farid.one/installation.html)
 - [API Reference](https://cnsplots.farid.one/api.html)

--- a/examples/plot_040_boxplot.py
+++ b/examples/plot_040_boxplot.py
@@ -211,7 +211,7 @@ iris_melted = iris.melt(
     value_name="value",
 )
 
-cns.figure(200, 120)
+cns.figure(120, 200)
 ax = cns.boxplot(
     data=iris_melted,
     x="measurement",
@@ -230,7 +230,7 @@ plt.setp(ax.get_xticklabels(), ha="right", rotation_mode="anchor")
 # Boxplot with grouped hue and all comparisons within groups
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # When using hue, you can compare all subgroups within a category.
-cns.figure(180, 120)
+cns.figure(120, 180)
 ax = cns.boxplot(
     data=tips,
     x="day",

--- a/examples/plot_050_stackplot.py
+++ b/examples/plot_050_stackplot.py
@@ -119,13 +119,13 @@ ax.set_title("Custom Bar Order")
 # Stacked bar plot with custom width
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Adjust bar width with the ``width`` parameter.
-mp = cns.multipanel(max_width=260)
+mp = cns.multipanel(max_width=250)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 80, 100)
 cns.stackplot(data=tips, x="day", y="sex", normalize=True, width=0.3)
 mp.get_axes("A").set_title("width=0.3 (narrow)")
 
-mp.panel("B", 80, 120)
+mp.panel("B", 80, 100, margin_right=0)
 cns.stackplot(data=tips, x="day", y="sex", normalize=True, width=0.8)
 mp.get_axes("B").set_title("width=0.8 (wide)")
 
@@ -143,13 +143,13 @@ ax.set_title("Set2 Palette")
 # Stacked bar plot with different palettes
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Showcase multiple palette options.
-mp = cns.multipanel(max_width=260)
+mp = cns.multipanel(max_width=250)
 
-mp.panel("A", 80, 120, color_cycle="Bold")
+mp.panel("A", 80, 100, color_cycle="Bold")
 cns.stackplot(data=tips, x="day", y="sex", normalize=True)
 mp.get_axes("A").set_title("Bold")
 
-mp.panel("B", 80, 120, color_cycle="BlueRed")
+mp.panel("B", 80, 100, color_cycle="BlueRed", margin_right=0)
 cns.stackplot(data=tips, x="day", y="sex", normalize=True)
 mp.get_axes("B").set_title("BlueRed")
 

--- a/examples/plot_320_multipanel.py
+++ b/examples/plot_320_multipanel.py
@@ -69,7 +69,7 @@ mp.get_axes("C").set_title("KDE Plot")
 # 3x2 grid with uniform panel sizes
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Consistent panel sizes for organized appearance.
-mp = cns.multipanel(max_width=450)
+mp = cns.multipanel(max_width=440)
 
 mp.panel("A", 100, 100, margin_bottom=20)
 cns.boxplot(data=iris, x="species", y="sepal_length")
@@ -154,7 +154,7 @@ ax_c.set_xlabel("Day of Week")
 # Using custom color palettes
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Apply different palettes to the multi-panel figure.
-mp = cns.multipanel(max_width=460)
+mp = cns.multipanel(max_width=450)
 
 mp.panel("A", 100, 100, pad_top=5, color_cycle="Tableau")
 cns.barplot(data=tips, x="day", y="total_bill")


### PR DESCRIPTION
## What changed
- enabled the `no-commit-to-branch` pre-commit hook for `main`
- fixed the README documentation URL text to match the hosted docs domain
- adjusted boxplot, stackplot, and multipanel example dimensions for a tighter gallery layout

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- the remaining risk is mostly visual: the example sizing changes may still want a quick gallery eyeball check in GitHub Pages or local docs output