### PR TITLE
🔧 Remove no-commit-to-branch pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,6 @@ repos:
       - id: check-ast
       - id: check-added-large-files
       - id: debug-statements
-      - id: no-commit-to-branch
-        args: [--branch, main]
       - id: requirements-txt-fixer
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0


### PR DESCRIPTION
## What changed
- removed the `no-commit-to-branch` hook from pre-commit so linting no longer fails after merges to `main`

## How it was tested
- `make lint`
- `make test`

## Risks or follow-ups
- local pre-commit no longer blocks direct commits to protected branches, so branch protection should remain enforced on GitHub