### PR TITLE
🐛 Fix showcase cropping in Figure 1 panels Q and R

### DIFF
--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -179,7 +179,15 @@ ax = cns.slopeplot(data=slope_df, x="site", y="value", hue="label")
 ax.set_title("Slopeplot")
 
 # Panel Q: scatterplot
-mp.panel("Q", 90, 90, margin_right=50, margin_top=-10, color_cycle="Set1")
+mp.panel(
+    "Q",
+    90,
+    90,
+    margin_right=50,
+    margin_top=-10,
+    margin_bottom=20,
+    color_cycle="Set1",
+)
 ax = cns.scatterplot(
     data=iris_df, x="sepal_length", y="sepal_width", hue="species", s=5
 )
@@ -202,7 +210,7 @@ ax.axvline(
 cns.take_legend_out()
 
 # Panel R: heatmapplot
-mp.panel("R", 80, 190, margin_top=-10, margin_right=0)
+mp.panel("R", 80, 210, margin_top=-10, margin_right=0)
 cmp = cns.heatmapplot(
     blobs,
     label="Z-score",
@@ -216,9 +224,9 @@ cmp = cns.heatmapplot(
     row_dendrogram=True,
     xlabel="Genes",
     ylabel="Patients",
-    legend_hpad=2,
-    legend_vpad=4,
-    legend_hgap=4,
+    legend_hpad=0,
+    legend_vpad=0,
+    legend_hgap=0,
     legend_vgap=0,
     legend_order=["Ensemble", "blobs", "Z-score"],
     xticklabels_rotation=20,

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -226,8 +226,9 @@ cmp = cns.heatmapplot(
     ylabel="Patients",
     legend_hpad=0,
     legend_vpad=0,
-    legend_hgap=0,
+    legend_hgap=2,
     legend_vgap=0,
+    legend_width=3.0,
     legend_order=["Ensemble", "blobs", "Z-score"],
     xticklabels_rotation=20,
 )

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -210,7 +210,7 @@ ax.axvline(
 cns.take_legend_out()
 
 # Panel R: heatmapplot
-mp.panel("R", 80, 210, margin_top=-10, margin_right=0)
+mp.panel("R", 90, 190, margin_top=-10, margin_right=0)
 cmp = cns.heatmapplot(
     blobs,
     label="Z-score",
@@ -224,13 +224,14 @@ cmp = cns.heatmapplot(
     row_dendrogram=True,
     xlabel="Genes",
     ylabel="Patients",
-    legend_hpad=0,
+    legend_hpad=-4,
     legend_vpad=0,
-    legend_hgap=2,
+    legend_hgap=5,
     legend_vgap=0,
     legend_width=3.0,
     legend_order=["Ensemble", "blobs", "Z-score"],
     xticklabels_rotation=20,
+    xlabel_labelpad=0,
 )
 cmp.ax.set_title("Heatmapplot")
 


### PR DESCRIPTION
## What changed
- added bottom margin to panel `Q` in `examples/plot_000_showcase.py` so the scatterplot xlabel stays inside the exported canvas
- increased panel `R` height slightly and tightened the heatmap legend spacing so `Ensemble` sits above `blobs` and the `Z-score` legend no longer gets cropped
- kept the change scoped to the showcase example only

## How it was tested
- exported the updated Figure 1 to `/tmp/figure1-verify.svg` and confirmed the `sepal_length` xlabel and `Z-score` legend text were inside the SVG viewBox
- `make test`
- `make lint`

## Risks or follow-ups
- this is an example-layout fix rather than a broader multipanel autofit change, so other custom showcase layouts would still need their own spacing adjustments if similar crowding appears
