### PR TITLE
🐛 Preserve bold multipanel titles in SVG exports

### DIFF
--- a/src/cnsplots/_svg.py
+++ b/src/cnsplots/_svg.py
@@ -19,7 +19,13 @@ def _collect_bold_texts() -> set[str]:
     """Collect text strings that are bold in the current matplotlib figure."""
     bold_texts: set[str] = set()
     fig = plt.gcf()
-    for artist in fig.findobj(match=lambda obj: isinstance(obj, Text)):
+    text_artists = list(fig.texts)
+    for ax in fig.get_axes():
+        for artist in ax.get_children():
+            if isinstance(artist, Text):
+                text_artists.append(artist)
+
+    for artist in text_artists:
         txt = artist.get_text().strip()
         if not txt:
             continue

--- a/src/cnsplots/_svg.py
+++ b/src/cnsplots/_svg.py
@@ -19,22 +19,19 @@ def _collect_bold_texts() -> set[str]:
     """Collect text strings that are bold in the current matplotlib figure."""
     bold_texts: set[str] = set()
     fig = plt.gcf()
-    for ax in fig.get_axes():
-        for artist in ax.get_children():
-            if not isinstance(artist, Text):
-                continue
-            txt = artist.get_text().strip()
-            if not txt:
-                continue
-            weight = artist.get_fontweight()
-            if weight in ("bold", "heavy", "extra bold", "semibold", "demibold") or (
-                isinstance(weight, (int, float)) and weight >= 600
-            ):
-                bold_texts.add(txt)
-                for line in txt.split("\n"):
-                    line = line.strip()
-                    if line:
-                        bold_texts.add(line)
+    for artist in fig.findobj(match=lambda obj: isinstance(obj, Text)):
+        txt = artist.get_text().strip()
+        if not txt:
+            continue
+        weight = artist.get_fontweight()
+        if weight in ("bold", "heavy", "extra bold", "semibold", "demibold") or (
+            isinstance(weight, (int, float)) and weight >= 600
+        ):
+            bold_texts.add(txt)
+            for line in txt.split("\n"):
+                line = line.strip()
+                if line:
+                    bold_texts.add(line)
     return bold_texts
 
 

--- a/src/cnsplots/_svg.py
+++ b/src/cnsplots/_svg.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from tempfile import TemporaryDirectory
 import warnings
 from typing import TYPE_CHECKING
@@ -13,6 +14,8 @@ import subprocess
 import matplotlib.pyplot as plt
 from lxml import etree
 from matplotlib.text import Text
+
+_PDF_SUBSET_FONT_PREFIX = re.compile(r"^[A-Z]{6}\+")
 
 
 def _collect_bold_texts() -> set[str]:
@@ -125,6 +128,9 @@ def _correct_svg(
     # Restore bold font-weight lost during PDF→SVG conversion
     _restore_bold_fonts(root, ns, bold_texts or set())
 
+    # Normalize PDF subset font names for better SVG editor compatibility
+    _normalize_text_fonts(root, ns)
+
     # Flatten any remaining g elements
     _flatten_groups(root, ns)
 
@@ -184,6 +190,47 @@ def _restore_bold_fonts(
         content = (text_el.text or "").strip()
         if content in bold_texts:
             text_el.set("font-weight", "bold")
+
+
+def _normalize_pdf_font_family(
+    font_family: str,
+) -> tuple[str, str | None, str | None]:
+    """Convert PDF subset font names into SVG-friendly family/style attributes."""
+    normalized_family = _PDF_SUBSET_FONT_PREFIX.sub("", font_family).strip()
+    font_weight = None
+    font_style = None
+
+    for suffix, weight, style in (
+        ("-BoldOblique", "bold", "italic"),
+        ("-BoldItalic", "bold", "italic"),
+        ("-Bold", "bold", None),
+        ("-Oblique", None, "italic"),
+        ("-Italic", None, "italic"),
+    ):
+        if normalized_family.endswith(suffix):
+            normalized_family = normalized_family[: -len(suffix)] or normalized_family
+            font_weight = weight
+            font_style = style
+            break
+
+    return normalized_family, font_weight, font_style
+
+
+def _normalize_text_fonts(root: _Element, ns: dict[str, str]) -> None:
+    """Normalize subsetted PDF font names for broader SVG editor compatibility."""
+    for text_el in root.xpath(".//svg:text", namespaces=ns):
+        font_family = text_el.get("font-family")
+        if not font_family:
+            continue
+
+        normalized_family, font_weight, font_style = _normalize_pdf_font_family(
+            font_family
+        )
+        text_el.set("font-family", normalized_family)
+        if font_weight is not None:
+            text_el.set("font-weight", font_weight)
+        if font_style is not None:
+            text_el.set("font-style", font_style)
 
 
 def _prepend_transform(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -762,29 +762,33 @@ def test_svg_helpers_and_export(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     output_dir.mkdir(parents=True)
-    cns.figure(120, 120)
-    plt.gcf().text(0.5, 0.9, "Figure Bold", fontweight="bold")
-    ax = plt.gca()
-    ax.text(0.5, 0.5, "Bold", fontweight="bold")
+    mp = cns.multipanel(max_width=220, title="Figure Bold")
+    ax = mp.panel("A", width=80, height=60)
+    ax.set_title("Panel Bold")
     ax.text(0.5, 0.3, "Plain")
     bold_texts = _svg._collect_bold_texts()
-    assert "Bold" in bold_texts
     assert "Figure Bold" in bold_texts
+    assert "Panel Bold" in bold_texts
+    assert "A" in bold_texts
 
     svg_in = output_dir / "input.svg"
     svg_out = output_dir / "output.svg"
     svg_in.write_text(
         """<svg xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#c1)"><text x="1" y="1"><tspan x="1" y="1">Bold</tspan></text></g>
+<g clip-path="url(#c1)">
+<text x="1" y="1"><tspan x="1" y="1">Panel Bold</tspan></text>
+<text x="2" y="2"><tspan x="2" y="2">Figure Bold</tspan></text>
+</g>
 </svg>""",
         encoding="utf-8",
     )
-    _svg._correct_svg(str(svg_in), str(svg_out), {"Bold"})
+    _svg._correct_svg(str(svg_in), str(svg_out), {"Panel Bold", "Figure Bold"})
     root = etree.parse(str(svg_out)).getroot()
     ns = {"svg": "http://www.w3.org/2000/svg"}
-    text_el = root.xpath(".//svg:text", namespaces=ns)[0]
-    assert text_el.get("font-weight") == "bold"
-    assert text_el.get("clip-path") == "url(#c1)"
+    text_els = root.xpath(".//svg:text", namespaces=ns)
+    assert len(text_els) == 2
+    assert all(text_el.get("font-weight") == "bold" for text_el in text_els)
+    assert all(text_el.get("clip-path") == "url(#c1)" for text_el in text_els)
 
     svg_image_in = output_dir / "input-image.svg"
     svg_image_out = output_dir / "output-image.svg"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -776,8 +776,10 @@ def test_svg_helpers_and_export(
     svg_in.write_text(
         """<svg xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#c1)">
-<text x="1" y="1"><tspan x="1" y="1">Panel Bold</tspan></text>
-<text x="2" y="2"><tspan x="2" y="2">Figure Bold</tspan></text>
+<text x="1" y="1" font-family="EDQXKT+Helvetica-Bold"><tspan x="1" y="1">Panel Bold</tspan></text>
+<text x="2" y="2" font-family="EDQXKT+Helvetica-Bold"><tspan x="2" y="2">Figure Bold</tspan></text>
+<text x="3" y="3" font-family="EDQXKT+Helvetica-Oblique">Italic</text>
+<text x="4" y="4">No Font</text>
 </g>
 </svg>""",
         encoding="utf-8",
@@ -786,8 +788,14 @@ def test_svg_helpers_and_export(
     root = etree.parse(str(svg_out)).getroot()
     ns = {"svg": "http://www.w3.org/2000/svg"}
     text_els = root.xpath(".//svg:text", namespaces=ns)
-    assert len(text_els) == 2
-    assert all(text_el.get("font-weight") == "bold" for text_el in text_els)
+    assert len(text_els) == 4
+    assert text_els[0].get("font-family") == "Helvetica"
+    assert text_els[0].get("font-weight") == "bold"
+    assert text_els[1].get("font-family") == "Helvetica"
+    assert text_els[1].get("font-weight") == "bold"
+    assert text_els[2].get("font-family") == "Helvetica"
+    assert text_els[2].get("font-style") == "italic"
+    assert text_els[3].get("font-family") is None
     assert all(text_el.get("clip-path") == "url(#c1)" for text_el in text_els)
 
     svg_image_in = output_dir / "input-image.svg"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -763,11 +763,13 @@ def test_svg_helpers_and_export(
 ) -> None:
     output_dir.mkdir(parents=True)
     cns.figure(120, 120)
+    plt.gcf().text(0.5, 0.9, "Figure Bold", fontweight="bold")
     ax = plt.gca()
     ax.text(0.5, 0.5, "Bold", fontweight="bold")
     ax.text(0.5, 0.3, "Plain")
     bold_texts = _svg._collect_bold_texts()
     assert "Bold" in bold_texts
+    assert "Figure Bold" in bold_texts
 
     svg_in = output_dir / "input.svg"
     svg_out = output_dir / "output.svg"


### PR DESCRIPTION
## What changed
- Restore bold SVG text based on matplotlib text weights.
- Normalize subsetted PDF font names into plain SVG font attributes for better Sketch compatibility.
- Add regression coverage for multipanel figure titles, panel labels, and SVG font normalization.

## How it was tested
- make test
- make lint
- Re-exported `/Users/farid/Desktop/Figure1.svg` and verified the multipanel title and panel labels now emit `font-family="Helvetica"` with `font-weight="bold"`.

## Risks or follow-ups
- The showcase example still sets `cns.settings.title_fontweight = "normal"`, so per-panel plot titles in Figure 1 remain regular by design.