### PR TITLE
🐛 Fix Figure 2 showcase dotplot legend layout

### DIFF
--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -284,10 +284,12 @@ dp = cns.dotplot(
     yticklabels_fontsize=6,
     max_s=40,
 )
-for label in dp.heatmap_axes[-1, 0].get_xticklabels():
+hm_ax = dp.heatmap_axes[-1, 0]
+for label in hm_ax.get_xticklabels():
     label.set_ha("right")
     label.set_rotation_mode("anchor")
-dp.ax_heatmap.set_title("Dotplot")
+dp.ax_heatmap.set_title("")
+hm_ax.set_title("Dotplot")
 
 cbar = next(obj for obj in dp.cbars if isinstance(obj, Colorbar))
 size_legend = next(obj for obj in dp.cbars if isinstance(obj, Legend))
@@ -313,18 +315,18 @@ def _sync_panel_c_dotplot() -> None:
         original_detached_sync()
 
     host_box = host_c.get_position().frozen()
-    dp.ax_heatmap.set_position(
-        [
-            host_box.x0,
-            host_box.y0,
-            host_box.width * 0.34,
-            host_box.height,
-        ]
-    )
-    legend_box = [
-        host_box.x0 + host_box.width * 0.80,
+    heatmap_box = [
+        host_box.x0,
         host_box.y0,
-        host_box.width * 0.20,
+        host_box.width * 0.55,
+        host_box.height,
+    ]
+    dp.ax_heatmap.set_position(heatmap_box)
+    hm_ax.set_position(heatmap_box)
+    legend_box = [
+        host_box.x0 + host_box.width * 0.72,
+        host_box.y0,
+        host_box.width * 0.28,
         host_box.height,
     ]
     legend_ax.set_position(legend_box)

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -315,30 +315,34 @@ def _sync_panel_c_dotplot() -> None:
         original_detached_sync()
 
     host_box = host_c.get_position().frozen()
+    left_pad = host_box.width * 0.07
+    top_pad = host_box.height * 0.10
+    content_height = host_box.height - top_pad
     heatmap_box = [
-        host_box.x0,
+        host_box.x0 + left_pad,
         host_box.y0,
-        host_box.width * 0.55,
-        host_box.height,
+        host_box.width * 0.44,
+        content_height,
     ]
     dp.ax_heatmap.set_position(heatmap_box)
     hm_ax.set_position(heatmap_box)
     legend_box = [
-        host_box.x0 + host_box.width * 0.72,
+        host_box.x0 + host_box.width * 0.68,
         host_box.y0,
-        host_box.width * 0.28,
-        host_box.height,
+        host_box.width * 0.30,
+        content_height,
     ]
     legend_ax.set_position(legend_box)
+    cbar_width = host_box.width * 0.022
     cbar_ax.set_position(
         [
             legend_box[0],
-            host_box.y0 + host_box.height * 0.20,
-            host_box.width * 0.03,
-            host_box.height * 0.78,
+            legend_box[1] + legend_box[3] * 0.18,
+            cbar_width,
+            legend_box[3] * 0.72,
         ]
     )
-    size_legend.set_bbox_to_anchor((0.05, 0.58), transform=legend_ax.transAxes)
+    size_legend.set_bbox_to_anchor((0.42, 0.56), transform=legend_ax.transAxes)
     legend_ax.set_axis_off()
 
 

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -295,6 +295,40 @@ dp.cbar_ax.tick_params(labelsize=6, length=0)
 dp.cbar_ax.set_title("size", fontsize=6, pad=1)
 dp.cbar_ax.set_ylabel("")
 
+
+def _finalize_panel_c() -> None:
+    if mp.fig is not None:
+        mp.fig.canvas.draw()
+    setattr(host_c, "_cnsplots_sync_embedded_axes", None)
+    setattr(host_c, "_cnsplots_sync_detached_legends", None)
+    host_box = host_c.get_position().frozen()
+    heatmap_box = [
+        host_box.x0 + host_box.width * 0.06,
+        host_box.y0,
+        host_box.width * 0.40,
+        host_box.height * 0.90,
+    ]
+    legend_box = [
+        host_box.x0 + host_box.width * 0.63,
+        host_box.y0,
+        host_box.width * 0.33,
+        host_box.height * 0.90,
+    ]
+    dp.ax_heatmap.set_position(heatmap_box)
+    hm_ax.set_position(heatmap_box)
+    dp.legend_ax.set_position(legend_box)
+    dp.cbar_ax.set_position(
+        [
+            legend_box[0],
+            legend_box[1] + legend_box[3] * 0.16,
+            host_box.width * 0.018,
+            legend_box[3] * 0.70,
+        ]
+    )
+    dp.dot_legend.set_bbox_to_anchor((0.66, 1.02), transform=dp.legend_ax.transAxes)
+    dp.legend_ax.set_axis_off()
+
+
 # Panel D: ?
 ax = mp.panel("D", 85, 85, margin_right=0)
 cns.placeholderplot("Placeholder")
@@ -368,37 +402,7 @@ ax = mp.panel("L", 100, 100)
 cns.placeholderplot("Placeholder")
 ax.set_title("?")
 
-# Finalize panel C after the multipanel layout settles.
-if mp.fig is not None:
-    mp.fig.canvas.draw()
-setattr(host_c, "_cnsplots_sync_embedded_axes", None)
-setattr(host_c, "_cnsplots_sync_detached_legends", None)
-host_box = host_c.get_position().frozen()
-heatmap_box = [
-    host_box.x0 + host_box.width * 0.06,
-    host_box.y0,
-    host_box.width * 0.40,
-    host_box.height * 0.90,
-]
-legend_box = [
-    host_box.x0 + host_box.width * 0.63,
-    host_box.y0,
-    host_box.width * 0.33,
-    host_box.height * 0.90,
-]
-dp.ax_heatmap.set_position(heatmap_box)
-hm_ax.set_position(heatmap_box)
-dp.legend_ax.set_position(legend_box)
-dp.cbar_ax.set_position(
-    [
-        legend_box[0],
-        legend_box[1] + legend_box[3] * 0.16,
-        host_box.width * 0.018,
-        legend_box[3] * 0.70,
-    ]
-)
-dp.dot_legend.set_bbox_to_anchor((0.66, 1.02), transform=dp.legend_ax.transAxes)
-dp.legend_ax.set_axis_off()
+_finalize_panel_c()
 
 # Save final figure
 cns.savefig("~/Desktop/Figure2.jpg")

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -260,10 +260,29 @@ ax.imshow(mpimg.imread(showcase_images / "image2.webp"))
 ax.set_title("Immunofluorescence")
 ax.set_axis_off()
 
-# Panel C: ?
-ax = mp.panel("C", 85, 85)
-cns.placeholderplot("Placeholder")
-ax.set_title("?")
+# Panel C: dotplot
+mp.panel("C", 60, 100, pad_top=30, pad_left=20)
+tips_minmax = tips_df.groupby(["day", "sex"]).agg({"total_bill": ["min", "size"]})
+tips_minmax.columns = ["min", "size"]
+tips_minmax = tips_minmax.reset_index()
+dp = cns.dotplot(
+    tips_minmax,
+    x="sex",
+    y="day",
+    color="size",
+    size="min",
+    value="size",
+    legend=True,
+    legend_width=10,
+    legend_hpad=0,
+    xlabel="",
+    ylabel="",
+    xticklabels_rotation=60,
+    max_s=40,
+)
+for label in dp.heatmap_axes[-1, 0].get_xticklabels():
+    label.set_ha("center")
+dp.ax_heatmap.set_title("Dotplot")
 
 # Panel D: ?
 ax = mp.panel("D", 85, 85, margin_right=0)
@@ -275,29 +294,6 @@ ax = mp.panel("E", 102, 116, below="B", pad_left=-50)
 ax.imshow(mpimg.imread(showcase_images / "image4.webp"))
 ax.set_title("Western Blot")
 ax.set_axis_off()
-
-# Panel F: dotplot
-# mp.panel("F", 60, 60, below="D")
-# tips_minmax = tips_df.groupby(["day", "sex"]).agg({"total_bill": ["min", "size"]})
-# tips_minmax.columns = ["min", "size"]
-# tips_minmax = tips_minmax.reset_index()
-# plt.sca(mp.get_axes("E"))
-# dp = cns.dotplot(
-#     tips_minmax,
-#     x="sex",
-#     y="day",
-#     color="size",
-#     size="min",
-#     value="size",
-#     legend=False,
-#     xlabel="",
-#     ylabel="",
-#     xticklabels_rotation=60,
-#     max_s=40,
-# )
-# for label in dp.heatmap_axes[-1, 0].get_xticklabels():
-#     label.set_ha("center")
-# dp.ax_heatmap.set_title("Dotplot")
 
 # Panel F: lineplot
 ax = mp.panel("F", 85, 85, below="C", margin_top=15)
@@ -362,4 +358,4 @@ cns.placeholderplot("Placeholder")
 ax.set_title("?")
 
 # Save final figure
-cns.savefig("~/Desktop/Figure2.svg")
+cns.savefig("~/Desktop/Figure2.jpg")

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -263,7 +263,7 @@ ax.set_title("Immunofluorescence")
 ax.set_axis_off()
 
 # Panel C: dotplot
-host_c = mp.panel("C", 60, 80, pad_top=20, pad_left=40, margin_right=20)
+host_c = mp.panel("C", 90, 80, pad_top=20, pad_left=40, margin_right=20)
 tips_minmax = tips_df.groupby(["day", "sex"]).agg({"total_bill": ["min", "size"]})
 tips_minmax.columns = ["min", "size"]
 tips_minmax = tips_minmax.reset_index()
@@ -342,7 +342,7 @@ def _sync_panel_c_dotplot() -> None:
             legend_box[3] * 0.72,
         ]
     )
-    size_legend.set_bbox_to_anchor((0.42, 0.72), transform=legend_ax.transAxes)
+    size_legend.set_bbox_to_anchor((0.42, 1.1), transform=legend_ax.transAxes)
     legend_ax.set_axis_off()
 
 
@@ -362,7 +362,7 @@ ax.set_title("Western Blot")
 ax.set_axis_off()
 
 # Panel F: lineplot
-ax = mp.panel("F", 85, 85, below="C", margin_top=48)
+ax = mp.panel("F", 80, 80, below="C", margin_top=15)
 ax = cns.lineplot(
     data=line_df,
     x="timepoint",
@@ -377,7 +377,7 @@ if legend is not None:
 ax.set_title("Lineplot")
 
 # Panel G: qqplot
-ax = mp.panel("G", 85, 85, below="D", margin_top=15, margin_right=0)
+ax = mp.panel("G", 80, 80, below="D", margin_top=15, margin_right=0)
 ax = cns.qqplot(iris_df, x="sepal_length", dist=stats.norm, fit=True, line="45")
 ax.set_title("Qqplot")
 

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -12,8 +12,6 @@ focused per-feature examples in the rest of the gallery.
 # Load data
 # ~~~~~~~~~
 import matplotlib.image as mpimg
-from matplotlib.colorbar import Colorbar
-from matplotlib.legend import Legend
 from scipy import stats
 
 import cnsplots as cns
@@ -284,17 +282,18 @@ dp = cns.dotplot(
     yticklabels_fontsize=6,
     max_s=40,
 )
-hm_ax = dp.heatmap_axes[-1, 0]
+hm_ax = dp.hm_ax
 for label in hm_ax.get_xticklabels():
     label.set_ha("right")
     label.set_rotation_mode("anchor")
 dp.ax_heatmap.set_title("")
 hm_ax.set_title("Dotplot")
 
-cbar = next(obj for obj in dp.cbars if isinstance(obj, Colorbar))
-size_legend = next(obj for obj in dp.cbars if isinstance(obj, Legend))
-legend_ax = size_legend.axes
-cbar_ax = cbar.ax
+size_legend = dp.dot_legend
+legend_ax = dp.legend_ax
+cbar_ax = dp.cbar_ax
+if size_legend is None or legend_ax is None or cbar_ax is None:
+    raise RuntimeError("Dotplot legends were not created")
 
 size_legend.get_title().set_fontsize(6)
 for text in size_legend.get_texts():
@@ -302,53 +301,6 @@ for text in size_legend.get_texts():
 cbar_ax.tick_params(labelsize=6, length=0)
 cbar_ax.set_title("size", fontsize=6, pad=1)
 cbar_ax.set_ylabel("")
-
-original_embedded_sync = getattr(host_c, "_cnsplots_sync_embedded_axes", None)
-original_detached_sync = getattr(host_c, "_cnsplots_sync_detached_legends", None)
-
-
-def _sync_panel_c_dotplot() -> None:
-    """Keep the dotplot and both legends inside panel C during relayout."""
-    if callable(original_embedded_sync):
-        original_embedded_sync()
-    if callable(original_detached_sync):
-        original_detached_sync()
-
-    host_box = host_c.get_position().frozen()
-    left_pad = host_box.width * 0.07
-    top_pad = host_box.height * 0.10
-    content_height = host_box.height - top_pad
-    heatmap_box = [
-        host_box.x0 + left_pad,
-        host_box.y0,
-        host_box.width * 0.44,
-        content_height,
-    ]
-    dp.ax_heatmap.set_position(heatmap_box)
-    hm_ax.set_position(heatmap_box)
-    legend_box = [
-        host_box.x0 + host_box.width * 0.68,
-        host_box.y0,
-        host_box.width * 0.30,
-        content_height,
-    ]
-    legend_ax.set_position(legend_box)
-    cbar_width = host_box.width * 0.022
-    cbar_ax.set_position(
-        [
-            legend_box[0],
-            legend_box[1] + legend_box[3] * 0.18,
-            cbar_width,
-            legend_box[3] * 0.72,
-        ]
-    )
-    size_legend.set_bbox_to_anchor((0.42, 1.1), transform=legend_ax.transAxes)
-    legend_ax.set_axis_off()
-
-
-host_c._cnsplots_sync_embedded_axes = _sync_panel_c_dotplot
-host_c._cnsplots_sync_detached_legends = _sync_panel_c_dotplot
-_sync_panel_c_dotplot()
 
 # Panel D: ?
 ax = mp.panel("D", 85, 85, margin_right=0)
@@ -422,6 +374,38 @@ ax.set_title("Confusionplot")
 ax = mp.panel("L", 100, 100)
 cns.placeholderplot("Placeholder")
 ax.set_title("?")
+
+# Finalize panel C after the multipanel layout settles.
+if mp.fig is not None:
+    mp.fig.canvas.draw()
+setattr(host_c, "_cnsplots_sync_embedded_axes", None)
+setattr(host_c, "_cnsplots_sync_detached_legends", None)
+host_box = host_c.get_position().frozen()
+heatmap_box = [
+    host_box.x0 + host_box.width * 0.07,
+    host_box.y0,
+    host_box.width * 0.44,
+    host_box.height * 0.90,
+]
+legend_box = [
+    host_box.x0 + host_box.width * 0.68,
+    host_box.y0,
+    host_box.width * 0.30,
+    host_box.height * 0.90,
+]
+dp.ax_heatmap.set_position(heatmap_box)
+hm_ax.set_position(heatmap_box)
+legend_ax.set_position(legend_box)
+cbar_ax.set_position(
+    [
+        legend_box[0],
+        legend_box[1] + legend_box[3] * 0.18,
+        host_box.width * 0.022,
+        legend_box[3] * 0.72,
+    ]
+)
+size_legend.set_bbox_to_anchor((0.42, 1.1), transform=legend_ax.transAxes)
+legend_ax.set_axis_off()
 
 # Save final figure
 cns.savefig("~/Desktop/Figure2.jpg")

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -12,6 +12,8 @@ focused per-feature examples in the rest of the gallery.
 # Load data
 # ~~~~~~~~~
 import matplotlib.image as mpimg
+from matplotlib.colorbar import Colorbar
+from matplotlib.legend import Legend
 from scipy import stats
 
 import cnsplots as cns
@@ -261,7 +263,7 @@ ax.set_title("Immunofluorescence")
 ax.set_axis_off()
 
 # Panel C: dotplot
-mp.panel("C", 60, 100, pad_top=30, pad_left=20)
+host_c = mp.panel("C", 60, 116, pad_top=30, pad_left=4)
 tips_minmax = tips_df.groupby(["day", "sex"]).agg({"total_bill": ["min", "size"]})
 tips_minmax.columns = ["min", "size"]
 tips_minmax = tips_minmax.reset_index()
@@ -277,12 +279,69 @@ dp = cns.dotplot(
     legend_hpad=0,
     xlabel="",
     ylabel="",
-    xticklabels_rotation=60,
+    xticklabels_rotation=30,
+    xticklabels_fontsize=6,
+    yticklabels_fontsize=6,
     max_s=40,
 )
 for label in dp.heatmap_axes[-1, 0].get_xticklabels():
-    label.set_ha("center")
+    label.set_ha("right")
+    label.set_rotation_mode("anchor")
 dp.ax_heatmap.set_title("Dotplot")
+
+cbar = next(obj for obj in dp.cbars if isinstance(obj, Colorbar))
+size_legend = next(obj for obj in dp.cbars if isinstance(obj, Legend))
+legend_ax = size_legend.axes
+cbar_ax = cbar.ax
+
+size_legend.get_title().set_fontsize(6)
+for text in size_legend.get_texts():
+    text.set_fontsize(6)
+cbar_ax.tick_params(labelsize=6, length=0)
+cbar_ax.yaxis.label.set_size(6)
+
+original_embedded_sync = getattr(host_c, "_cnsplots_sync_embedded_axes", None)
+original_detached_sync = getattr(host_c, "_cnsplots_sync_detached_legends", None)
+
+
+def _sync_panel_c_dotplot() -> None:
+    """Keep the dotplot and both legends inside panel C during relayout."""
+    if callable(original_embedded_sync):
+        original_embedded_sync()
+    if callable(original_detached_sync):
+        original_detached_sync()
+
+    host_box = host_c.get_position().frozen()
+    dp.ax_heatmap.set_position(
+        [
+            host_box.x0,
+            host_box.y0,
+            host_box.width * 0.49,
+            host_box.height,
+        ]
+    )
+    legend_box = [
+        host_box.x0 + host_box.width * 0.70,
+        host_box.y0,
+        host_box.width * 0.30,
+        host_box.height,
+    ]
+    legend_ax.set_position(legend_box)
+    cbar_ax.set_position(
+        [
+            legend_box[0],
+            host_box.y0 + host_box.height * 0.20,
+            host_box.width * 0.048,
+            host_box.height * 0.78,
+        ]
+    )
+    size_legend.set_bbox_to_anchor((0.28, 0.58), transform=legend_ax.transAxes)
+    legend_ax.set_axis_off()
+
+
+host_c._cnsplots_sync_embedded_axes = _sync_panel_c_dotplot
+host_c._cnsplots_sync_detached_legends = _sync_panel_c_dotplot
+_sync_panel_c_dotplot()
 
 # Panel D: ?
 ax = mp.panel("D", 85, 85, margin_right=0)
@@ -296,7 +355,7 @@ ax.set_title("Western Blot")
 ax.set_axis_off()
 
 # Panel F: lineplot
-ax = mp.panel("F", 85, 85, below="C", margin_top=15)
+ax = mp.panel("F", 85, 85, below="C", margin_top=48)
 ax = cns.lineplot(
     data=line_df,
     x="timepoint",

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -263,7 +263,7 @@ ax.set_title("Immunofluorescence")
 ax.set_axis_off()
 
 # Panel C: dotplot
-host_c = mp.panel("C", 60, 120, pad_top=30, pad_left=0)
+host_c = mp.panel("C", 60, 80, pad_top=20, pad_left=40, margin_right=20)
 tips_minmax = tips_df.groupby(["day", "sex"]).agg({"total_bill": ["min", "size"]})
 tips_minmax.columns = ["min", "size"]
 tips_minmax = tips_minmax.reset_index()

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -263,7 +263,7 @@ ax.set_title("Immunofluorescence")
 ax.set_axis_off()
 
 # Panel C: dotplot
-host_c = mp.panel("C", 60, 116, pad_top=30, pad_left=4)
+host_c = mp.panel("C", 60, 120, pad_top=30, pad_left=0)
 tips_minmax = tips_df.groupby(["day", "sex"]).agg({"total_bill": ["min", "size"]})
 tips_minmax.columns = ["min", "size"]
 tips_minmax = tips_minmax.reset_index()
@@ -279,7 +279,7 @@ dp = cns.dotplot(
     legend_hpad=0,
     xlabel="",
     ylabel="",
-    xticklabels_rotation=30,
+    xticklabels_rotation=25,
     xticklabels_fontsize=6,
     yticklabels_fontsize=6,
     max_s=40,
@@ -298,7 +298,8 @@ size_legend.get_title().set_fontsize(6)
 for text in size_legend.get_texts():
     text.set_fontsize(6)
 cbar_ax.tick_params(labelsize=6, length=0)
-cbar_ax.yaxis.label.set_size(6)
+cbar_ax.set_title("size", fontsize=6, pad=1)
+cbar_ax.set_ylabel("")
 
 original_embedded_sync = getattr(host_c, "_cnsplots_sync_embedded_axes", None)
 original_detached_sync = getattr(host_c, "_cnsplots_sync_detached_legends", None)
@@ -316,14 +317,14 @@ def _sync_panel_c_dotplot() -> None:
         [
             host_box.x0,
             host_box.y0,
-            host_box.width * 0.49,
+            host_box.width * 0.34,
             host_box.height,
         ]
     )
     legend_box = [
-        host_box.x0 + host_box.width * 0.70,
+        host_box.x0 + host_box.width * 0.80,
         host_box.y0,
-        host_box.width * 0.30,
+        host_box.width * 0.20,
         host_box.height,
     ]
     legend_ax.set_position(legend_box)
@@ -331,11 +332,11 @@ def _sync_panel_c_dotplot() -> None:
         [
             legend_box[0],
             host_box.y0 + host_box.height * 0.20,
-            host_box.width * 0.048,
+            host_box.width * 0.03,
             host_box.height * 0.78,
         ]
     )
-    size_legend.set_bbox_to_anchor((0.28, 0.58), transform=legend_ax.transAxes)
+    size_legend.set_bbox_to_anchor((0.05, 0.58), transform=legend_ax.transAxes)
     legend_ax.set_axis_off()
 
 

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -295,40 +295,6 @@ dp.cbar_ax.tick_params(labelsize=6, length=0)
 dp.cbar_ax.set_title("size", fontsize=6, pad=1)
 dp.cbar_ax.set_ylabel("")
 
-
-def _finalize_panel_c() -> None:
-    if mp.fig is not None:
-        mp.fig.canvas.draw()
-    setattr(host_c, "_cnsplots_sync_embedded_axes", None)
-    setattr(host_c, "_cnsplots_sync_detached_legends", None)
-    host_box = host_c.get_position().frozen()
-    heatmap_box = [
-        host_box.x0 + host_box.width * 0.06,
-        host_box.y0,
-        host_box.width * 0.40,
-        host_box.height * 0.90,
-    ]
-    legend_box = [
-        host_box.x0 + host_box.width * 0.63,
-        host_box.y0,
-        host_box.width * 0.33,
-        host_box.height * 0.90,
-    ]
-    dp.ax_heatmap.set_position(heatmap_box)
-    hm_ax.set_position(heatmap_box)
-    dp.legend_ax.set_position(legend_box)
-    dp.cbar_ax.set_position(
-        [
-            legend_box[0],
-            legend_box[1] + legend_box[3] * 0.16,
-            host_box.width * 0.018,
-            legend_box[3] * 0.70,
-        ]
-    )
-    dp.dot_legend.set_bbox_to_anchor((0.66, 1.02), transform=dp.legend_ax.transAxes)
-    dp.legend_ax.set_axis_off()
-
-
 # Panel D: ?
 ax = mp.panel("D", 85, 85, margin_right=0)
 cns.placeholderplot("Placeholder")
@@ -402,7 +368,37 @@ ax = mp.panel("L", 100, 100)
 cns.placeholderplot("Placeholder")
 ax.set_title("?")
 
-_finalize_panel_c()
+# Finalize panel C after the multipanel layout settles.
+if mp.fig is not None:
+    mp.fig.canvas.draw()
+setattr(host_c, "_cnsplots_sync_embedded_axes", None)
+setattr(host_c, "_cnsplots_sync_detached_legends", None)
+host_box = host_c.get_position().frozen()
+heatmap_box = [
+    host_box.x0 + host_box.width * 0.06,
+    host_box.y0,
+    host_box.width * 0.40,
+    host_box.height * 0.90,
+]
+legend_box = [
+    host_box.x0 + host_box.width * 0.63,
+    host_box.y0,
+    host_box.width * 0.33,
+    host_box.height * 0.90,
+]
+dp.ax_heatmap.set_position(heatmap_box)
+hm_ax.set_position(heatmap_box)
+dp.legend_ax.set_position(legend_box)
+dp.cbar_ax.set_position(
+    [
+        legend_box[0],
+        legend_box[1] + legend_box[3] * 0.16,
+        host_box.width * 0.018,
+        legend_box[3] * 0.70,
+    ]
+)
+dp.dot_legend.set_bbox_to_anchor((0.66, 1.02), transform=dp.legend_ax.transAxes)
+dp.legend_ax.set_axis_off()
 
 # Save final figure
 cns.savefig("~/Desktop/Figure2.jpg")

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -288,19 +288,12 @@ for label in hm_ax.get_xticklabels():
     label.set_rotation_mode("anchor")
 dp.ax_heatmap.set_title("")
 hm_ax.set_title("Dotplot")
-
-size_legend = dp.dot_legend
-legend_ax = dp.legend_ax
-cbar_ax = dp.cbar_ax
-if size_legend is None or legend_ax is None or cbar_ax is None:
-    raise RuntimeError("Dotplot legends were not created")
-
-size_legend.get_title().set_fontsize(6)
-for text in size_legend.get_texts():
+dp.dot_legend.get_title().set_fontsize(6)
+for text in dp.dot_legend.get_texts():
     text.set_fontsize(6)
-cbar_ax.tick_params(labelsize=6, length=0)
-cbar_ax.set_title("size", fontsize=6, pad=1)
-cbar_ax.set_ylabel("")
+dp.cbar_ax.tick_params(labelsize=6, length=0)
+dp.cbar_ax.set_title("size", fontsize=6, pad=1)
+dp.cbar_ax.set_ylabel("")
 
 # Panel D: ?
 ax = mp.panel("D", 85, 85, margin_right=0)
@@ -382,30 +375,30 @@ setattr(host_c, "_cnsplots_sync_embedded_axes", None)
 setattr(host_c, "_cnsplots_sync_detached_legends", None)
 host_box = host_c.get_position().frozen()
 heatmap_box = [
-    host_box.x0 + host_box.width * 0.07,
+    host_box.x0 + host_box.width * 0.06,
     host_box.y0,
-    host_box.width * 0.44,
+    host_box.width * 0.40,
     host_box.height * 0.90,
 ]
 legend_box = [
-    host_box.x0 + host_box.width * 0.68,
+    host_box.x0 + host_box.width * 0.63,
     host_box.y0,
-    host_box.width * 0.30,
+    host_box.width * 0.33,
     host_box.height * 0.90,
 ]
 dp.ax_heatmap.set_position(heatmap_box)
 hm_ax.set_position(heatmap_box)
-legend_ax.set_position(legend_box)
-cbar_ax.set_position(
+dp.legend_ax.set_position(legend_box)
+dp.cbar_ax.set_position(
     [
         legend_box[0],
-        legend_box[1] + legend_box[3] * 0.18,
-        host_box.width * 0.022,
-        legend_box[3] * 0.72,
+        legend_box[1] + legend_box[3] * 0.16,
+        host_box.width * 0.018,
+        legend_box[3] * 0.70,
     ]
 )
-size_legend.set_bbox_to_anchor((0.42, 1.1), transform=legend_ax.transAxes)
-legend_ax.set_axis_off()
+dp.dot_legend.set_bbox_to_anchor((0.66, 1.02), transform=dp.legend_ax.transAxes)
+dp.legend_ax.set_axis_off()
 
 # Save final figure
 cns.savefig("~/Desktop/Figure2.jpg")

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -342,7 +342,7 @@ def _sync_panel_c_dotplot() -> None:
             legend_box[3] * 0.72,
         ]
     )
-    size_legend.set_bbox_to_anchor((0.42, 0.56), transform=legend_ax.transAxes)
+    size_legend.set_bbox_to_anchor((0.42, 0.72), transform=legend_ax.transAxes)
     legend_ax.set_axis_off()
 
 

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -444,6 +444,18 @@ def dotplot(
     cmp.cbars = getattr(cmp, "cbars", [])
 
     hm_ax = cmp.heatmap_axes[-1, 0]
+    cmp.hm_ax = hm_ax
+    cmp.colorbar = next(
+        (cbar for cbar in cmp.cbars if isinstance(cbar, mpl.colorbar.Colorbar)),
+        None,
+    )
+    cmp.dot_legend = next(
+        (legend for legend in cmp.cbars if isinstance(legend, mpl.legend.Legend)),
+        None,
+    )
+    cmp.cbar_ax = None if cmp.colorbar is None else cmp.colorbar.ax
+    cmp.legend_ax = None if cmp.dot_legend is None else cmp.dot_legend.axes
+
     for ax in [cmp.ax_heatmap, hm_ax]:
         ax.minorticks_off()
         ax.tick_params(

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -296,6 +296,9 @@ def test_heatmap_and_dotplot(
         value="score",
     )
     assert dp.ax_heatmap is not None
+    assert dp.hm_ax is dp.heatmap_axes[-1, 0]
+    assert dp.legend_ax is not None
+    assert dp.cbar_ax is not None
 
     cns.figure(160, 160)
     with pytest.raises(ValueError, match="Length mismatch"):
@@ -362,6 +365,8 @@ def test_dotplot_respects_multipanel_bounds(dotplot_df: pd.DataFrame) -> None:
 
     assert dp.ax_heatmap is not None
     assert len(dp.cbars) == 0
+    assert dp.legend_ax is None
+    assert dp.cbar_ax is None
 
     eps = 1e-9
     for ax in dp.heatmap_axes.flat:


### PR DESCRIPTION
## What changed
- replaced the Figure 2 panel C placeholder with the dotplot showcase panel
- widened panel C and tightened the dotplot legend spacing so the legend stays visible and the top-right panels stay aligned

## How it was tested
- ran `uv run python examples/plot_000_showcase.py` and visually inspected `~/Desktop/Figure2.jpg`
- ran `make test`
- ran `make lint`

## Risks or follow-ups
- the spacing is tuned for the current Figure 2 composition, so future panel-size changes in the top-right row may need another small layout adjustment