### PR TITLE
✨ Replace Figure 2 placeholders with showcase plot examples

### DIFF
--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -340,10 +340,11 @@ ax = cns.cumulativeincidenceplot(
     event="event",
     hue="group",
     hue_order=["Control", "Treatment"],
-    pvalue_position=(float(cumulative_incidence_df["time"].max()) * 0.06, 0.15),
+    pvalue_position=(0, 0.9),
     show_risk_table=False,
 )
 legend = ax.get_legend()
+legend.set_loc("lower right")
 if legend is not None:
     legend.set_title(None)
     for text in legend.get_texts():
@@ -394,7 +395,7 @@ ax.set_title("Placeholder")
 mp.newline()
 
 # Panel J: lollipopplot
-ax = mp.panel("J", 100, 30, color_cycle="NEJM", margin_right=15)
+ax = mp.panel("J", 80, 30, color_cycle="NEJM", margin_right=15, margin_bottom=20)
 ax = cns.lollipopplot(data=tips_df, x="day", y="total_bill", errorbar="se")
 ax.set_title("Lollipopplot")
 ax.set_xticklabels(
@@ -416,7 +417,7 @@ ax = cns.confusionplot(
 ax.set_title("Confusionplot")
 
 # Panel L: forestplot
-host_l = mp.panel("L", 100, 100, color_cycle=[cns.CHOCOLATE], margin_right=15)
+host_l = mp.panel("L", 90, 90, color_cycle=[cns.CHOCOLATE], pad_left=15, pad_top=10)
 forest_model = cns.methods.CoxModel(
     data=forest_df,
     duration="time",
@@ -434,15 +435,14 @@ forest_ax.set_title("Forestplot")
 detached_panel_layouts.append((host_l, [forest_ax], 0.03, 0.04))
 
 # Panel M: upsetplot
-host_m = mp.panel("M", 145, 100, margin_right=0)
+host_m = mp.panel("M", 110, 200, margin_right=0, pad_left=-100, pad_top=10)
 upset_axes = cns.upsetplot(
     upset_sets,
     fig=mp.fig,
     sort_by="cardinality",
     totals_plot_elements=0,
-    facecolor=cns.GREEN,
+    facecolor="black",
     show_counts=False,
-    element_size=14,
 )
 upset_axes["intersections"].set_title("UpSetplot")
 detached_panel_layouts.append((host_m, list(upset_axes.values()), 0.03, 0.04))

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -27,10 +27,46 @@ import cnsplots as cns
     slope_df,
     confusion_df,
     line_df,
+    cumulative_incidence_df,
+    forest_df,
+    upset_sets,
     showcase_images,
 ) = cns.get_showcase_data(
     include_showcase_images=True,
 )
+
+
+def _embed_detached_axes(host_ax, detached_axes, *, xpad=0.0, ypad=0.0):
+    detached_axes = [ax for ax in detached_axes if ax is not None]
+    if not detached_axes:
+        return
+
+    host_ax.set_axis_off()
+    host_box = host_ax.get_position().frozen()
+    detached_boxes = [ax.get_position().frozen() for ax in detached_axes]
+    left = min(box.x0 for box in detached_boxes)
+    right = max(box.x1 for box in detached_boxes)
+    bottom = min(box.y0 for box in detached_boxes)
+    top = max(box.y1 for box in detached_boxes)
+    width = max(right - left, 1e-9)
+    height = max(top - bottom, 1e-9)
+
+    inner_x0 = host_box.x0 + host_box.width * xpad
+    inner_y0 = host_box.y0 + host_box.height * ypad
+    inner_width = host_box.width * (1 - 2 * xpad)
+    inner_height = host_box.height * (1 - 2 * ypad)
+
+    for ax, box in zip(detached_axes, detached_boxes):
+        ax.set_position(
+            [
+                inner_x0 + inner_width * ((box.x0 - left) / width),
+                inner_y0 + inner_height * ((box.y0 - bottom) / height),
+                inner_width * (box.width / width),
+                inner_height * (box.height / height),
+            ]
+        )
+
+    cns.utils._capture_detached_axes_layout(host_ax, detached_axes=detached_axes)
 
 
 # %%
@@ -247,6 +283,7 @@ cns.savefig("~/Desktop/Figure1.svg")
 mp = cns.multipanel(
     max_width=540, title="Figure 2", title_fontweight="bold", loc="left"
 )
+detached_panel_layouts = []
 
 # Panel A: load pathology image
 ax = mp.panel("A", 237, 149, pad_left=-70)
@@ -295,10 +332,25 @@ dp.cbar_ax.tick_params(labelsize=6, length=0)
 dp.cbar_ax.set_title("size", fontsize=6, pad=1)
 dp.cbar_ax.set_ylabel("")
 
-# Panel D: ?
-ax = mp.panel("D", 85, 85, margin_right=0)
-cns.placeholderplot("Placeholder")
-ax.set_title("?")
+# Panel D: cumulativeincidenceplot
+ax = mp.panel("D", 85, 85, margin_right=0, color_cycle="BlueRed")
+ax = cns.cumulativeincidenceplot(
+    data=cumulative_incidence_df,
+    duration="time",
+    event="event",
+    hue="group",
+    hue_order=["Control", "Treatment"],
+    pvalue_position=(float(cumulative_incidence_df["time"].max()) * 0.06, 0.15),
+    show_risk_table=False,
+)
+legend = ax.get_legend()
+if legend is not None:
+    legend.set_title(None)
+    for text in legend.get_texts():
+        text.set_text(text.get_text().split(" (", 1)[0])
+ax.set_xlabel("Time")
+ax.set_ylabel("Incidence")
+ax.set_title("Cumulative Incidence")
 
 # Panel E: load western blot image
 ax = mp.panel("E", 102, 116, below="B", pad_left=-50)
@@ -363,10 +415,37 @@ ax = cns.confusionplot(
 )
 ax.set_title("Confusionplot")
 
-# Panel L: ?
-ax = mp.panel("L", 100, 100)
-cns.placeholderplot("Placeholder")
-ax.set_title("?")
+# Panel L: forestplot
+host_l = mp.panel("L", 100, 100, color_cycle=[cns.CHOCOLATE], margin_right=15)
+forest_model = cns.methods.CoxModel(
+    data=forest_df,
+    duration="time",
+    event="event",
+    variates=[
+        "age",
+        "C(risk, levels=['Low', 'High'])",
+        "C(stage, levels=['I', 'II'])",
+        "np.log(marker)",
+    ],
+)
+forest_model.fit()
+forest_ax = cns.forestplot(forest_model, add_pvalue=False)
+forest_ax.set_title("Forestplot")
+detached_panel_layouts.append((host_l, [forest_ax], 0.03, 0.04))
+
+# Panel M: upsetplot
+host_m = mp.panel("M", 145, 100, margin_right=0)
+upset_axes = cns.upsetplot(
+    upset_sets,
+    fig=mp.fig,
+    sort_by="cardinality",
+    totals_plot_elements=0,
+    facecolor=cns.GREEN,
+    show_counts=False,
+    element_size=14,
+)
+upset_axes["intersections"].set_title("UpSetplot")
+detached_panel_layouts.append((host_m, list(upset_axes.values()), 0.03, 0.04))
 
 # Finalize panel C after the multipanel layout settles.
 if mp.fig is not None:
@@ -399,6 +478,10 @@ dp.cbar_ax.set_position(
 )
 dp.dot_legend.set_bbox_to_anchor((0.66, 1.02), transform=dp.legend_ax.transAxes)
 dp.legend_ax.set_axis_off()
+for host_ax, detached_axes, xpad, ypad in detached_panel_layouts:
+    _embed_detached_axes(host_ax, detached_axes, xpad=xpad, ypad=ypad)
+if mp.fig is not None:
+    mp.fig.canvas.draw()
 
 # Save final figure
 cns.savefig("~/Desktop/Figure2.jpg")

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -408,11 +408,31 @@ ax = cns.confusionplot(
     data=confusion_df,
     x="pred",
     y="truth",
-    add_pvalue=True,
+    add_pvalue=False,
     x_order=["Neg", "Pos"],
     y_order=["Neg", "Pos"],
-    pvalue_y_pad=3.9,
-    pvalue_x_pad=-0.2,
+)
+confusion_counts = (
+    confusion_df.groupby(["truth", "pred"])
+    .size()
+    .unstack(fill_value=0)
+    .reindex(index=["Neg", "Pos"], columns=["Neg", "Pos"], fill_value=0)
+)
+_, confusion_pvalue = stats.fisher_exact(
+    [
+        [confusion_counts.loc["Pos", "Pos"], confusion_counts.loc["Neg", "Pos"]],
+        [confusion_counts.loc["Pos", "Neg"], confusion_counts.loc["Neg", "Neg"]],
+    ]
+)
+ax.text(
+    0.7,
+    -0.3,
+    f"P = {confusion_pvalue:.2g}",
+    transform=ax.transAxes,
+    ha="center",
+    va="top",
+    fontsize=6,
+    clip_on=False,
 )
 ax.set_title("Confusionplot")
 

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -395,7 +395,7 @@ ax.set_title("Placeholder")
 mp.newline()
 
 # Panel J: lollipopplot
-ax = mp.panel("J", 80, 30, color_cycle="NEJM", margin_right=15, margin_bottom=20)
+ax = mp.panel("J", 100, 40, color_cycle="NEJM", margin_right=15, margin_bottom=20)
 ax = cns.lollipopplot(data=tips_df, x="day", y="total_bill", errorbar="se")
 ax.set_title("Lollipopplot")
 ax.set_xticklabels(
@@ -403,41 +403,21 @@ ax.set_xticklabels(
 )
 
 # Panel K: confusionplot
-ax = mp.panel("K", 30, 30, margin_right=30)
+ax = mp.panel("K", 30, 30, margin_right=60)
 ax = cns.confusionplot(
     data=confusion_df,
     x="pred",
     y="truth",
-    add_pvalue=False,
+    add_pvalue=True,
     x_order=["Neg", "Pos"],
     y_order=["Neg", "Pos"],
-)
-confusion_counts = (
-    confusion_df.groupby(["truth", "pred"])
-    .size()
-    .unstack(fill_value=0)
-    .reindex(index=["Neg", "Pos"], columns=["Neg", "Pos"], fill_value=0)
-)
-_, confusion_pvalue = stats.fisher_exact(
-    [
-        [confusion_counts.loc["Pos", "Pos"], confusion_counts.loc["Neg", "Pos"]],
-        [confusion_counts.loc["Pos", "Neg"], confusion_counts.loc["Neg", "Neg"]],
-    ]
-)
-ax.text(
-    0.7,
-    -0.3,
-    f"P = {confusion_pvalue:.2g}",
-    transform=ax.transAxes,
-    ha="center",
-    va="top",
-    fontsize=6,
-    clip_on=False,
+    pvalue_x_pad=-0.3,
+    pvalue_y_pad=3.8,
 )
 ax.set_title("Confusionplot")
 
 # Panel L: forestplot
-host_l = mp.panel("L", 90, 90, color_cycle=[cns.CHOCOLATE], pad_left=15, pad_top=10)
+host_l = mp.panel("L", 100, 100, color_cycle=[cns.CHOCOLATE], pad_left=15, pad_top=10)
 forest_model = cns.methods.CoxModel(
     data=forest_df,
     duration="time",
@@ -455,7 +435,7 @@ forest_ax.set_title("Forestplot")
 detached_panel_layouts.append((host_l, [forest_ax], 0.03, 0.04))
 
 # Panel M: upsetplot
-host_m = mp.panel("M", 110, 200, margin_right=0, pad_left=-100, pad_top=10)
+host_m = mp.panel("M", 120, 200, margin_right=0, pad_left=-100, pad_top=10)
 upset_axes = cns.upsetplot(
     upset_sets,
     fig=mp.fig,

--- a/examples/plot_000_showcase.py
+++ b/examples/plot_000_showcase.py
@@ -484,4 +484,4 @@ if mp.fig is not None:
     mp.fig.canvas.draw()
 
 # Save final figure
-cns.savefig("~/Desktop/Figure2.jpg")
+cns.savefig("~/Desktop/Figure2.svg")

--- a/examples/plot_110_regplot.py
+++ b/examples/plot_110_regplot.py
@@ -83,7 +83,7 @@ ax.set_title("Set2 Palette")
 # Multiple regression comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare regression trends across different subsets.
-mp = cns.multipanel(max_width=540)
+mp = cns.multipanel(max_width=560)
 
 for i, day in enumerate(["Thur", "Fri", "Sat", "Sun"]):
     label = chr(65 + i)  # A, B, C, D

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -1188,6 +1188,57 @@ def get_showcase_data(
         }
     )
 
+    # Competing-risks showcase data
+    cumulative_incidence_rows = []
+    for group, scale, event_probs in [
+        ("Control", 18, [0.22, 0.56, 0.22]),
+        ("Treatment", 26, [0.30, 0.40, 0.30]),
+    ]:
+        times = np.random.exponential(scale=scale, size=60)
+        events = np.random.choice([0, 1, 2], size=60, p=event_probs)
+        for time, event in zip(times, events):
+            cumulative_incidence_rows.append(
+                {"time": float(time), "event": int(event), "group": group}
+            )
+    cumulative_incidence_df = pd.DataFrame(cumulative_incidence_rows)
+
+    # Forest plot data
+    n_patients = 240
+    risk = np.random.choice(["Low", "High"], size=n_patients, p=[0.58, 0.42])
+    stage = np.random.choice(["I", "II"], size=n_patients, p=[0.55, 0.45])
+    age = np.random.normal(61, 9, size=n_patients)
+    marker = np.random.lognormal(mean=1.2, sigma=0.35, size=n_patients)
+    hazard_scale = np.where(risk == "High", 1.35, 0.85) * np.where(
+        stage == "II", 1.2, 0.95
+    )
+    forest_df = pd.DataFrame(
+        {
+            "time": np.random.exponential(scale=30 / hazard_scale, size=n_patients),
+            "event": np.random.binomial(
+                1,
+                np.where(risk == "High", 0.72, 0.48)
+                + np.where(stage == "II", 0.06, -0.02),
+                size=n_patients,
+            ),
+            "risk": risk,
+            "stage": stage,
+            "age": age,
+            "marker": marker,
+        }
+    )
+
+    # UpSet plot data
+    genes = np.array([f"Gene{x}" for x in range(1, 61)])
+    upset_sets = {
+        "RNA": set(genes[:18]) | set(genes[24:30]) | set(genes[40:44]),
+        "ATAC": set(genes[8:28]) | set(genes[34:40]),
+        "WES": set(genes[4:16]) | set(genes[22:34]) | set(genes[48:54]),
+        "CRISPR": set(genes[:6])
+        | set(genes[14:24])
+        | set(genes[30:33])
+        | set(genes[44:52]),
+    }
+
     data = (
         iris_df,
         tips_df,
@@ -1199,6 +1250,9 @@ def get_showcase_data(
         slope_df,
         confusion_df,
         line_df,
+        cumulative_incidence_df,
+        forest_df,
+        upset_sets,
     )
     if include_showcase_images:
         return (*data, _resolve_showcase_images())

--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    pass
+    from matplotlib.figure import Figure
 
 from collections.abc import Mapping
 from collections.abc import Set as AbstractSet
@@ -27,7 +27,12 @@ def _normalize_text_position(text: Any) -> None:
     text.set_position((_to_scalar(x), _to_scalar(y)))
 
 
-def upsetplot(sets: Mapping[str, AbstractSet[Any] | list[Any]], **kwargs: Any) -> dict:
+def upsetplot(
+    sets: Mapping[str, AbstractSet[Any] | list[Any]],
+    *,
+    fig: Figure | None = None,
+    **kwargs: Any,
+) -> dict:
     """
     Create an UpSet plot for visualizing set intersections.
 
@@ -38,6 +43,8 @@ def upsetplot(sets: Mapping[str, AbstractSet[Any] | list[Any]], **kwargs: Any) -
     ----------
     sets : dict
         Dictionary mapping set names (str) to sets or array-like collections.
+    fig : matplotlib.figure.Figure or None, optional
+        Figure to draw the UpSet plot into. Defaults to a new figure.
     **kwargs
         Additional keyword arguments passed to `upsetplot.UpSet`.
 
@@ -83,10 +90,13 @@ def upsetplot(sets: Mapping[str, AbstractSet[Any] | list[Any]], **kwargs: Any) -
         membership = [name for name, s in normalized_sets.items() if item in s]
         memberships.append(membership)
     data = usp.from_memberships(memberships)
-    # Set default subset_size to "count" to handle non-unique groups
+    # Set defaults for compact, publication-style UpSet plots while allowing
+    # callers to override them when a different layout is needed.
     kwargs.setdefault("subset_size", "count")
-    upset = usp.UpSet(data, element_size=17, show_counts="{:,}", **kwargs)
-    axes = upset.plot()
+    kwargs.setdefault("element_size", 17)
+    kwargs.setdefault("show_counts", "{:,}")
+    upset = usp.UpSet(data, **kwargs)
+    axes = upset.plot(fig=fig)
     plt.grid(False)
     ax_tot = axes.get("totals")
     cns.setup_ax(axes["matrix"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,9 @@ ShowcaseBundle = tuple[
     pd.DataFrame,
     pd.DataFrame,
     pd.DataFrame,
+    pd.DataFrame,
+    pd.DataFrame,
+    dict[str, set[str]],
 ]
 
 
@@ -298,6 +301,29 @@ def showcase_bundle(
             "condition": ["Control"] * 6 + ["Treatment"] * 6,
         }
     )
+    cumulative_incidence_df = pd.DataFrame(
+        {
+            "time": [3.0, 6.0, 8.0, 5.0, 9.0, 12.0],
+            "event": [1, 0, 2, 1, 2, 0],
+            "group": ["Control"] * 3 + ["Treatment"] * 3,
+        }
+    )
+    forest_df = pd.DataFrame(
+        {
+            "time": [5.0, 8.0, 13.0, 21.0, 7.0, 15.0],
+            "event": [1, 0, 1, 1, 0, 1],
+            "risk": ["Low", "Low", "High", "High", "Low", "High"],
+            "stage": ["I", "II", "I", "II", "I", "II"],
+            "age": [56.0, 62.0, 68.0, 71.0, 59.0, 65.0],
+            "marker": [2.1, 2.5, 3.8, 4.2, 2.3, 3.4],
+        }
+    )
+    upset_sets = {
+        "RNA": {"Gene1", "Gene2", "Gene3", "Gene4"},
+        "ATAC": {"Gene2", "Gene3", "Gene5"},
+        "WES": {"Gene1", "Gene3", "Gene6"},
+        "CRISPR": {"Gene3", "Gene4", "Gene6"},
+    }
     return (
         categorical_df.rename(columns={"group": "species", "value": "sepal_length"})[
             ["species", "sepal_length"]
@@ -315,6 +341,9 @@ def showcase_bundle(
         slope_df,
         confusion_df,
         line_df,
+        cumulative_incidence_df,
+        forest_df,
+        upset_sets,
     )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1177,14 +1177,17 @@ def test_utils_helpers_and_showcase_data(
     monkeypatch.setitem(sys.modules, "seaborn", fake_sns)
     monkeypatch.setitem(sys.modules, "scanpy", fake_sc)
     data = _utils.get_showcase_data()
-    assert len(data) == 10
+    assert len(data) == 13
+    assert isinstance(data[10], pd.DataFrame)
+    assert isinstance(data[11], pd.DataFrame)
+    assert isinstance(data[12], dict)
     data_with_assets = _utils.get_showcase_data(
         include_showcase_images=True,
         caller_file=Path(__file__).resolve().parents[1]
         / "examples"
         / "plot_320_multipanel.py",
     )
-    assert len(data_with_assets) == 11
+    assert len(data_with_assets) == 14
     assert data_with_assets[-1].name == "assets"
 
     monkeypatch.chdir(Path(__file__).resolve().parents[1])
@@ -1195,7 +1198,7 @@ def test_utils_helpers_and_showcase_data(
     )
     data_without_file = module_globals["result"]
     assert isinstance(data_without_file, tuple)
-    assert len(data_without_file) == 11
+    assert len(data_without_file) == 14
     assert data_without_file[-1].name == "assets"
 
 

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -314,6 +314,10 @@ def test_sets_and_specialized_plots(
         for tick in axes["shading"].yaxis.get_major_ticks()
     )
 
+    fig = plt.figure()
+    embedded_axes = cns.upsetplot(sets_fixture, fig=fig, min_subset_size=1)
+    assert all(ax is None or ax.figure is fig for ax in embedded_axes.values())
+
     cns.figure(120, 120)
     venn = cns.vennplot(list(sets_fixture.values())[:2], labels=["A", "B"])
     assert venn is not None


### PR DESCRIPTION
## What changed
- replaced Figure 2 panel D with a cumulative incidence example driven by `get_showcase_data`
- replaced Figure 2 panel L with a forest plot example driven by `get_showcase_data`
- added Figure 2 panel M with an UpSet plot example driven by `get_showcase_data`
- extended `get_showcase_data` with the synthetic competing-risks, forest-plot, and UpSet datasets needed by the showcase
- added a small `upsetplot(..., fig=...)` path so the UpSet example can render inside the multipanel figure
- updated showcase-data tests for the expanded bundle

## How it was tested
- `make test`
- `make lint`
- rendered `examples/plot_000_showcase.py` locally to verify the Figure 2 layout

## Risks or follow-ups
- the Figure 2 layout is tuned to the current synthetic showcase datasets, so future data-shape changes may need small panel spacing adjustments