### PR TITLE
👷 Automate tag-driven draft releases with generated notes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -253,6 +253,12 @@ Fixes #(issue number)
 - [ ] Breaking change
 - [ ] Documentation update
 
+## Release Notes Label
+
+Maintainers: apply one release label before merge so generated release notes are
+categorized correctly: `bug`, `enhancement`, `documentation`, `maintenance`, or
+`ignore-for-release`.
+
 ## Changes Made
 
 - Change 1
@@ -277,9 +283,31 @@ Add screenshots for visual changes
 ### Review Process
 
 - Maintainers will review your PR
+- Maintainers apply one release label before merge: `bug`, `enhancement`,
+  `documentation`, `maintenance`, or `ignore-for-release`
 - Address any feedback or requested changes
 - Once approved, a maintainer will merge your PR
 - Your contribution will be included in the next release
+
+### Release Process
+
+Maintainers can create a release with:
+
+```bash
+make release patch
+```
+
+You can replace `patch` with `minor` or `major` as needed. This bumps the
+package version, creates the release tag, and prepares the release commit.
+After pushing the commit and tag, GitHub Actions will:
+
+- publish the package to PyPI
+- create a draft GitHub release for the new tag
+- generate release notes from merged PRs since the previous tag
+
+Before publishing the draft release, add a short human-written summary under
+the `Added`, `Changed`, and `Fixed` headings, then verify the generated PR list
+and changelog link.
 
 ## Community
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,10 @@ Fixes #(issue number)
 - [ ] Breaking change
 - [ ] Documentation update
 
+## Release Notes Label
+Maintainers: apply one release label before merge so generated release notes are categorized correctly:
+`bug`, `enhancement`, `documentation`, `maintenance`, or `ignore-for-release`.
+
 ## Checklist
 - [ ] My code follows the project's style guidelines
 - [ ] I have performed a self-review of my code

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: 🚀 Features & Enhancements
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🧰 Maintenance & Under the Hood
+      labels:
+        - maintenance
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -50,3 +50,72 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  release-draft:
+    name: Draft GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Find previous tag
+        id: previous-tag
+        run: |
+          tag_commit="$(git rev-list -n 1 "${GITHUB_REF_NAME}")"
+          previous_tag=""
+
+          if git rev-parse "${tag_commit}^" >/dev/null 2>&1; then
+            previous_tag="$(git describe --tags --abbrev=0 "${tag_commit}^" 2>/dev/null || true)"
+          fi
+
+          echo "previous_tag=${previous_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check for existing release
+        id: existing-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create draft GitHub release
+        if: steps.existing-release.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIOUS_TAG: ${{ steps.previous-tag.outputs.previous_tag }}
+        run: |
+          summary_template=$(cat <<'EOF'
+          ## Summary
+
+          ### Added
+          - _Add release highlights here._
+
+          ### Changed
+          - _Add release highlights here._
+
+          ### Fixed
+          - _Add release highlights here._
+          EOF
+          )
+
+          args=(
+            release create "${GITHUB_REF_NAME}"
+            --verify-tag
+            --draft
+            --generate-notes
+            --notes "${summary_template}"
+          )
+
+          if [ -n "${PREVIOUS_TAG}" ]; then
+            args+=(--notes-start-tag "${PREVIOUS_TAG}")
+          fi
+
+          gh "${args[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,13 @@
 ## Pull request rules
 
 - Use `gh pr create`.
+- When creating a PR, add exactly one release label with `gh pr create --label <label>`.
+- Use the release label that matches the dominant change:
+  - `bug` for bug fixes
+  - `enhancement` for user-facing features or improvements
+  - `documentation` for documentation or text-only changes
+  - `maintenance` for internal chores, tooling, config, or refactors
+  - `ignore-for-release` only when the PR should be excluded from release notes
 - Base branch must be `main`.
 - Open the first pull request as a draft unless explicitly told otherwise.
 - Push the branch before creating the pull request.


### PR DESCRIPTION
## What changed
- add a tag-triggered GitHub release draft step to the existing publish workflow after PyPI publishing succeeds
- add `.github/release.yml` so generated release notes group PRs into features, fixes, docs, maintenance, and other changes
- document the release-label requirement in the PR template, contributing guide, and `AGENTS.md`
- keep a human-editable summary block at the top of each draft release before GitHub-generated notes

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- future PRs need one release label to land in the intended release note category
- the first real tagged release should confirm the draft release is created after PyPI publish and that the previous-tag range is correct
- the summary section in the draft release still needs a maintainer to fill in before publishing