### PR TITLE
🐛 Fix prerank missing gseapy error path

### DIFF
--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -551,8 +551,11 @@ def prerank(
     """
     try:
         import gseapy as gp
-    except ImportError:
-        print("pip install gseapy")
+    except ImportError as exc:
+        raise ImportError(
+            "[prerank] gseapy is required but not installed. "
+            "Install with: pip install gseapy"
+        ) from exc
 
     rnk = data.copy()
     rnk = rnk[[name_gene, name_rank]]

--- a/tests/test_methods_and_helpers.py
+++ b/tests/test_methods_and_helpers.py
@@ -145,9 +145,7 @@ def test_prerank_with_mocked_gseapy(
     ]
 
 
-def test_prerank_import_error_prints(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_prerank_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
     real_import = builtins.__import__
 
     def fake_import(
@@ -162,11 +160,10 @@ def test_prerank_import_error_prints(
         return real_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    with pytest.raises(UnboundLocalError):
+    with pytest.raises(ImportError, match="Install with: pip install gseapy"):
         _methods.prerank(
             pd.DataFrame({"gene": ["a"], "rank": [1]}), {"set": ["A"]}, "gene", "rank"
         )
-    assert "pip install gseapy" in capsys.readouterr().out
 
 
 def test_competing_risk_helper(competing_risk_df: pd.DataFrame) -> None:


### PR DESCRIPTION
## What changed
- Raise a clear ImportError from public prerank API when gseapy is unavailable
- Replace the accidental UnboundLocalError regression test with an assertion on the install hint

## How it was tested
- make test
- make lint

## Risks or follow-ups
- Low risk; this only changes the missing-dependency path for prerank
- Callers that were accidentally depending on the UnboundLocalError will now receive the intended ImportError