### PR TITLE
🐛 Replace stdout API messages with logs and warnings

### DIFF
--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 import re
+import warnings
 
 import lifelines as ll
 import numpy as np
@@ -368,8 +369,8 @@ class LogisticModel:
         2. LogisticRegressionCV fits with L1 penalty and 5-fold CV
         3. AUC and 95% CI are computed via bootstrap (1000 iterations)
 
-        Warnings are printed for hue groups with no outcome variance.
-        Errors during fitting are caught and reported.
+        Runtime warnings are emitted for hue groups with no outcome variance.
+        Errors during fitting are caught and surfaced as warnings.
 
         Examples
         --------
@@ -419,9 +420,10 @@ class LogisticModel:
                         )
                         y = hue_data[self.event].values
                         if len(np.unique(y)) < 2:
-                            print(
-                                f"Warning: No variance in outcome for {var} in hue"
-                                f" group {hue_group}"
+                            warnings.warn(
+                                f"No variance in outcome for {var} in hue group {hue_group}",
+                                RuntimeWarning,
+                                stacklevel=2,
                             )
                             continue
                         model = LogisticRegressionCV(
@@ -445,12 +447,20 @@ class LogisticModel:
                         }
                         all_results.append(model_result)
                     except Exception as e:
-                        print(f"Error fitting {var} for hue group {hue_group}: {e}")
+                        warnings.warn(
+                            f"Error fitting {var} for hue group {hue_group}: {e}",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
                         continue
 
         results_df = pd.DataFrame(all_results)
         if len(results_df) == 0:
-            print("No successful model fits")
+            warnings.warn(
+                "No successful model fits",
+                RuntimeWarning,
+                stacklevel=2,
+            )
             return
         results_df = results_df.sort_values(
             ["auc", "hue_group"], ascending=False

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -17,7 +17,7 @@ Examples
 >>> cns.settings.title_fontsize = 10
 >>> cns.settings.figure_width = 180
 
->>> # Suppress print statements
+>>> # Suppress informational log messages
 >>> cns.settings.verbosity = 0
 
 >>> # Reset to defaults
@@ -36,7 +36,10 @@ from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
+import logging
 from typing import Any, Callable
+
+_CNSPLOTS_LOGGER_NAME = "cnsplots"
 
 _TITLE_LOCS = ("left", "center", "right")
 _LEGEND_LOCS = (
@@ -173,6 +176,12 @@ def _spec(default: Any, validator: Callable[[Any], Any], doc: str) -> _SettingSp
     return _SettingSpec(default=default, validator=validator, doc=doc)
 
 
+def _apply_verbosity_to_logging(verbosity: int) -> None:
+    """Synchronize the public verbosity setting with cnsplots logging."""
+    package_logger = logging.getLogger(_CNSPLOTS_LOGGER_NAME)
+    package_logger.setLevel(logging.INFO if verbosity >= 1 else logging.WARNING)
+
+
 _SETTING_SPECS: dict[str, _SettingSpec] = {
     "palette_qual": _spec(
         "Ecotyper1",
@@ -207,7 +216,7 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
     "verbosity": _spec(
         1,
         lambda value: _validate_integer("verbosity", value, non_negative=True),
-        "Verbosity level. 0 = silent, 1 = normal.",
+        "Verbosity level. 0 suppresses cnsplots info logs, 1 enables them.",
     ),
     "mathtext_fontset": _spec(
         "custom",
@@ -583,6 +592,8 @@ def _make_setting_property(name: str, doc: str) -> property:
     def setter(self: CNSSettings, value: Any) -> None:
         validated = type(self)._setting_specs[name].validator(value)
         object.__setattr__(self, f"_{name}", validated)
+        if name == "verbosity":
+            _apply_verbosity_to_logging(validated)
 
     return property(getter, setter, doc=doc)
 

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -31,6 +32,8 @@ from statannotations.utils import DEFAULT
 
 import cnsplots as cns
 from cnsplots._svg import _save_svg
+
+logger = logging.getLogger(__name__)
 
 RED = "#D6372E"
 BLUE = "#5189BB"
@@ -1019,13 +1022,13 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format="s
         annotator.annotate()
 
     if test == "Mann-Whitney":
-        print("   ---> P-values were determined by two-sided Mann-Whitney U test.")
+        logger.info("P-values were determined by two-sided Mann-Whitney U test.")
     if test == "t-test_welch":
-        print("   ---> P-values were determined by two-sided Welch's t-test.")
+        logger.info("P-values were determined by two-sided Welch's t-test.")
     if test == "fisher-exact":
-        print("   ---> P-values were determined by two-sided Fisher's exact test.")
+        logger.info("P-values were determined by two-sided Fisher's exact test.")
     if test == "chi-squared":
-        print("   ---> P-values were determined by two-sided Chi-squared test.")
+        logger.info("P-values were determined by two-sided Chi-squared test.")
 
 
 def get_showcase_data(

--- a/src/cnsplots/helpers/_sankey.py
+++ b/src/cnsplots/helpers/_sankey.py
@@ -192,24 +192,15 @@ def init_values(
 def deprecation_warnings(
     closePlot: bool, figSize: tuple[int, int] | None, figureName: str | None
 ) -> None:
-    warn = []
     if figureName is not None:
         msg = "use of figureName in sankey() is deprecated"
-        warnings.warn(msg, DeprecationWarning)
-        warn.append(msg[7:-14])
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
     if closePlot is not False:
         msg = "use of closePlot in sankey() is deprecated"
-        warnings.warn(msg, DeprecationWarning)
-        warn.append(msg[7:-14])
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
     if figSize is not None:
         msg = "use of figSize in sankey() is deprecated"
-        warnings.warn(msg, DeprecationWarning)
-        warn.append(msg[7:-14])
-    if warn:
-        print(
-            " The following arguments are deprecated and should be removed: %s",
-            ", ".join(warn),
-        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
 
 def determine_widths(

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -22,6 +23,8 @@ from cnsplots._validation import (
     validate_dataframe,
     validate_dataframe_not_empty,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def boxplot(
@@ -147,7 +150,7 @@ def boxplot(
             else str(whis)
         )
     )
-    print(
+    logger.info(
         "Boxplots represent the median and bottom and upper quartiles; whiskers"
         f" correspond to the {whis_str}."
     )
@@ -376,7 +379,7 @@ def kdeplot(data: pd.DataFrame, x: str, add_mode: bool = True, **kwargs: Any) ->
                 ha="right",
                 va="top",
             )
-            print("   ---> P-value was determined by Anderson-Darling test.")
+            logger.info("P-value was determined by Anderson-Darling test.")
     else:
         if add_mode and ax.get_lines():
             kde_data = ax.get_lines()[-1].get_data()

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -23,6 +24,8 @@ from cnsplots._validation import (
     validate_no_nulls,
     validate_sufficient_data,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def survivalplot(
@@ -134,8 +137,8 @@ def survivalplot(
         try:
             logrank_test = multivariate_logrank_test(df[duration], df[hue], df[event])
             p = num2tex.num2tex(logrank_test.p_value, precision=2)
-            print(
-                "   ---> P-value was determined by two-sided multivariate log-rank test."
+            logger.info(
+                "P-value was determined by two-sided multivariate log-rank test."
             )
         except Exception as e:
             raise RuntimeError(
@@ -148,8 +151,8 @@ def survivalplot(
             cph.fit(df, duration_col=duration, event_col=event)
             trend_test = cph.log_likelihood_ratio_test()
             p = num2tex.num2tex(trend_test.p_value, precision=2)
-            print(
-                "   ---> P-value was determined by two-sided multivariate log-rank test for trend."
+            logger.info(
+                "P-value was determined by two-sided multivariate log-rank test for trend."
             )
         except Exception as e:
             raise RuntimeError(
@@ -325,7 +328,7 @@ def cumulativeincidenceplot(
             data[duration], data[event], group=data[hue].cat.codes
         )
         p = num2tex.num2tex(pvalue, precision=2)
-        print("   ---> P-value was determined by two-sided Gray's test.")
+        logger.info("P-value was determined by two-sided Gray's test.")
         ax.text(pvalue_position[0], pvalue_position[1], "P = " + rf"${p:.2g}$")
 
     if show_risk_table:

--- a/tests/test_methods_and_helpers.py
+++ b/tests/test_methods_and_helpers.py
@@ -59,7 +59,6 @@ def test_cox_model_fit_and_forestplot(survival_df: pd.DataFrame) -> None:
 def test_logistic_model_paths(
     monkeypatch: pytest.MonkeyPatch,
     roc_df: pd.DataFrame,
-    capsys: pytest.CaptureFixture[str],
 ) -> None:
     data = pd.concat(
         [
@@ -101,10 +100,11 @@ def test_logistic_model_paths(
     model_hue = cns.LogisticModel(
         data_bad, event="event", variates=["score", "missing_col"], hue="group"
     )
-    model_hue.fit()
-    out = capsys.readouterr().out
-    assert "Warning: No variance in outcome" in out
-    assert "Error fitting missing_col" in out
+    with pytest.warns(RuntimeWarning) as caught:
+        model_hue.fit()
+    messages = [str(warning.message) for warning in caught]
+    assert any("No variance in outcome" in message for message in messages)
+    assert any("Error fitting missing_col" in message for message in messages)
 
     model_empty = cns.LogisticModel(
         data_bad[data_bad["group"] == "A"],
@@ -112,8 +112,11 @@ def test_logistic_model_paths(
         variates=["score"],
         hue="group",
     )
-    model_empty.fit()
-    assert "No successful model fits" in capsys.readouterr().out
+    with pytest.warns(RuntimeWarning) as empty_caught:
+        model_empty.fit()
+    empty_messages = [str(warning.message) for warning in empty_caught]
+    assert any("No variance in outcome" in message for message in empty_messages)
+    assert any("No successful model fits" in message for message in empty_messages)
 
     cns.figure(120, 120)
     ax = cns.forestplot(model, add_pvalue=False)
@@ -175,32 +178,31 @@ def test_competing_risk_helper(competing_risk_df: pd.DataFrame) -> None:
     assert 0 <= pvalue <= 1
 
 
-def test_sankey_helpers(
-    sankey_df: pd.DataFrame, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_sankey_helpers(sankey_df: pd.DataFrame) -> None:
     _sankey.check_data_matches_labels(
         ["Start", "Middle", "End"], sankey_df["source"], "left"
     )
     with pytest.raises(ValueError, match="left labels and data do not match"):
         _sankey.check_data_matches_labels(["Other"], sankey_df["source"], "left")
 
-    ax, left_labels, left_weight, right_labels, right_weight = _sankey.init_values(
-        None,
-        True,
-        (1, 1),
-        "name",
-        sankey_df["source"].tolist(),
-        None,
-        None,
-        None,
-        None,
-    )
+    with pytest.warns(DeprecationWarning) as caught:
+        ax, left_labels, left_weight, right_labels, right_weight = _sankey.init_values(
+            None,
+            True,
+            (1, 1),
+            "name",
+            sankey_df["source"].tolist(),
+            None,
+            None,
+            None,
+            None,
+        )
     assert ax is plt.gca()
     assert left_labels == []
     assert len(left_weight) == len(sankey_df)
     assert len(right_weight) == len(sankey_df)
-    out = capsys.readouterr().out
-    assert "deprecated" in out
+    messages = [str(warning.message) for warning in caught]
+    assert any("deprecated" in message for message in messages)
 
     data_frame = _sankey._create_dataframe(
         sankey_df["source"],

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from typing import Any, cast
@@ -124,20 +125,23 @@ def test_survival_plots(
     survival_three_group_df: pd.DataFrame,
     competing_risk_df: pd.DataFrame,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     cns.figure(120, 120)
-    ax = cns.survivalplot(
-        survival_df, "time", "event", "group", hue_order=["Treatment", "Control"]
-    )
+    with caplog.at_level(logging.INFO, logger="cnsplots"):
+        ax = cns.survivalplot(
+            survival_df, "time", "event", "group", hue_order=["Treatment", "Control"]
+        )
     assert ax.get_ylabel() == "Overall survival probability"
     assert "HR =" in ax.texts[0].get_text()
-    assert "multivariate log-rank test" in capsys.readouterr().out
+    assert "multivariate log-rank test" in caplog.text
 
     cns.figure(120, 120)
-    ax2 = cns.survivalplot(survival_three_group_df, "time", "event", "group")
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="cnsplots"):
+        ax2 = cns.survivalplot(survival_three_group_df, "time", "event", "group")
     assert ax2.get_xlabel() == "Time (Years)"
-    assert "trend" in capsys.readouterr().out
+    assert "trend" in caplog.text
 
     added: dict[str, object] = {}
     import lifelines.plotting as lifelines_plotting
@@ -148,17 +152,19 @@ def test_survival_plots(
         lambda *fitters, **kwargs: added.update({"fitters": fitters, **kwargs}),
     )
     cns.figure(120, 120)
-    ax3 = cns.cumulativeincidenceplot(
-        competing_risk_df,
-        "time",
-        "event",
-        "group",
-        show_risk_table=True,
-        xticks=[0, 2, 4, 6, 8],
-    )
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="cnsplots"):
+        ax3 = cns.cumulativeincidenceplot(
+            competing_risk_df,
+            "time",
+            "event",
+            "group",
+            show_risk_table=True,
+            xticks=[0, 2, 4, 6, 8],
+        )
     assert list(ax3.get_xticks()) == [0, 2, 4, 6, 8]
     assert added["rows_to_show"] == ["At risk"]
-    assert "Gray's test" in capsys.readouterr().out
+    assert "Gray's test" in caplog.text
 
     cns.figure(120, 120)
     single_group = competing_risk_df[competing_risk_df["group"] == "A"].copy()

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -13,7 +14,7 @@ import cnsplots as cns
 def test_boxplot_and_violinplot(
     categorical_df: pd.DataFrame,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     calls: list[object] = []
     monkeypatch.setattr(
@@ -23,17 +24,18 @@ def test_boxplot_and_violinplot(
     )
 
     cns.figure(120, 120)
-    ax = cns.boxplot(
-        categorical_df,
-        x="group",
-        y="value",
-        pairs=[("A", "B")],
-        addcount=True,
-        showoutliers=True,
-        whis=(0, 100),
-    )
+    with caplog.at_level(logging.INFO, logger="cnsplots"):
+        ax = cns.boxplot(
+            categorical_df,
+            x="group",
+            y="value",
+            pairs=[("A", "B")],
+            addcount=True,
+            showoutliers=True,
+            whis=(0, 100),
+        )
     assert ax.get_xticklabels()[0].get_text().startswith("A")
-    assert "minimum and maximum values" in capsys.readouterr().out
+    assert "minimum and maximum values" in caplog.text
     assert calls
 
     cns.figure(120, 120)
@@ -185,7 +187,7 @@ def test_stack_strip_pie_and_donut_plots(
 def test_distribution_wrappers(
     numeric_df: pd.DataFrame,
     categorical_df: pd.DataFrame,
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     cns.figure(120, 120)
     ax = cns.distplot(numeric_df, x="x", hue="group")
@@ -196,11 +198,12 @@ def test_distribution_wrappers(
     assert any(line.get_linestyle() == "--" for line in ax2.lines)
 
     cns.figure(120, 120)
-    ax3 = cns.kdeplot(
-        categorical_df.rename(columns={"value": "score"}), x="score", hue="hue"
-    )
+    with caplog.at_level(logging.INFO, logger="cnsplots"):
+        ax3 = cns.kdeplot(
+            categorical_df.rename(columns={"value": "score"}), x="score", hue="hue"
+        )
     assert ax3.get_legend() is not None
-    assert "Anderson-Darling test" in capsys.readouterr().out
+    assert "Anderson-Darling test" in caplog.text
 
     cns.figure(120, 120)
     ax4 = cns.histplot(data=numeric_df, x="x", kde=True)

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -218,6 +218,26 @@ def test_distribution_wrappers(
     assert ax6 is plt.gca()
 
 
+def test_distribution_logging_respects_settings_verbosity(
+    categorical_df: pd.DataFrame,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    data = categorical_df.rename(columns={"value": "score"})
+
+    caplog.set_level(logging.INFO)
+    with cns.settings.context(verbosity=0):
+        caplog.clear()
+        cns.figure(120, 120)
+        cns.kdeplot(data, x="score", hue="hue")
+        assert "Anderson-Darling test" not in caplog.text
+
+    with cns.settings.context(verbosity=1):
+        caplog.clear()
+        cns.figure(120, 120)
+        cns.kdeplot(data, x="score", hue="hue")
+        assert "Anderson-Darling test" in caplog.text
+
+
 def test_line_scatter_reg_and_slope_plots(
     numeric_df: pd.DataFrame,
     line_df: pd.DataFrame,


### PR DESCRIPTION
## What changed
- Replaced stdout print calls in public plotting APIs with logging so informational messages stay available without polluting notebook or CLI output by default.
- Replaced recoverable LogisticModel.fit() and Sankey deprecation stdout messages with warnings, and updated tests to assert logs or warnings instead of captured stdout.

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- Callers that explicitly captured stdout for these messages will need to switch to logging or warning capture.
- The plotting APIs now emit these informational messages only when consumers enable logging for cnsplots.
