### PR TITLE
👷 Simplify GitHub release publishing workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -43,7 +43,7 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/
@@ -51,71 +51,23 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-  release-draft:
-    name: Draft GitHub release
+  github-release:
+    name: Create GitHub Release
     needs: publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v5
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          name: dist
+          path: dist
 
-      - name: Find previous tag
-        id: previous-tag
-        run: |
-          tag_commit="$(git rev-list -n 1 "${GITHUB_REF_NAME}")"
-          previous_tag=""
-
-          if git rev-parse "${tag_commit}^" >/dev/null 2>&1; then
-            previous_tag="$(git describe --tags --abbrev=0 "${tag_commit}^" 2>/dev/null || true)"
-          fi
-
-          echo "previous_tag=${previous_tag}" >> "${GITHUB_OUTPUT}"
-
-      - name: Check for existing release
-        id: existing-release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            echo "exists=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "exists=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Create draft GitHub release
-        if: steps.existing-release.outputs.exists != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PREVIOUS_TAG: ${{ steps.previous-tag.outputs.previous_tag }}
-        run: |
-          summary_template=$(cat <<'EOF'
-          ## Summary
-
-          ### Added
-          - _Add release highlights here._
-
-          ### Changed
-          - _Add release highlights here._
-
-          ### Fixed
-          - _Add release highlights here._
-          EOF
-          )
-
-          args=(
-            release create "${GITHUB_REF_NAME}"
-            --verify-tag
-            --draft
-            --generate-notes
-            --notes "${summary_template}"
-          )
-
-          if [ -n "${PREVIOUS_TAG}" ]; then
-            args+=(--notes-start-tag "${PREVIOUS_TAG}")
-          fi
-
-          gh "${args[@]}"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/*


### PR DESCRIPTION
## What changed
- Replaced the custom draft-release shell steps with `softprops/action-gh-release@v2`.
- Updated the release workflow to use `actions/download-artifact@v5` for current artifact downloads.
- Made the GitHub release step fail fast if the built `dist/*` assets are missing.

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- Tag pushes will now publish the GitHub release immediately instead of creating a draft release, so the next tagged release is the first behavior change to watch.
