### PR TITLE
🔧 Enable pytest warnings in test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lint:
 	uv run pre-commit run --all-files
 
 test:
-	uv run pytest --disable-warnings ./tests
+	uv run pytest ./tests
 
 doc: clean
 	cd docs && $(MAKE) html


### PR DESCRIPTION
## What changed
- removed `--disable-warnings` from the `make test` pytest command in `Makefile`
- verified the suite still passes cleanly with warnings enabled, so no additional warning cleanup was needed

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- this change will now surface any future pytest warnings in CI and local runs instead of hiding them