### PR TITLE
✨ Add matplotlib and seaborn cns gallery examples

### DIFF
--- a/examples/plot_305_matplotlib.py
+++ b/examples/plot_305_matplotlib.py
@@ -1,0 +1,107 @@
+"""
+matplotlib
+----------
+
+Use native matplotlib plotting with cnsplots sizing, styling, and export helpers.
+
+These examples intentionally stick to matplotlib's plotting API and only use
+``cns.figure()`` and ``cns.save()`` from cnsplots.
+"""
+
+# %%
+# Load packages
+# ~~~~~~~~~~~~~
+from pathlib import Path
+import tempfile
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import cnsplots as cns
+
+
+# %%
+# Generate synthetic assay data
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Create smooth trajectories plus a noisy measurement track.
+rng = np.random.default_rng(42)
+time = np.linspace(0, 6 * np.pi, 200)
+signal_a = np.sin(time) + 0.15 * np.cos(time / 2)
+signal_b = 0.75 * np.cos(time - 0.8)
+observed = signal_a + rng.normal(0, 0.12, size=time.size)
+
+
+# %%
+# Line plot with confidence band
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# cnsplots handles the figure setup while matplotlib draws everything.
+cns.figure(160, 220)
+ax = plt.gca()
+ax.plot(time, signal_a, color="#1f77b4", linewidth=2, label="Condition A")
+ax.plot(time, signal_b, color="#d62728", linewidth=2, label="Condition B")
+ax.fill_between(
+    time,
+    signal_a - 0.18,
+    signal_a + 0.18,
+    color="#1f77b4",
+    alpha=0.18,
+    linewidth=0,
+)
+ax.set_xlabel("Time (hours)")
+ax.set_ylabel("Normalized signal")
+ax.set_title("Matplotlib with cns.figure")
+ax.legend(frameon=False, loc="upper right")
+
+
+# %%
+# Two-panel matplotlib layout
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The cnsplots canvas also works with matplotlib's subplot helpers.
+cns.figure(160, 300)
+fig = plt.gcf()
+ax_left, ax_right = fig.subplots(1, 2)
+
+ax_left.scatter(time[::4], observed[::4], color="#2ca02c", s=14, alpha=0.8)
+ax_left.plot(time, signal_a, color="#1f77b4", linewidth=1.8)
+ax_left.set_xlabel("Time (hours)")
+ax_left.set_ylabel("Observed signal")
+ax_left.set_title("Measurements")
+
+window = np.linspace(1, 6, 6)
+means = np.array([observed[i * 30 : (i + 1) * 30].mean() for i in range(6)])
+errors = np.array([observed[i * 30 : (i + 1) * 30].std() for i in range(6)])
+ax_right.errorbar(
+    window,
+    means,
+    yerr=errors,
+    fmt="o-",
+    color="#9467bd",
+    linewidth=1.8,
+    capsize=3,
+)
+ax_right.set_xlabel("Replicate")
+ax_right.set_ylabel("Mean +/- SD")
+ax_right.set_title("Summary")
+
+fig.tight_layout()
+
+
+# %%
+# Save a matplotlib figure with cns.save
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Export the current matplotlib figure using the cnsplots save helper.
+export_dir = Path(tempfile.gettempdir()) / "cnsplots-gallery"
+export_dir.mkdir(parents=True, exist_ok=True)
+
+cns.figure(140, 180)
+ax = plt.gca()
+ax.plot(time, signal_a, color="#1f77b4", linewidth=2, label="Condition A")
+ax.plot(time, observed, color="#7f7f7f", linewidth=1.2, alpha=0.85, label="Observed")
+ax.set_xlabel("Time (hours)")
+ax.set_ylabel("Signal")
+ax.set_title("Saved with cns.save")
+ax.legend(frameon=False, loc="upper right")
+
+export_path = export_dir / "matplotlib_with_cns.svg"
+cns.save(export_path)
+print(f"Saved demo figure to {export_path}")

--- a/examples/plot_306_seaborn.py
+++ b/examples/plot_306_seaborn.py
@@ -1,0 +1,116 @@
+"""
+seaborn
+-------
+
+Use native seaborn plotting with cnsplots sizing, styling, and export helpers.
+
+These examples intentionally stick to seaborn's plotting API and only use
+``cns.figure()`` and ``cns.save()`` from cnsplots.
+"""
+
+# %%
+# Load packages
+# ~~~~~~~~~~~~~
+from pathlib import Path
+import tempfile
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+import cnsplots as cns
+
+
+# %%
+# Load example datasets
+# ~~~~~~~~~~~~~~~~~~~~~
+tips = sns.load_dataset("tips")
+penguins = sns.load_dataset("penguins").dropna(
+    subset=["bill_length_mm", "bill_depth_mm", "species", "sex"]
+)
+flights = sns.load_dataset("flights")
+
+
+# %%
+# Scatter plot with seaborn
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# cnsplots prepares the canvas while seaborn handles the plot.
+cns.figure(160, 220)
+ax = plt.gca()
+sns.scatterplot(
+    data=penguins,
+    x="bill_length_mm",
+    y="bill_depth_mm",
+    hue="species",
+    style="sex",
+    s=45,
+    ax=ax,
+)
+ax.set_xlabel("Bill length (mm)")
+ax.set_ylabel("Bill depth (mm)")
+ax.set_title("Seaborn with cns.figure")
+
+
+# %%
+# Two seaborn plots on one cnsplots canvas
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Axes-level seaborn functions work naturally with matplotlib subplots.
+cns.figure(170, 320)
+fig = plt.gcf()
+ax_left, ax_right = fig.subplots(1, 2)
+
+sns.boxplot(
+    data=tips,
+    x="day",
+    y="total_bill",
+    hue="sex",
+    ax=ax_left,
+)
+ax_left.set_xlabel("")
+ax_left.set_ylabel("Total bill")
+ax_left.set_title("Box plot")
+
+sns.histplot(
+    data=tips,
+    x="tip",
+    hue="sex",
+    element="step",
+    stat="density",
+    common_norm=False,
+    ax=ax_right,
+)
+ax_right.set_xlabel("Tip")
+ax_right.set_ylabel("Density")
+ax_right.set_title("Histogram")
+
+fig.tight_layout()
+
+
+# %%
+# Save a seaborn figure with cns.save
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Export the current seaborn figure using the cnsplots save helper.
+monthly_passengers = (
+    flights.groupby("year", as_index=False)["passengers"].mean().rename(
+        columns={"passengers": "mean_passengers"}
+    )
+)
+export_dir = Path(tempfile.gettempdir()) / "cnsplots-gallery"
+export_dir.mkdir(parents=True, exist_ok=True)
+
+cns.figure(150, 200)
+ax = plt.gca()
+sns.lineplot(
+    data=monthly_passengers,
+    x="year",
+    y="mean_passengers",
+    marker="o",
+    linewidth=2,
+    ax=ax,
+)
+ax.set_xlabel("Year")
+ax.set_ylabel("Mean passengers")
+ax.set_title("Saved with cns.save")
+
+export_path = export_dir / "seaborn_with_cns.pdf"
+cns.save(export_path)
+print(f"Saved demo figure to {export_path}")

--- a/examples/plot_306_seaborn.py
+++ b/examples/plot_306_seaborn.py
@@ -90,9 +90,9 @@ fig.tight_layout()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Export the current seaborn figure using the cnsplots save helper.
 monthly_passengers = (
-    flights.groupby("year", as_index=False)["passengers"].mean().rename(
-        columns={"passengers": "mean_passengers"}
-    )
+    flights.groupby("year", as_index=False)["passengers"]
+    .mean()
+    .rename(columns={"passengers": "mean_passengers"})
 )
 export_dir = Path(tempfile.gettempdir()) / "cnsplots-gallery"
 export_dir.mkdir(parents=True, exist_ok=True)

--- a/src/cnsplots/__init__.py
+++ b/src/cnsplots/__init__.py
@@ -66,6 +66,7 @@ from cnsplots.plots import (
 )
 
 __version__ = "0.0.4"
+save = savefig
 __all__ = (
     "utils",
     "settings",
@@ -93,6 +94,7 @@ __all__ = (
     "apply_unicode_font",
     "figure",
     "multipanel",
+    "save",
     "savefig",
     "palettes",
     "take_legend_out",

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -42,7 +42,9 @@ def test_public_namespace_contract() -> None:
     exec("from cnsplots import *", namespace)
     assert namespace["boxplot"] is cns.boxplot
     assert namespace["placeholderplot"] is cns.placeholderplot
+    assert namespace["save"] is cns.save
     assert namespace["savefig"] is cns.savefig
+    assert cns.save is cns.savefig
     assert namespace["validation"] is cns.validation
 
 
@@ -313,7 +315,7 @@ def test_public_prerank_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
 
-def test_public_figure_and_savefig_contract(output_dir: Path) -> None:
+def test_public_figure_and_save_alias_contract(output_dir: Path) -> None:
     png_path = output_dir / "nested" / "plot.png"
     pdf_path = output_dir / "nested" / "plot.pdf"
     svg_path = output_dir / "nested" / "plot.svg"
@@ -322,9 +324,9 @@ def test_public_figure_and_savefig_contract(output_dir: Path) -> None:
     plt.plot([0, 1], [0, 1])
     plt.title("Contract Export")
 
-    cns.savefig(str(png_path))
+    cns.save(str(png_path))
     cns.savefig(str(pdf_path))
-    cns.savefig(str(svg_path))
+    cns.save(str(svg_path))
 
     assert png_path.exists()
     assert pdf_path.exists()


### PR DESCRIPTION
## What changed
- add `plot_305_matplotlib.py` to show native matplotlib plots wrapped with `cns.figure()` and `cns.save()`
- add `plot_306_seaborn.py` to show native seaborn plots wrapped with `cns.figure()` and `cns.save()`
- add a public `cns.save` alias and cover it in the API contract test

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- low risk; the new gallery examples save into a temporary directory so docs/example execution does not write into the repository
- if we want the alias to be discoverable in the API docs navigation later, we can add `save` alongside `savefig` in `docs/api.md`