### PR TITLE
💄 Refine release notes layout and navigation

### DIFF
--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -255,16 +255,11 @@ article[role="main"]
 }
 
 .release-notes-entry {
-  padding: 1.4rem;
-  border: 1px solid var(--color-foreground-border);
-  border-radius: 18px;
-  background: color-mix(
-    in srgb,
-    var(--color-brand-content) 3%,
-    var(--color-background-primary)
-  );
-  box-shadow: 0 8px 24px
-    color-mix(in srgb, var(--color-brand-content) 8%, transparent);
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .release-notes-entry > :first-child,
@@ -288,16 +283,7 @@ article[role="main"]
 
 .release-notes-title {
   margin: 0;
-  font-size: clamp(1.15rem, 1.1rem + 0.35vw, 1.45rem);
-}
-
-.release-notes-title a {
-  text-decoration: none;
-}
-
-.release-notes-title a:hover,
-.release-notes-title a:focus-visible {
-  text-decoration: underline;
+  font-size: clamp(1.45rem, 1.3rem + 0.9vw, 2rem);
 }
 
 .release-notes-meta {
@@ -307,31 +293,6 @@ article[role="main"]
   align-items: center;
   color: var(--color-foreground-secondary);
   font-size: 0.93rem;
-}
-
-.release-notes-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.2rem 0.55rem;
-  border: 1px solid color-mix(
-    in srgb,
-    var(--color-brand-content) 22%,
-    var(--color-foreground-border)
-  );
-  border-radius: 999px;
-  background: color-mix(
-    in srgb,
-    var(--color-brand-content) 10%,
-    var(--color-background-primary)
-  );
-  color: var(--color-brand-content);
-  font-size: 0.85rem;
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.release-notes-github-link {
-  white-space: nowrap;
 }
 
 .release-notes-body {
@@ -381,11 +342,6 @@ article[role="main"]
 }
 
 @media (max-width: 640px) {
-  .release-notes-entry {
-    padding: 1rem;
-    border-radius: 14px;
-  }
-
   .release-notes-header {
     flex-direction: column;
   }

--- a/docs/_static/js/release-notes.js
+++ b/docs/_static/js/release-notes.js
@@ -8,6 +8,9 @@
   const dateFormatter = new Intl.DateTimeFormat("en", { dateStyle: "long" });
   const pageSize = 100;
   const maxPages = 10;
+  const plainUrlPattern = /https?:\/\/[^\s<]+/g;
+  const generatedReleaseNotesCommentPattern =
+    /^\s*<!--\s*Release notes generated using configuration in \.github\/release\.yml(?: at .*?)?\s*-->\s*$/i;
 
   function getCacheKey(user, repo) {
     return `release-notes:github:${user}/${repo}`;
@@ -42,7 +45,94 @@
     }
   }
 
+  function createSafeLink(url, label) {
+    if (!isSafeUrl(url)) {
+      return document.createTextNode(label);
+    }
+
+    const link = document.createElement("a");
+    link.href = url;
+    link.textContent = label;
+
+    if (isExternalUrl(url)) {
+      link.rel = "noreferrer noopener";
+      link.target = "_blank";
+    }
+
+    return link;
+  }
+
+  function linkifyPlainTextUrls(root) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        const parent = node.parentElement;
+        if (!parent || !node.textContent || !plainUrlPattern.test(node.textContent)) {
+          plainUrlPattern.lastIndex = 0;
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        plainUrlPattern.lastIndex = 0;
+        if (parent.closest("a, code, pre, samp, kbd, script, style, textarea")) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+
+    const textNodes = [];
+    while (walker.nextNode()) {
+      textNodes.push(walker.currentNode);
+    }
+
+    textNodes.forEach(function (textNode) {
+      const text = textNode.textContent || "";
+      plainUrlPattern.lastIndex = 0;
+
+      let match = plainUrlPattern.exec(text);
+      if (!match) {
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      let currentIndex = 0;
+
+      while (match) {
+        let url = match[0];
+        let trailingPunctuation = "";
+
+        while (/[),.;!?]$/.test(url)) {
+          trailingPunctuation = url.slice(-1) + trailingPunctuation;
+          url = url.slice(0, -1);
+        }
+
+        if (match.index > currentIndex) {
+          fragment.appendChild(
+            document.createTextNode(text.slice(currentIndex, match.index)),
+          );
+        }
+
+        fragment.appendChild(createSafeLink(url, url));
+
+        if (trailingPunctuation) {
+          fragment.appendChild(document.createTextNode(trailingPunctuation));
+        }
+
+        currentIndex = match.index + match[0].length;
+        match = plainUrlPattern.exec(text);
+      }
+
+      if (currentIndex < text.length) {
+        fragment.appendChild(document.createTextNode(text.slice(currentIndex)));
+      }
+
+      textNode.replaceWith(fragment);
+    });
+  }
+
   function sanitizeRenderedContent(root) {
+    linkifyPlainTextUrls(root);
+
     for (const link of root.querySelectorAll("a")) {
       const href = link.getAttribute("href");
       if (!href || !isSafeUrl(href)) {
@@ -101,15 +191,217 @@
     status.hidden = true;
   }
 
+  function getHeadingLabel(heading) {
+    const clone = heading.cloneNode(true);
+    clone.querySelectorAll(".headerlink").forEach(function (link) {
+      link.remove();
+    });
+    return clone.textContent.trim();
+  }
+
+  function addHeadingPermalink(heading) {
+    if (!heading.id || heading.querySelector(".headerlink")) {
+      return;
+    }
+
+    const permalink = document.createElement("a");
+    permalink.className = "headerlink";
+    permalink.href = `#${heading.id}`;
+    permalink.title = "Link to this heading";
+    permalink.setAttribute("aria-label", "Link to this heading");
+    permalink.textContent = "¶";
+    heading.appendChild(permalink);
+  }
+
+  function normalizeReleaseBody(body) {
+    if (typeof body !== "string" || !body.trim()) {
+      return "_No release notes provided._";
+    }
+
+    const normalizedBody = body
+      .split(/\r?\n/)
+      .filter(function (line) {
+        return !generatedReleaseNotesCommentPattern.test(line);
+      })
+      .join("\n")
+      .trim();
+
+    return normalizedBody || "_No release notes provided._";
+  }
+
   function renderMarkdown(body) {
     if (typeof markdownRenderer !== "function") {
       return "<p>Release notes could not be rendered in the browser.</p>";
     }
 
-    const source = typeof body === "string" && body.trim()
-      ? body
-      : "_No release notes provided._";
+    const source = normalizeReleaseBody(body);
     return markdownRenderer(escapeHtml(source));
+  }
+
+  function demoteReleaseBodyHeadings(root) {
+    const headings = Array.from(
+      root.querySelectorAll("h1, h2, h3, h4, h5, h6"),
+    );
+
+    headings.forEach(function (heading) {
+      const currentLevel = Number(heading.tagName.slice(1));
+      const nextLevel = Math.min(currentLevel + 1, 6);
+      if (nextLevel === currentLevel) {
+        return;
+      }
+
+      const replacement = document.createElement(`h${nextLevel}`);
+      heading.getAttributeNames().forEach(function (attributeName) {
+        replacement.setAttribute(
+          attributeName,
+          heading.getAttribute(attributeName) || "",
+        );
+      });
+
+      while (heading.firstChild) {
+        replacement.appendChild(heading.firstChild);
+      }
+
+      heading.replaceWith(replacement);
+    });
+  }
+
+  function assignReleaseBodyHeadingIds(root, prefix) {
+    const assignedIds = new Set([prefix]);
+    const headings = Array.from(root.querySelectorAll("h1, h2, h3, h4, h5, h6"));
+
+    headings.forEach(function (heading, index) {
+      if (heading.id) {
+        assignedIds.add(heading.id);
+        return;
+      }
+
+      const headingLabel = getHeadingLabel(heading);
+      const baseId = `${prefix}-${slugify(headingLabel, `section-${index}`)}`;
+      let headingId = baseId;
+      let duplicateIndex = 2;
+
+      while (assignedIds.has(headingId) || document.getElementById(headingId)) {
+        headingId = `${baseId}-${duplicateIndex}`;
+        duplicateIndex += 1;
+      }
+
+      heading.id = headingId;
+      assignedIds.add(headingId);
+    });
+  }
+
+  function addPermalinksToHeadings(root) {
+    root.querySelectorAll("h1, h2, h3, h4, h5, h6").forEach(function (heading) {
+      addHeadingPermalink(heading);
+    });
+  }
+
+  function ensurePageTocTree() {
+    const tocDrawer = document.querySelector(".toc-drawer");
+    if (!tocDrawer) {
+      return null;
+    }
+
+    let tocTree = tocDrawer.querySelector(".toc-tree");
+    if (tocTree) {
+      return tocTree;
+    }
+
+    const sticky = document.createElement("div");
+    sticky.className = "toc-sticky toc-scroll";
+
+    const titleContainer = document.createElement("div");
+    titleContainer.className = "toc-title-container";
+
+    const title = document.createElement("span");
+    title.className = "toc-title";
+    title.textContent = "On this page";
+    titleContainer.appendChild(title);
+
+    const treeContainer = document.createElement("div");
+    treeContainer.className = "toc-tree-container";
+
+    tocTree = document.createElement("div");
+    tocTree.className = "toc-tree";
+    treeContainer.appendChild(tocTree);
+
+    sticky.appendChild(titleContainer);
+    sticky.appendChild(treeContainer);
+    tocDrawer.replaceChildren(sticky);
+
+    return tocTree;
+  }
+
+  function setTocVisibility(isVisible) {
+    document.querySelectorAll(
+      ".toc-header-icon, .toc-content-icon, .toc-drawer",
+    ).forEach(function (element) {
+      element.classList.toggle("no-toc", !isVisible);
+    });
+  }
+
+  function updatePageToc(container) {
+    const tocTree = ensurePageTocTree();
+    if (!tocTree) {
+      return;
+    }
+
+    const releaseHeadings = Array.from(
+      container.querySelectorAll(".release-notes-title[id]"),
+    );
+    if (!releaseHeadings.length) {
+      tocTree.replaceChildren();
+      setTocVisibility(false);
+      return;
+    }
+
+    const pageHeading = document.querySelector("article[role='main'] h1");
+    const rootList = document.createElement("ul");
+    const rootItem = document.createElement("li");
+    const rootLink = document.createElement("a");
+    rootLink.className = "reference internal";
+    rootLink.href = pageHeading?.id ? `#${pageHeading.id}` : "#";
+    rootLink.textContent = pageHeading
+      ? getHeadingLabel(pageHeading)
+      : "Release Notes";
+    rootItem.appendChild(rootLink);
+
+    const nestedList = document.createElement("ul");
+    releaseHeadings.forEach(function (heading) {
+      const item = document.createElement("li");
+      const link = document.createElement("a");
+      link.className = "reference internal";
+      link.href = `#${heading.id}`;
+      link.textContent = getHeadingLabel(heading);
+      item.appendChild(link);
+      nestedList.appendChild(item);
+    });
+
+    rootItem.appendChild(nestedList);
+    rootList.appendChild(rootItem);
+    tocTree.replaceChildren(rootList);
+    setTocVisibility(true);
+  }
+
+  function scrollToCurrentHash() {
+    if (!window.location.hash) {
+      return;
+    }
+
+    let targetId = window.location.hash.slice(1);
+    try {
+      targetId = decodeURIComponent(targetId);
+    } catch (error) {
+      return;
+    }
+
+    const target = document.getElementById(targetId);
+    if (!target) {
+      return;
+    }
+
+    target.scrollIntoView();
   }
 
   function slugify(value, fallback) {
@@ -134,45 +426,31 @@
       `entry-${index}`,
     )}`;
     article.setAttribute("aria-labelledby", heading.id);
-
-    const titleLink = document.createElement("a");
-    titleLink.href = release.html_url;
-    titleLink.textContent = release.name && release.name !== release.tag_name
+    heading.textContent = release.name && release.name !== release.tag_name
       ? release.name
       : release.tag_name;
-    titleLink.rel = "noreferrer noopener";
-    titleLink.target = "_blank";
-    heading.appendChild(titleLink);
-
-    const meta = document.createElement("div");
-    meta.className = "release-notes-meta";
-
-    const tag = document.createElement("span");
-    tag.className = "release-notes-tag";
-    tag.textContent = release.tag_name;
-    meta.appendChild(tag);
+    addHeadingPermalink(heading);
 
     const publishedDate = release.published_at || release.created_at;
+    header.appendChild(heading);
+
     if (publishedDate) {
+      const meta = document.createElement("div");
+      meta.className = "release-notes-meta";
+
       const date = document.createElement("span");
       date.textContent = dateFormatter.format(new Date(publishedDate));
       meta.appendChild(date);
+
+      header.appendChild(meta);
     }
-
-    const githubLink = document.createElement("a");
-    githubLink.className = "release-notes-github-link";
-    githubLink.href = release.html_url;
-    githubLink.textContent = "View on GitHub";
-    githubLink.rel = "noreferrer noopener";
-    githubLink.target = "_blank";
-    meta.appendChild(githubLink);
-
-    header.appendChild(heading);
-    header.appendChild(meta);
 
     const body = document.createElement("div");
     body.className = "release-notes-body";
     body.innerHTML = renderMarkdown(release.body);
+    demoteReleaseBodyHeadings(body);
+    assignReleaseBodyHeadingIds(body, heading.id);
+    addPermalinksToHeadings(body);
     sanitizeRenderedContent(body);
 
     article.appendChild(header);
@@ -205,6 +483,8 @@
 
     list.hidden = false;
     hideStatus(container);
+    updatePageToc(container);
+    scrollToCurrentHash();
   }
 
   async function fetchAllReleases(user, repo) {


### PR DESCRIPTION
## What changed
- removed the release note card border and promoted each release version title to an h2
- demoted rendered release-note body headings, removed the generated GitHub comment, and simplified header metadata
- added runtime TOC/permalink support for fetched release headings and linkified bare changelog URLs in release content

## How it was tested
- `make lint`
- `make test`
- `make html`

## Risks or follow-ups
- the release notes page still depends on client-side rendering after GitHub release data loads
- TOC entries for release headings are generated at runtime rather than at Sphinx build time