### PR TITLE
🐛 Remove white background from UpSet plot

### DIFF
--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -135,6 +135,15 @@ def upsetplot(
     upset = usp.UpSet(data, **kwargs)
     axes = upset.plot(fig=fig)
     plt.grid(False)
+    for ax in axes.values():
+        if ax is not None:
+            ax.set_facecolor("none")
+    plot_fig = next((ax.figure for ax in axes.values() if ax is not None), None)
+    if plot_fig is not None and np.allclose(
+        plot_fig.patch.get_facecolor(), (1.0, 1.0, 1.0, 1.0)
+    ):
+        plot_fig.patch.set_facecolor("none")
+        plot_fig.patch.set_alpha(0)
     ax_tot = axes.get("totals")
     cns.setup_ax(axes["matrix"])
     cns.setup_ax(axes["shading"])

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -5,7 +5,7 @@ import logging
 import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
-from matplotlib.colors import to_hex
+from matplotlib.colors import to_hex, to_rgba
 from matplotlib.patches import Circle, FancyBboxPatch, Polygon, Wedge
 
 import cnsplots as cns
@@ -332,6 +332,8 @@ def test_sets_and_specialized_plots(
     cns.figure(120, 120)
     axes = cns.upsetplot(sets_fixture, min_subset_size=1)
     assert set(axes) >= {"matrix", "intersections"}
+    assert all(ax is None or ax.get_facecolor()[-1] == 0 for ax in axes.values())
+    assert axes["matrix"].figure.patch.get_facecolor()[-1] == 0
     assert all(
         not tick.tick1line.get_visible()
         for tick in axes["shading"].yaxis.get_major_ticks()
@@ -340,6 +342,13 @@ def test_sets_and_specialized_plots(
     fig = plt.figure()
     embedded_axes = cns.upsetplot(sets_fixture, fig=fig, min_subset_size=1)
     assert all(ax is None or ax.figure is fig for ax in embedded_axes.values())
+    assert fig.patch.get_facecolor()[-1] == 0
+
+    custom_fig = plt.figure()
+    custom_fig.patch.set_facecolor("red")
+    custom_fig.patch.set_alpha(1)
+    cns.upsetplot(sets_fixture, fig=custom_fig, min_subset_size=1)
+    assert custom_fig.patch.get_facecolor() == to_rgba("red")
 
     cns.figure(120, 120)
     venn = cns.vennplot(list(sets_fixture.values())[:2], labels=["A", "B"])


### PR DESCRIPTION
## What changed
- make UpSet subplot axes transparent
- make the default white UpSet figure canvas transparent while preserving explicit custom figure backgrounds
- add regression coverage for standalone, embedded, and custom-background rendering

## How it was tested
- make test
- make lint

## Risks or follow-ups
- Existing rendered images need to be regenerated to pick up the transparent background change.