### PR TITLE
👷 Add separate docs validation job to CI tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Sync dependencies
-        run: uv sync --all-extras
+        run: uv sync --extra dev
 
       - name: Run lint
         run: make lint
@@ -44,10 +44,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync dependencies
+        run: uv sync --extra dev
 
       - name: Install mutool
         run: |
@@ -55,8 +56,29 @@ jobs:
           sudo apt-get install -y mupdf-tools
 
       - name: Run tests
-        run: python -m pytest --disable-warnings ./tests
+        run: make test
 
+  docs:
+    name: docs-validation
+    runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync dependencies
+        run: uv sync --extra doc
+
+      - name: Build docs
+        run: make doc
   package:
     name: package-validation
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ test:
 
 doc: clean
 	cd docs && $(MAKE) html
+ifneq ($(CI),true)
 	cd docs/build/html && python -m http.server 8080
+endif
 
 install:
 	uv sync --all-extras


### PR DESCRIPTION
## What changed
- add a dedicated `docs-validation` job to `.github/workflows/ci-tests.yml`
- switch the lint, test, and docs CI jobs to `uv` sync commands that install only the extras they need
- make `make doc` skip starting the local docs server when `CI=true` so the docs job can finish in GitHub Actions

## How it was tested
- `make lint`
- `make test`
- `CI=true make doc`

## Risks or follow-ups
- the docs job is still relatively heavy because Sphinx Gallery executes the full example set; if CI time becomes a concern later, we may want a lighter docs smoke target