### PR TITLE
🔧 Consolidate docs dependencies into the dev extra

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -109,7 +109,7 @@ cd cnsplots
 make install
 ```
 
-This uses `uv sync --all-extras` to install the package in editable mode with all dependencies, and sets up pre-commit hooks.
+This uses `uv sync --extra dev` to install the package in editable mode with all dependencies, and sets up pre-commit hooks.
 
 ### Development Commands
 

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Sync docs dependencies
-        run: uv sync --extra doc
+        run: uv sync --extra dev
       - name: Verify docs font
         run: |
           uv run python - <<'PY'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -75,7 +75,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Sync dependencies
-        run: uv sync --extra doc
+        run: uv sync --extra dev
 
       - name: Build docs
         run: make doc

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifneq ($(CI),true)
 endif
 
 install:
-	uv sync --all-extras
+	uv sync --extra dev
 	uv run pre-commit install
 
 release:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,8 +4,8 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-# Run Sphinx through uv so `make html` uses the project's doc extras.
-SPHINXBUILD   ?= uv run --extra doc sphinx-build
+# Run Sphinx through uv so `make html` uses the project's development extra.
+SPHINXBUILD   ?= uv run --extra dev sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = build
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ cd cnsplots
 make install
 ```
 
-This uses `uv sync --all-extras` to install the package in editable mode with
+This uses `uv sync --extra dev` to install the package in editable mode with
 the project's development and documentation extras, and sets up pre-commit
 hooks.
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -5,7 +5,7 @@ pushd %~dp0
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=uv run --extra doc sphinx-build
+	set SPHINXBUILD=uv run --extra dev sphinx-build
 )
 set SOURCEDIR=.
 set BUILDDIR=build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,6 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-]
-doc = [
     "furo",
     "myst-parser",
     "sphinx<9; python_version < '3.11'",

--- a/uv.lock
+++ b/uv.lock
@@ -707,19 +707,17 @@ dependencies = [
 dev = [
     { name = "bump-my-version" },
     { name = "fastcluster" },
+    { name = "furo" },
     { name = "ipykernel", version = "6.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ipykernel", version = "7.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
-]
-doc = [
-    { name = "furo" },
-    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -740,7 +738,7 @@ requires-dist = [
     { name = "biopython" },
     { name = "bump-my-version", marker = "extra == 'dev'" },
     { name = "fastcluster", marker = "extra == 'dev'" },
-    { name = "furo", marker = "extra == 'doc'" },
+    { name = "furo", marker = "extra == 'dev'" },
     { name = "glasbey" },
     { name = "gseapy" },
     { name = "ipykernel", marker = "extra == 'dev'" },
@@ -748,7 +746,7 @@ requires-dist = [
     { name = "lxml" },
     { name = "matplotlib" },
     { name = "matplotlib-venn" },
-    { name = "myst-parser", marker = "extra == 'doc'" },
+    { name = "myst-parser", marker = "extra == 'dev'" },
     { name = "natsort" },
     { name = "num2tex" },
     { name = "numba", specifier = ">=0.58.1" },
@@ -764,18 +762,18 @@ requires-dist = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
-    { name = "sphinx", marker = "python_full_version >= '3.11' and extra == 'doc'", specifier = ">=9,<9.1" },
-    { name = "sphinx", marker = "python_full_version < '3.11' and extra == 'doc'", specifier = "<9" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'doc'" },
-    { name = "sphinx-copybutton", marker = "extra == 'doc'" },
-    { name = "sphinx-design", marker = "extra == 'doc'" },
-    { name = "sphinx-gallery", marker = "extra == 'doc'" },
-    { name = "sphinx-sitemap", marker = "extra == 'doc'" },
+    { name = "sphinx", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = ">=9,<9.1" },
+    { name = "sphinx", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = "<9" },
+    { name = "sphinx-autodoc-typehints", marker = "extra == 'dev'" },
+    { name = "sphinx-copybutton", marker = "extra == 'dev'" },
+    { name = "sphinx-design", marker = "extra == 'dev'" },
+    { name = "sphinx-gallery", marker = "extra == 'dev'" },
+    { name = "sphinx-sitemap", marker = "extra == 'dev'" },
     { name = "statannotations" },
     { name = "statsmodels" },
     { name = "upsetplot" },
 ]
-provides-extras = ["dev", "doc"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
## What changed
- merged the separate `doc` optional dependency group into `dev`
- updated `make install`, CI workflows, and contributor/docs installation instructions to use `uv sync --extra dev`
- refreshed `uv.lock` to match the optional dependency change

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- anyone currently using `uv sync --extra doc` will need to switch to `uv sync --extra dev`
- if external documentation still references the removed `doc` extra, it should be updated separately