### PR TITLE
🐛 Remove scanpy white background in setup_scanpy

### DIFF
--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -443,7 +443,7 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
         "Default scanpy figure size in inches.",
     ),
     "scanpy_facecolor": _spec(
-        "white",
+        "none",
         lambda value: _validate_string("scanpy_facecolor", value),
         "Default scanpy figure background color.",
     ),

--- a/src/cnsplots/_setup.py
+++ b/src/cnsplots/_setup.py
@@ -362,7 +362,7 @@ def setup_scanpy() -> None:
     2. Sets scanpy figure parameters:
        - scanpy=False: Disable scanpy's default styling
        - figsize=(2.5, 2.5): Default figure size in inches
-       - facecolor='white': White background for figures
+       - facecolor='none': Transparent figure and axes backgrounds
 
     This ensures consistency between cnsplots and scanpy visualizations in
     single-cell analysis workflows.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -130,6 +130,7 @@ def test_settings_behavior() -> None:
     assert settings.palette_qual == "Ecotyper1"
     assert settings.savefig_bbox == "tight"
     assert settings.savefig_transparent is True
+    assert settings.scanpy_facecolor == "none"
     settings.palette_qual = "Set2"
     settings.palette_seq = "parula"
     settings.title_fontsize = 10
@@ -600,6 +601,10 @@ def test_setup_functions(monkeypatch: pytest.MonkeyPatch) -> None:
         set_figure_params=lambda **kwargs: calls.update(kwargs)
     )
     monkeypatch.setitem(sys.modules, "scanpy", fake_scanpy)
+    _setup.setup_scanpy()
+    assert calls == {"scanpy": False, "figsize": (2.5, 2.5), "facecolor": "none"}
+
+    calls.clear()
     with cns.settings.context(
         scanpy_use_default_style=True,
         scanpy_figsize=(3.0, 4.0),

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -330,6 +330,61 @@ def test_import_upsetplot_module_tolerates_path_resolution_errors(
     assert usp is valid_module
 
 
+def test_upsetplot_clears_white_figure_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakePatch:
+        def __init__(self) -> None:
+            self.facecolor: object = (1.0, 1.0, 1.0, 1.0)
+            self.alpha: object = None
+
+        def get_facecolor(self) -> object:
+            return self.facecolor
+
+        def set_facecolor(self, value: object) -> None:
+            self.facecolor = value
+
+        def set_alpha(self, value: object) -> None:
+            self.alpha = value
+
+    class FakeAxes:
+        def __init__(self, figure: object) -> None:
+            self.figure = figure
+            self.facecolor: object = None
+            self.texts: list[object] = []
+
+        def set_facecolor(self, value: object) -> None:
+            self.facecolor = value
+
+        def tick_params(self, *args: object, **kwargs: object) -> None:
+            return None
+
+    class FakeUpSet:
+        def __init__(self, data: object, **kwargs: object) -> None:
+            self.data = data
+            self.kwargs = kwargs
+
+        def plot(self, fig: object = None) -> dict[str, object]:
+            patch = FakePatch()
+            figure = types.SimpleNamespace(patch=patch)
+            return {
+                "matrix": FakeAxes(figure),
+                "shading": FakeAxes(figure),
+                "intersections": FakeAxes(figure),
+                "totals": None,
+            }
+
+    fake_module = types.SimpleNamespace(
+        from_memberships=lambda memberships: memberships,
+        UpSet=FakeUpSet,
+    )
+    monkeypatch.setattr(sets_mod, "_import_upsetplot_module", lambda: fake_module)
+    monkeypatch.setattr(cns, "setup_ax", lambda ax: None)
+
+    axes = cns.upsetplot({"A": {"x"}, "B": {"x", "y"}})
+
+    assert axes["matrix"].figure.patch.facecolor == "none"
+    assert axes["matrix"].figure.patch.alpha == 0
+
+
 def test_svg_internal_coverage() -> None:
     class FakeText:
         def getparent(self) -> None:


### PR DESCRIPTION
## What changed
- Change the default `scanpy_facecolor` to `"none"` so `setup_scanpy()` stops forcing a white background.
- Update the Scanpy setup docs to describe the transparent background behavior.
- Add regression coverage for the default Scanpy figure params, explicit facecolor overrides, and the UpSet white-figure patch path.

## How it was tested
- `make lint`
- `make test`

## Risks or follow-ups
- Existing callers that relied on the old white Scanpy background will now get a transparent background by default, but they can still override it with `cns.settings.scanpy_facecolor`.