### PR TITLE
✨ Add versioned docs with gh-pages publishing

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,47 +1,26 @@
 name: CI / Docs
 
 on:
-  workflow_run:
-    workflows:
-      - CI / Tests
-    types:
-      - completed
   push:
+    branches:
+      - main
     tags:
       - "v*"
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
+  group: gh-pages
   cancel-in-progress: true
 
 jobs:
-  build:
-    if: >-
-      ${{
-        (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_branch == 'main') ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
-      }}
+  deploy:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
-        if: ${{ github.event_name == 'workflow_run' }}
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
-      - uses: actions/checkout@v5
-        if: ${{ github.event_name == 'push' }}
-        with:
-          fetch-depth: 0
-      - name: Set up Pages
-        uses: actions/configure-pages@v5
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -54,6 +33,13 @@ jobs:
         run: |
           git fetch --force --tags origin +refs/heads/main:refs/remotes/origin/main
           git branch -f dev origin/main
+      - name: Select docs build mode
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "DOCS_BUILD_MODE=release" >> "${GITHUB_ENV}"
+          else
+            echo "DOCS_BUILD_MODE=main" >> "${GITHUB_ENV}"
+          fi
       - name: Verify docs font
         run: |
           uv run python - <<'PY'
@@ -82,27 +68,18 @@ jobs:
           assert resolved_name == "Helvetica"
           PY
       - name: Build versioned documentation
-        run: uv run python docs/_scripts/build_versioned_docs.py docs/build/html
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        run: |
+          rm -rf site-build
+          uv run python docs/_scripts/build_versioned_docs.py \
+            --mode "${DOCS_BUILD_MODE}" \
+            site-build
+      - name: Publish to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: docs/build/html
-
-  deploy:
-    if: >-
-      ${{
-        (github.event_name == 'workflow_run' &&
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_branch == 'main') ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
-      }}
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          branch: gh-pages
+          folder: site-build
+          clean: true
+          single-commit: true
+          commit-message: Deploy documentation for ${{ github.sha }}
+          git-config-name: github-actions[bot]
+          git-config-email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -6,6 +6,9 @@ on:
       - CI / Tests
     types:
       - completed
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: read
@@ -18,12 +21,25 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+    if: >-
+      ${{
+        (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main') ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
+        if: ${{ github.event_name == 'workflow_run' }}
         with:
+          fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: actions/checkout@v5
+        if: ${{ github.event_name == 'push' }}
+        with:
+          fetch-depth: 0
       - name: Set up Pages
         uses: actions/configure-pages@v5
       - name: Set up Python
@@ -34,6 +50,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Sync docs dependencies
         run: uv sync --extra dev
+      - name: Prepare multiversion refs
+        run: |
+          git fetch --force --tags origin +refs/heads/main:refs/remotes/origin/main
+          git branch -f dev origin/main
       - name: Verify docs font
         run: |
           uv run python - <<'PY'
@@ -61,16 +81,22 @@ jobs:
           print(f"{resolved_name} -> {font_path}")
           assert resolved_name == "Helvetica"
           PY
-      - name: Build documentation
-        run: uv run sphinx-build -b html docs docs/build/html
-      # Keep the custom domain in GitHub Pages settings, not as a committed CNAME file.
+      - name: Build versioned documentation
+        run: uv run python docs/_scripts/build_versioned_docs.py docs/build/html
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: docs/build/html
 
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
+    if: >-
+      ${{
+        (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main') ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      }}
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/docs/_scripts/build_versioned_docs.py
+++ b/docs/_scripts/build_versioned_docs.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import argparse
+import html
+import os
+import posixpath
+import re
+import shutil
+import subprocess
+from pathlib import Path, PurePosixPath
+
+SITE_URL = "https://cnsplots.farid.one/"
+DEV_DOCS_NAME = "dev"
+LATEST_DOCS_NAME = "latest"
+RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs"
+ROBOTS_FILE = DOCS_DIR / "robots.txt"
+COMPAT_SITE_DIR = Path(__file__).resolve().parent / "compat"
+
+
+def _run(*args: str) -> str:
+    """Run a command in the repo root and return stripped stdout."""
+    return subprocess.check_output(args, cwd=REPO_ROOT, text=True).strip()
+
+
+def _find_latest_release_tag() -> str:
+    """Return the newest release tag that matches vX.Y.Z."""
+    tags = _run("git", "tag", "--list", "v*", "--sort=-version:refname").splitlines()
+    for tag in tags:
+        if RELEASE_TAG_PATTERN.fullmatch(tag):
+            return tag
+    raise RuntimeError("No release tag matching vX.Y.Z was found.")
+
+
+def _write_text(path: Path, content: str) -> None:
+    """Write UTF-8 text to disk, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _version_sort_key(name: str) -> tuple[int, int, int]:
+    """Return a semantic sort key for release tags."""
+    match = RELEASE_TAG_PATTERN.fullmatch(name)
+    if not match:
+        return (-1, -1, -1)
+    return tuple(int(part) for part in name[1:].split("."))
+
+
+def _relative_target(stub_relative_path: Path, target_path: PurePosixPath) -> str:
+    """Return a relative redirect target from the stub path to the target path."""
+    stub_parent = PurePosixPath(stub_relative_path.parent.as_posix())
+    start = "." if str(stub_parent) in {"", "."} else stub_parent.as_posix()
+    return posixpath.relpath(target_path.as_posix(), start=start)
+
+
+def _render_redirect_page(relative_target: str, absolute_target: str) -> str:
+    """Render a simple HTML redirect page."""
+    escaped_relative = html.escape(relative_target, quote=True)
+    escaped_absolute = html.escape(absolute_target, quote=True)
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url={escaped_relative}">
+    <link rel="canonical" href="{escaped_absolute}">
+    <script>
+      window.location.replace({relative_target!r});
+    </script>
+  </head>
+  <body>
+    <p>Redirecting to <a href="{escaped_relative}">the latest release docs</a>.</p>
+  </body>
+</html>
+"""
+
+
+def _latest_absolute_url(relative_path: str = "") -> str:
+    """Return the absolute public URL for the latest docs alias."""
+    suffix = f"/{relative_path.lstrip('/')}" if relative_path else ""
+    return f"{SITE_URL.rstrip('/')}/{LATEST_DOCS_NAME}{suffix}"
+
+
+def _rewrite_latest_alias_content(
+    content: str, latest_release_tag: str, suffix: str
+) -> str:
+    """Rewrite copied latest-release files to use the stable /latest public URL."""
+    rewritten = content.replace(
+        f"{SITE_URL.rstrip('/')}/{latest_release_tag}/",
+        _latest_absolute_url("/"),
+    )
+    if suffix == ".xml":
+        rewritten = rewritten.replace(
+            f"<loc>{SITE_URL}",
+            f"<loc>{_latest_absolute_url('/')}",
+        )
+    if suffix == ".html":
+        rewritten = rewritten.replace(
+            f'<span class="docs-version-switcher-current">{latest_release_tag}</span>',
+            f'<span class="docs-version-switcher-current">{LATEST_DOCS_NAME}</span>',
+        )
+        rewritten = re.sub(
+            rf'(<option value="[^"]+" selected>){re.escape(latest_release_tag)}(</option>)',
+            rf"\1{LATEST_DOCS_NAME}\2",
+            rewritten,
+        )
+    return rewritten
+
+
+def _write_latest_release_alias(output_dir: Path, latest_release_tag: str) -> None:
+    """Copy the newest release docs into the stable /latest alias."""
+    latest_release_dir = output_dir / latest_release_tag
+    latest_alias_dir = output_dir / LATEST_DOCS_NAME
+    if not latest_release_dir.exists():
+        raise RuntimeError(
+            f"Latest release docs were not built at {latest_release_dir}."
+        )
+
+    shutil.copytree(latest_release_dir, latest_alias_dir)
+    for path in latest_alias_dir.rglob("*"):
+        if not path.is_file() or path.suffix not in {".html", ".xml"}:
+            continue
+        content = path.read_text(encoding="utf-8")
+        rewritten = _rewrite_latest_alias_content(
+            content, latest_release_tag, path.suffix
+        )
+        if rewritten != content:
+            path.write_text(rewritten, encoding="utf-8")
+
+
+def _write_root_redirects(output_dir: Path) -> None:
+    """Mirror latest HTML paths at the site root via redirect stubs."""
+    latest_alias_dir = output_dir / LATEST_DOCS_NAME
+    if not latest_alias_dir.exists():
+        raise RuntimeError(f"Latest docs alias was not built at {latest_alias_dir}.")
+
+    latest_alias_prefix = PurePosixPath(LATEST_DOCS_NAME)
+    for source_path in latest_alias_dir.rglob("*.html"):
+        relative_html = source_path.relative_to(latest_alias_dir)
+        if relative_html.name == "404.html":
+            continue
+
+        destination_path = output_dir / relative_html
+        if relative_html == Path("index.html"):
+            target_path = latest_alias_prefix
+            relative_target = f"{LATEST_DOCS_NAME}/"
+            absolute_target = _latest_absolute_url("/")
+        else:
+            target_path = latest_alias_prefix / PurePosixPath(relative_html.as_posix())
+            relative_target = _relative_target(relative_html, target_path)
+            absolute_target = f"{SITE_URL.rstrip('/')}/{target_path.as_posix()}"
+        _write_text(
+            destination_path,
+            _render_redirect_page(relative_target, absolute_target),
+        )
+
+
+def _write_root_404(output_dir: Path) -> None:
+    """Write a site-wide 404 page that points users to the latest release."""
+    home_target = f"{LATEST_DOCS_NAME}/"
+    _write_text(
+        output_dir / "404.html",
+        f"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Page not found</title>
+    <meta name="robots" content="noindex, nofollow">
+  </head>
+  <body>
+    <main>
+      <h1>Page not found</h1>
+      <p>The page you requested does not exist, may have moved, or may have been renamed.</p>
+      <p><a href="{html.escape(home_target, quote=True)}">Return to the latest documentation homepage</a>.</p>
+    </main>
+  </body>
+</html>
+""",
+    )
+
+
+def _write_root_sitemap_index(output_dir: Path) -> None:
+    """Write a sitemap index that points to each published docs version."""
+    version_names: list[str] = []
+    for path in output_dir.iterdir():
+        if not path.is_dir():
+            continue
+        if path.name in {
+            DEV_DOCS_NAME,
+            LATEST_DOCS_NAME,
+        } or RELEASE_TAG_PATTERN.fullmatch(path.name):
+            if (path / "sitemap.xml").exists():
+                version_names.append(path.name)
+
+    release_names = sorted(
+        (
+            name
+            for name in version_names
+            if name not in {DEV_DOCS_NAME, LATEST_DOCS_NAME}
+        ),
+        key=_version_sort_key,
+        reverse=True,
+    )
+    version_names = (
+        ([LATEST_DOCS_NAME] if LATEST_DOCS_NAME in version_names else [])
+        + ([DEV_DOCS_NAME] if DEV_DOCS_NAME in version_names else [])
+        + release_names
+    )
+
+    sitemap_entries = "\n".join(
+        (
+            "  <sitemap>\n"
+            f"    <loc>{SITE_URL.rstrip('/')}/{name}/sitemap.xml</loc>\n"
+            "  </sitemap>"
+        )
+        for name in version_names
+    )
+    _write_text(
+        output_dir / "sitemap.xml",
+        (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            f"{sitemap_entries}\n"
+            "</sitemapindex>\n"
+        ),
+    )
+
+
+def _build_versioned_docs(output_dir: Path, latest_release_tag: str) -> None:
+    """Build all versioned docs into the output directory."""
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    compat_path = str(COMPAT_SITE_DIR)
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        compat_path
+        if not existing_pythonpath
+        else f"{compat_path}{os.pathsep}{existing_pythonpath}"
+    )
+    env["CNSPLOTS_DOCS_LATEST_VERSION"] = latest_release_tag
+
+    subprocess.run(
+        [
+            "sphinx-multiversion",
+            str(DOCS_DIR),
+            str(output_dir),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        env=env,
+    )
+
+
+def build(output_dir: Path) -> None:
+    """Build versioned docs and package them for GitHub Pages."""
+    latest_release_tag = _find_latest_release_tag()
+    _build_versioned_docs(output_dir, latest_release_tag)
+    _write_latest_release_alias(output_dir, latest_release_tag)
+    _write_root_redirects(output_dir)
+    shutil.copy2(ROBOTS_FILE, output_dir / "robots.txt")
+    (output_dir / ".nojekyll").write_text("", encoding="utf-8")
+    _write_root_404(output_dir)
+    _write_root_sitemap_index(output_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build versioned Sphinx docs and package them for GitHub Pages."
+    )
+    parser.add_argument(
+        "output_dir", type=Path, help="Directory to write the site into."
+    )
+    args = parser.parse_args()
+    build(args.output_dir.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/_scripts/build_versioned_docs.py
+++ b/docs/_scripts/build_versioned_docs.py
@@ -2,16 +2,23 @@ from __future__ import annotations
 
 import argparse
 import html
+import json
 import os
 import posixpath
 import re
 import shutil
 import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
+from typing import Iterator
+from urllib.parse import urlparse
 
 SITE_URL = "https://cnsplots.farid.one/"
 DEV_DOCS_NAME = "dev"
 LATEST_DOCS_NAME = "latest"
+GITHUB_PAGES_BRANCH = "gh-pages"
 RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -20,9 +27,16 @@ ROBOTS_FILE = DOCS_DIR / "robots.txt"
 COMPAT_SITE_DIR = Path(__file__).resolve().parent / "compat"
 
 
-def _run(*args: str) -> str:
+def _run(*args: str, env: dict[str, str] | None = None, cwd: Path = REPO_ROOT) -> str:
     """Run a command in the repo root and return stripped stdout."""
-    return subprocess.check_output(args, cwd=REPO_ROOT, text=True).strip()
+    return subprocess.check_output(args, cwd=cwd, env=env, text=True).strip()
+
+
+def _run_checked(
+    *args: str, env: dict[str, str] | None = None, cwd: Path = REPO_ROOT
+) -> None:
+    """Run a command in the repo root and require success."""
+    subprocess.run(args, cwd=cwd, env=env, check=True)
 
 
 def _find_latest_release_tag() -> str:
@@ -38,6 +52,13 @@ def _write_text(path: Path, content: str) -> None:
     """Write UTF-8 text to disk, creating parent directories as needed."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def _ensure_clean_dir(path: Path) -> None:
+    """Replace a directory with an empty copy."""
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
 
 
 def _version_sort_key(name: str) -> tuple[int, int, int]:
@@ -228,11 +249,15 @@ def _write_root_sitemap_index(output_dir: Path) -> None:
     )
 
 
-def _build_versioned_docs(output_dir: Path, latest_release_tag: str) -> None:
-    """Build all versioned docs into the output directory."""
-    if output_dir.exists():
-        shutil.rmtree(output_dir)
-    output_dir.parent.mkdir(parents=True, exist_ok=True)
+def _write_cname(output_dir: Path) -> None:
+    """Write the custom domain used by GitHub Pages when configured."""
+    hostname = urlparse(SITE_URL).hostname
+    if hostname:
+        _write_text(output_dir / "CNAME", f"{hostname}\n")
+
+
+def _docs_env(latest_release_tag: str) -> dict[str, str]:
+    """Return the environment used for docs builds."""
     env = os.environ.copy()
     compat_path = str(COMPAT_SITE_DIR)
     existing_pythonpath = env.get("PYTHONPATH")
@@ -242,29 +267,235 @@ def _build_versioned_docs(output_dir: Path, latest_release_tag: str) -> None:
         else f"{compat_path}{os.pathsep}{existing_pythonpath}"
     )
     env["CNSPLOTS_DOCS_LATEST_VERSION"] = latest_release_tag
-
-    subprocess.run(
-        [
-            "sphinx-multiversion",
-            str(DOCS_DIR),
-            str(output_dir),
-        ],
-        cwd=REPO_ROOT,
-        check=True,
-        env=env,
-    )
+    return env
 
 
-def build(output_dir: Path) -> None:
-    """Build versioned docs and package them for GitHub Pages."""
-    latest_release_tag = _find_latest_release_tag()
-    _build_versioned_docs(output_dir, latest_release_tag)
-    _write_latest_release_alias(output_dir, latest_release_tag)
+def _build_full_versioned_docs(output_dir: Path, latest_release_tag: str) -> None:
+    """Build all versioned docs into the output directory."""
+    _ensure_clean_dir(output_dir)
+    env = _docs_env(latest_release_tag)
+
+    _run_checked("sphinx-multiversion", str(DOCS_DIR), str(output_dir), env=env)
+
+
+def _finalize_site(output_dir: Path) -> None:
+    """Write the top-level files expected by GitHub Pages."""
+    if not (output_dir / LATEST_DOCS_NAME).exists():
+        raise RuntimeError(
+            f"Latest docs alias was not assembled at {output_dir / LATEST_DOCS_NAME}."
+        )
+
     _write_root_redirects(output_dir)
     shutil.copy2(ROBOTS_FILE, output_dir / "robots.txt")
-    (output_dir / ".nojekyll").write_text("", encoding="utf-8")
+    _write_text(output_dir / ".nojekyll", "")
+    _write_cname(output_dir)
     _write_root_404(output_dir)
     _write_root_sitemap_index(output_dir)
+
+
+def _build_full_site(output_dir: Path, latest_release_tag: str) -> None:
+    """Build a complete multiversion site and package it for publishing."""
+    _build_full_versioned_docs(output_dir, latest_release_tag)
+    _write_latest_release_alias(output_dir, latest_release_tag)
+    _finalize_site(output_dir)
+
+
+def _dump_multiversion_metadata(
+    output_dir: Path, latest_release_tag: str
+) -> dict[str, dict[str, object]]:
+    """Return sphinx-multiversion metadata without building HTML."""
+    env = _docs_env(latest_release_tag)
+    payload = _run(
+        "sphinx-multiversion",
+        "--dump-metadata",
+        str(DOCS_DIR),
+        str(output_dir),
+        env=env,
+    )
+    return json.loads(payload)
+
+
+def _remote_branch_exists(branch_name: str) -> bool:
+    """Return whether the named remote branch exists on origin."""
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "--heads", "origin", branch_name],
+        cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _fetch_remote_branch(branch_name: str) -> str | None:
+    """Fetch a remote branch into a local remote-tracking ref."""
+    if not _remote_branch_exists(branch_name):
+        return None
+
+    remote_ref = f"refs/remotes/origin/{branch_name}"
+    _run_checked(
+        "git",
+        "fetch",
+        "--depth=1",
+        "origin",
+        f"+refs/heads/{branch_name}:{remote_ref}",
+    )
+    return remote_ref
+
+
+@contextmanager
+def _temporary_worktree(ref: str) -> Iterator[Path]:
+    """Check out a detached git ref in a temporary worktree."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        worktree_path = Path(tmpdir)
+        _run_checked("git", "worktree", "add", "--detach", str(worktree_path), ref)
+        try:
+            yield worktree_path
+        finally:
+            _run_checked("git", "worktree", "remove", "--force", str(worktree_path))
+
+
+def _copy_preserved_versions(existing_site_dir: Path, output_dir: Path) -> list[str]:
+    """Copy published release directories and the stable alias into output_dir."""
+    release_names: list[str] = []
+    for path in existing_site_dir.iterdir():
+        if not path.is_dir():
+            continue
+        if RELEASE_TAG_PATTERN.fullmatch(path.name):
+            shutil.copytree(path, output_dir / path.name)
+            release_names.append(path.name)
+
+    latest_alias_dir = existing_site_dir / LATEST_DOCS_NAME
+    if latest_alias_dir.exists():
+        shutil.copytree(latest_alias_dir, output_dir / LATEST_DOCS_NAME)
+
+    return sorted(release_names, key=_version_sort_key)
+
+
+def _rewrite_metadata_entry(
+    entry: dict[str, object], outputdir: Path
+) -> dict[str, object]:
+    """Return a metadata entry that points to the assembled site tree."""
+    rewritten = dict(entry)
+    rewritten["outputdir"] = str(outputdir.resolve())
+    return rewritten
+
+
+def _build_metadata_for_main_site(
+    all_metadata: dict[str, dict[str, object]],
+    output_dir: Path,
+    preserved_release_names: list[str],
+) -> dict[str, dict[str, object]]:
+    """Return metadata for the dev build plus preserved release versions."""
+    if DEV_DOCS_NAME not in all_metadata:
+        raise RuntimeError("Missing dev metadata for the current main docs build.")
+
+    metadata = {
+        DEV_DOCS_NAME: _rewrite_metadata_entry(
+            all_metadata[DEV_DOCS_NAME], output_dir / DEV_DOCS_NAME
+        )
+    }
+    for name in preserved_release_names:
+        entry = all_metadata.get(name)
+        if entry is None:
+            continue
+        metadata[name] = _rewrite_metadata_entry(entry, output_dir / name)
+    return metadata
+
+
+def _build_single_version_docs(
+    version_name: str,
+    output_dir: Path,
+    metadata: dict[str, dict[str, object]],
+    latest_release_tag: str,
+) -> None:
+    """Build a single docs version using precomputed multiversion metadata."""
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+
+    env = _docs_env(latest_release_tag)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        metadata_path = Path(tmpdir) / "versions.json"
+        metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+        _run_checked(
+            sys.executable,
+            "-m",
+            "sphinx",
+            "-D",
+            f"smv_metadata_path={metadata_path}",
+            "-D",
+            f"smv_current_version={version_name}",
+            str(DOCS_DIR),
+            str(output_dir),
+            env=env,
+        )
+
+
+def _build_bootstrap_site(output_dir: Path, latest_release_tag: str) -> None:
+    """Build the full site for the initial gh-pages bootstrap."""
+    _build_full_site(output_dir, latest_release_tag)
+
+
+def _build_main_site(output_dir: Path, latest_release_tag: str) -> None:
+    """Build only dev docs and preserve published releases from gh-pages."""
+    remote_ref = _fetch_remote_branch(GITHUB_PAGES_BRANCH)
+    if remote_ref is None:
+        _build_bootstrap_site(output_dir, latest_release_tag)
+        return
+
+    all_metadata = _dump_multiversion_metadata(output_dir, latest_release_tag)
+    if latest_release_tag not in all_metadata:
+        raise RuntimeError(
+            f"Missing metadata for the latest release tag {latest_release_tag}."
+        )
+
+    with _temporary_worktree(remote_ref) as existing_site_dir:
+        if (
+            not (existing_site_dir / LATEST_DOCS_NAME).exists()
+            or not (existing_site_dir / latest_release_tag).exists()
+        ):
+            _build_bootstrap_site(output_dir, latest_release_tag)
+            return
+
+        _ensure_clean_dir(output_dir)
+        preserved_release_names = _copy_preserved_versions(
+            existing_site_dir, output_dir
+        )
+        if latest_release_tag not in preserved_release_names:
+            _build_bootstrap_site(output_dir, latest_release_tag)
+            return
+
+        metadata = _build_metadata_for_main_site(
+            all_metadata, output_dir, preserved_release_names
+        )
+        _build_single_version_docs(
+            DEV_DOCS_NAME,
+            output_dir / DEV_DOCS_NAME,
+            metadata,
+            latest_release_tag,
+        )
+
+    _finalize_site(output_dir)
+
+
+def _build_release_site(output_dir: Path, latest_release_tag: str) -> None:
+    """Build the full multiversion site for a tagged release."""
+    _build_full_site(output_dir, latest_release_tag)
+
+
+def build(output_dir: Path, mode: str) -> None:
+    """Build docs and package them for GitHub Pages."""
+    latest_release_tag = _find_latest_release_tag()
+    if mode == "bootstrap":
+        _build_bootstrap_site(output_dir, latest_release_tag)
+        return
+    if mode == "main":
+        _build_main_site(output_dir, latest_release_tag)
+        return
+    if mode == "release":
+        _build_release_site(output_dir, latest_release_tag)
+        return
+    raise ValueError(f"Unsupported build mode: {mode}")
 
 
 def main() -> None:
@@ -272,10 +503,16 @@ def main() -> None:
         description="Build versioned Sphinx docs and package them for GitHub Pages."
     )
     parser.add_argument(
+        "--mode",
+        choices=("bootstrap", "main", "release"),
+        default="bootstrap",
+        help="Build mode for docs publishing.",
+    )
+    parser.add_argument(
         "output_dir", type=Path, help="Directory to write the site into."
     )
     args = parser.parse_args()
-    build(args.output_dir.resolve())
+    build(args.output_dir.resolve(), args.mode)
 
 
 if __name__ == "__main__":

--- a/docs/_scripts/compat/sitecustomize.py
+++ b/docs/_scripts/compat/sitecustomize.py
@@ -1,0 +1,30 @@
+"""Compatibility patches for versioned docs subprocesses."""
+
+from __future__ import annotations
+
+import inspect
+
+from sphinx.config import Config
+from sphinx.util.tags import Tags
+
+_config_read = Config.read.__func__
+_signature = inspect.signature(_config_read)
+
+
+def _needs_keyword_compatibility() -> bool:
+    parameter = _signature.parameters.get("overrides")
+    return parameter is not None and parameter.kind is inspect.Parameter.KEYWORD_ONLY
+
+
+if _needs_keyword_compatibility():
+
+    def _compat_read(cls, confdir, overrides=None, tags=None, **kwargs):
+        if overrides is None:
+            overrides = kwargs.pop("overrides", {})
+        if tags is None:
+            tags = kwargs.pop("tags", None)
+        if tags is None:
+            tags = Tags()
+        return _config_read(cls, confdir, overrides=overrides, tags=tags)
+
+    Config.read = classmethod(_compat_read)

--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -859,3 +859,156 @@ article table.align-default {
   font-weight: 500;
   color: inherit;
 }
+
+.docs-version-banner {
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.125rem;
+  border: 1px solid var(--color-background-border);
+  border-left: 4px solid var(--color-brand-primary);
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(0, 50, 98, 0.08), transparent);
+}
+
+.docs-version-banner--development {
+  border-left-color: #8c510a;
+  background: linear-gradient(135deg, rgba(140, 81, 10, 0.1), transparent);
+}
+
+.docs-version-banner-title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.docs-version-banner-link {
+  font-weight: 500;
+}
+
+.docs-version-switcher {
+  margin: 1rem 0;
+  padding: 0.95rem 1rem 1rem;
+  border: 1px solid var(--color-background-border);
+  border-radius: 0.85rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-brand-primary) 5%, transparent),
+    var(--color-background-primary)
+  );
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--color-brand-primary) 7%, transparent);
+}
+
+.docs-version-switcher-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.8rem;
+}
+
+.docs-version-switcher-title,
+.docs-version-switcher-select-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.docs-version-switcher-current {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid color-mix(
+    in srgb,
+    var(--color-brand-primary) 24%,
+    var(--color-background-border)
+  );
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--color-brand-primary) 9%,
+    var(--color-background-primary)
+  );
+  color: var(--color-foreground-secondary);
+  font-family: var(--font-stack--monospace);
+  font-size: 0.82rem;
+}
+
+.docs-version-switcher-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.docs-version-switcher-select-label {
+  color: var(--color-foreground-secondary);
+}
+
+.docs-version-switcher-select-wrap {
+  position: relative;
+}
+
+.docs-version-switcher-select {
+  width: 100%;
+  padding: 0.82rem 2.8rem 0.82rem 0.95rem;
+  border: 1px solid color-mix(
+    in srgb,
+    var(--color-brand-primary) 18%,
+    var(--color-background-border)
+  );
+  border-radius: 0.8rem;
+  background: color-mix(
+    in srgb,
+    var(--color-brand-primary) 3%,
+    var(--color-background-primary)
+  );
+  color: var(--color-foreground-primary);
+  font-family: var(--font-stack--monospace);
+  font-size: 0.95rem;
+  font-weight: 500;
+  appearance: none;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.docs-version-switcher-select:hover {
+  border-color: color-mix(
+    in srgb,
+    var(--color-brand-primary) 48%,
+    var(--color-background-border)
+  );
+  background: color-mix(
+    in srgb,
+    var(--color-brand-primary) 6%,
+    var(--color-background-primary)
+  );
+}
+
+.docs-version-switcher-select:focus {
+  outline: none;
+  border-color: var(--color-brand-primary);
+  box-shadow: 0 0 0 4px
+    color-mix(in srgb, var(--color-brand-primary) 18%, transparent);
+}
+
+.docs-version-switcher-select optgroup {
+  color: var(--color-foreground-secondary);
+  font-style: normal;
+  font-weight: 700;
+}
+
+.docs-version-switcher-select option {
+  color: var(--color-foreground-primary);
+}
+
+.docs-version-switcher-chevron {
+  position: absolute;
+  top: 50%;
+  right: 1rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-right: 2px solid var(--color-foreground-secondary);
+  border-bottom: 2px solid var(--color-foreground-secondary);
+  pointer-events: none;
+  transform: translateY(-65%) rotate(45deg);
+}

--- a/docs/_templates/components/repo-stats.html
+++ b/docs/_templates/components/repo-stats.html
@@ -7,7 +7,10 @@
   data-repo="{{ repo_stats_repo|e }}"
   aria-label="{{ repo_stats_repo|e }} repository statistics"
 >
-  <span class="repo-stats-icon w-8 flex items-center justify-around shrink-0 text-3xl" aria-hidden="true">
+  <span
+    class="repo-stats-icon w-8 flex items-center justify-around shrink-0 text-3xl"
+    aria-hidden="true"
+  >
     <iconify-icon icon="simple-icons:github"></iconify-icon>
   </span>
   <span class="repo-stats-body flex-grow px-2 break-all">

--- a/docs/_templates/components/version-banner.html
+++ b/docs/_templates/components/version-banner.html
@@ -1,0 +1,10 @@
+{% if docs_version_banner %}
+<div
+  class="docs-version-banner docs-version-banner--{{ docs_version_banner.kind }}"
+>
+  <p class="docs-version-banner-title">{{ docs_version_banner.title }}</p>
+  <a class="docs-version-banner-link" href="{{ docs_version_banner.url }}">
+    {{ docs_version_banner.label }}
+  </a>
+</div>
+{% endif %}

--- a/docs/_templates/components/version-switcher.html
+++ b/docs/_templates/components/version-switcher.html
@@ -21,16 +21,9 @@
         <optgroup label="Development">
           <option
             value="{{ docs_development_version.url }}"
-            {%
-            if
-            current_version
-            and
-            current_version.name=""
-            ="docs_development_version.name"
-            %}
-            selected{%
-            endif
-            %}
+            {% if current_version and current_version.name == docs_development_version.name %}
+            selected
+            {% endif %}
           >
             dev
           </option>
@@ -40,16 +33,9 @@
           {% for item in docs_release_versions %}
           <option
             value="{{ item.url }}"
-            {%
-            if
-            current_version
-            and
-            current_version.name=""
-            ="item.name"
-            %}
-            selected{%
-            endif
-            %}
+            {% if current_version and current_version.name == item.name %}
+            selected
+            {% endif %}
           >
             {{ item.name }}
           </option>

--- a/docs/_templates/components/version-switcher.html
+++ b/docs/_templates/components/version-switcher.html
@@ -1,0 +1,64 @@
+{% if docs_release_versions or docs_development_version %}
+<div class="docs-version-switcher" aria-label="Documentation versions">
+  <div class="docs-version-switcher-header">
+    <span class="docs-version-switcher-title">Versions</span>
+    {% if docs_current_version_label %}
+    <span class="docs-version-switcher-current"
+      >{{ docs_current_version_label }}</span
+    >
+    {% endif %}
+  </div>
+
+  <div class="docs-version-switcher-field">
+    <div class="docs-version-switcher-select-wrap">
+      <select
+        id="docs-version-switcher-select"
+        class="docs-version-switcher-select"
+        aria-label="Select documentation version"
+        onchange="if (this.value) window.location.assign(this.value);"
+      >
+        {% if docs_development_version %}
+        <optgroup label="Development">
+          <option
+            value="{{ docs_development_version.url }}"
+            {%
+            if
+            current_version
+            and
+            current_version.name=""
+            ="docs_development_version.name"
+            %}
+            selected{%
+            endif
+            %}
+          >
+            dev
+          </option>
+        </optgroup>
+        {% endif %} {% if docs_release_versions %}
+        <optgroup label="Releases">
+          {% for item in docs_release_versions %}
+          <option
+            value="{{ item.url }}"
+            {%
+            if
+            current_version
+            and
+            current_version.name=""
+            ="item.name"
+            %}
+            selected{%
+            endif
+            %}
+          >
+            {{ item.name }}
+          </option>
+          {% endfor %}
+        </optgroup>
+        {% endif %}
+      </select>
+      <span class="docs-version-switcher-chevron" aria-hidden="true"></span>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,124 +1,144 @@
-{% extends "!page.html" %}
-
-{% block extrahead %}
-  {{ super() }}
-  <meta name="description" content="{{ seo_description|e }}">
-  <meta name="robots" content="{{ seo_robots|e }}">
-  <meta name="theme-color" content="#003262">
-  <link rel="icon" type="image/svg+xml" href="{{ pathto('_static/images/favicon.svg', 1) }}">
-  <link rel="icon" type="image/png" sizes="16x16" href="{{ pathto('_static/images/favicon-16x16.png', 1) }}">
-  <link rel="icon" type="image/png" sizes="32x32" href="{{ pathto('_static/images/favicon-32x32.png', 1) }}">
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ pathto('_static/images/apple-touch-icon.png', 1) }}">
-  <meta property="og:site_name" content="cnsplots">
-  <meta property="og:type" content="{{ seo_og_type|e }}">
-  <meta property="og:title" content="{{ seo_title|e }}">
-  <meta property="og:description" content="{{ seo_description|e }}">
-  <meta property="og:url" content="{{ seo_canonical_url|e }}">
-  <meta property="og:image" content="{{ seo_image_url|e }}">
-  <meta property="og:image:alt" content="{{ seo_image_alt|e }}">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{{ seo_title|e }}">
-  <meta name="twitter:description" content="{{ seo_description|e }}">
-  <meta name="twitter:image" content="{{ seo_image_url|e }}">
-{% endblock extrahead %}
-
-{% block right_sidebar %}
-{% if not furo_hide_toc %}
+{% extends "!page.html" %} {% block extrahead %} {{ super() }}
+<meta name="description" content="{{ seo_description|e }}" />
+<meta name="robots" content="{{ seo_robots|e }}" />
+<meta name="theme-color" content="#003262" />
+<link
+  rel="icon"
+  type="image/svg+xml"
+  href="{{ pathto('_static/images/favicon.svg', 1) }}"
+/>
+<link
+  rel="icon"
+  type="image/png"
+  sizes="16x16"
+  href="{{ pathto('_static/images/favicon-16x16.png', 1) }}"
+/>
+<link
+  rel="icon"
+  type="image/png"
+  sizes="32x32"
+  href="{{ pathto('_static/images/favicon-32x32.png', 1) }}"
+/>
+<link
+  rel="apple-touch-icon"
+  sizes="180x180"
+  href="{{ pathto('_static/images/apple-touch-icon.png', 1) }}"
+/>
+<meta property="og:site_name" content="cnsplots" />
+<meta property="og:type" content="{{ seo_og_type|e }}" />
+<meta property="og:title" content="{{ seo_title|e }}" />
+<meta property="og:description" content="{{ seo_description|e }}" />
+<meta property="og:url" content="{{ seo_canonical_url|e }}" />
+<meta property="og:image" content="{{ seo_image_url|e }}" />
+<meta property="og:image:alt" content="{{ seo_image_alt|e }}" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{ seo_title|e }}" />
+<meta name="twitter:description" content="{{ seo_description|e }}" />
+<meta name="twitter:image" content="{{ seo_image_url|e }}" />
+{% endblock extrahead %} {% block content %} {% include
+"components/version-banner.html" %} {{ super() }} {% endblock content %} {%
+block right_sidebar %}
 <div class="toc-sticky toc-scroll">
+  {% if not furo_hide_toc %}
   <div class="toc-title-container">
-    <span class="toc-title">
-      {{ _("On this page") }}
-    </span>
+    <span class="toc-title"> {{ _("On this page") }} </span>
   </div>
   <div class="toc-tree-container">
-    <div class="toc-tree">
-      {{ toc }}
-    </div>
+    <div class="toc-tree">{{ toc }}</div>
   </div>
-  {% include "components/repo-stats.html" %}
+  {% endif %} {% include "components/version-switcher.html" %} {% include
+  "components/repo-stats.html" %}
 </div>
-{% endif %}
-{% endblock right_sidebar %}
-
-{% block footer %}
+{% endblock right_sidebar %} {% block footer %}
 <div class="related-pages">
   {% if next -%}
-    <a class="next-page" href="{{ next.link }}">
-      <div class="page-info">
-        <div class="context">
-          <span>{{ _("Next") }}</span>
-        </div>
-        <div class="title">{{ next.title }}</div>
+  <a class="next-page" href="{{ next.link }}">
+    <div class="page-info">
+      <div class="context">
+        <span>{{ _("Next") }}</span>
       </div>
-      <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
-    </a>
-  {%- endif %}
-  {% if prev -%}
-    <a class="prev-page" href="{{ prev.link }}">
-      <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
-      <div class="page-info">
-        <div class="context">
-          <span>{{ _("Previous") }}</span>
-        </div>
-        {% if prev.link == pathto(master_doc) %}
-        <div class="title">{{ _("Home") }}</div>
-        {% else %}
-        <div class="title">{{ prev.title }}</div>
-        {% endif %}
+      <div class="title">{{ next.title }}</div>
+    </div>
+    <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+  </a>
+  {%- endif %} {% if prev -%}
+  <a class="prev-page" href="{{ prev.link }}">
+    <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+    <div class="page-info">
+      <div class="context">
+        <span>{{ _("Previous") }}</span>
       </div>
-    </a>
+      {% if prev.link == pathto(master_doc) %}
+      <div class="title">{{ _("Home") }}</div>
+      {% else %}
+      <div class="title">{{ prev.title }}</div>
+      {% endif %}
+    </div>
+  </a>
   {%- endif %}
 </div>
 <div class="bottom-of-page">
   <div class="left-details">
     {%- if show_copyright %}
     <div class="copyright">
-      {%- if hasdoc('copyright') %}
-        {% trans path=pathto('copyright'), copyright=copyright|e -%}
-          <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}
-        {%- endtrans %}
-      {%- else %}
-        {% trans copyright=copyright|e -%}
-          Copyright &#169; {{ copyright }}
-        {%- endtrans %}
-      {%- endif %}
+      {%- if hasdoc('copyright') %} {% trans path=pathto('copyright'),
+      copyright=copyright|e -%}
+      <a href="{{ path }}">Copyright</a> &#169; {{ copyright }} {%- endtrans %}
+      {%- else %} {% trans copyright=copyright|e -%} Copyright &#169; {{
+      copyright }} {%- endtrans %} {%- endif %}
     </div>
-    {%- endif %}
-    {%- if last_updated -%}
+    {%- endif %} {%- if last_updated -%}
     <div class="last-updated">
-      {% trans last_updated=last_updated|e -%}
-        Last updated on {{ last_updated }}
-      {%- endtrans -%}
+      {% trans last_updated=last_updated|e -%} Last updated on {{ last_updated
+      }} {%- endtrans -%}
     </div>
     {%- endif %}
   </div>
   <div class="right-details">
     {% if theme_footer_icons or READTHEDOCS -%}
     <div class="icons">
-      {% if theme_footer_icons -%}
-      {% for icon_dict in theme_footer_icons -%}
-      <a class="muted-link {{ icon_dict.class }}" href="{{ icon_dict.url }}" aria-label="{{ icon_dict.name }}">
+      {% if theme_footer_icons -%} {% for icon_dict in theme_footer_icons -%}
+      <a
+        class="muted-link {{ icon_dict.class }}"
+        href="{{ icon_dict.url }}"
+        aria-label="{{ icon_dict.name }}"
+      >
         {{- icon_dict.html -}}
       </a>
-      {% endfor %}
-      {%- else -%}
-      {#- Show Read the Docs project -#}
-      {%- if READTHEDOCS and slug -%}
-      <a class="muted-link" href="https://readthedocs.org/projects/{{ slug }}" aria-label="On Read the Docs">
+      {% endfor %} {%- else -%} {#- Show Read the Docs project -#} {%- if
+      READTHEDOCS and slug -%}
+      <a
+        class="muted-link"
+        href="https://readthedocs.org/projects/{{ slug }}"
+        aria-label="On Read the Docs"
+      >
         <svg x="0px" y="0px" viewBox="-125 217 360 360" xml:space="preserve">
-          <path fill="currentColor" d="M39.2,391.3c-4.2,0.6-7.1,4.4-6.5,8.5c0.4,3,2.6,5.5,5.5,6.3 c0,0,18.5,6.1,50,8.7c25.3,2.1,54-1.8,54-1.8c4.2-0.1,7.5-3.6,7.4-7.8c-0.1-4.2-3.6-7.5-7.8-7.4c-0.5,0-1,0.1-1.5,0.2 c0,0-28.1,3.5-50.9,1.6c-30.1-2.4-46.5-7.9-46.5-7.9C41.7,391.3,40.4,391.1,39.2,391.3z M39.2,353.6c-4.2,0.6-7.1,4.4-6.5,8.5 c0.4,3,2.6,5.5,5.5,6.3c0,0,18.5,6.1,50,8.7c25.3,2.1,54-1.8,54-1.8c4.2-0.1,7.5-3.6,7.4-7.8c-0.1-4.2-3.6-7.5-7.8-7.4 c-0.5,0-1,0.1-1.5,0.2c0,0-28.1,3.5-50.9,1.6c-30.1-2.4-46.5-7.9-46.5-7.9C41.7,353.6,40.4,353.4,39.2,353.6z M39.2,315.9 c-4.2,0.6-7.1,4.4-6.5,8.5c0.4,3,2.6,5.5,5.5,6.3c0,0,18.5,6.1,50,8.7c25.3,2.1,54-1.8,54-1.8c4.2-0.1,7.5-3.6,7.4-7.8 c-0.1-4.2-3.6-7.5-7.8-7.4c-0.5,0-1,0.1-1.5,0.2c0,0-28.1,3.5-50.9,1.6c-30.1-2.4-46.5-7.9-46.5-7.9 C41.7,315.9,40.4,315.8,39.2,315.9z M39.2,278.3c-4.2,0.6-7.1,4.4-6.5,8.5c0.4,3,2.6,5.5,5.5,6.3c0,0,18.5,6.1,50,8.7 c25.3,2.1,54-1.8,54-1.8c4.2-0.1,7.5-3.6,7.4-7.8c-0.1-4.2-3.6-7.5-7.8-7.4c-0.5,0-1,0.1-1.5,0.2c0,0-28.1,3.5-50.9,1.6 c-30.1-2.4-46.5-7.9-46.5-7.9C41.7,278.2,40.4,278.1,39.2,278.3z M-13.6,238.5c-39.6,0.3-54.3,12.5-54.3,12.5v295.7 c0,0,14.4-12.4,60.8-10.5s55.9,18.2,112.9,19.3s71.3-8.8,71.3-8.8l0.8-301.4c0,0-25.6,7.3-75.6,7.7c-49.9,0.4-61.9-12.7-107.7-14.2 C-8.2,238.6-10.9,238.5-13.6,238.5z M19.5,257.8c0,0,24,7.9,68.3,10.1c37.5,1.9,75-3.7,75-3.7v267.9c0,0-19,10-66.5,6.6 C59.5,536.1,19,522.1,19,522.1L19.5,257.8z M-3.6,264.8c4.2,0,7.7,3.4,7.7,7.7c0,4.2-3.4,7.7-7.7,7.7c0,0-12.4,0.1-20,0.8 c-12.7,1.3-21.4,5.9-21.4,5.9c-3.7,2-8.4,0.5-10.3-3.2c-2-3.7-0.5-8.4,3.2-10.3c0,0,0,0,0,0c0,0,11.3-6,27-7.5 C-16,264.9-3.6,264.8-3.6,264.8z M-11,302.6c4.2-0.1,7.4,0,7.4,0c4.2,0.5,7.2,4.3,6.7,8.5c-0.4,3.5-3.2,6.3-6.7,6.7 c0,0-12.4,0.1-20,0.8c-12.7,1.3-21.4,5.9-21.4,5.9c-3.7,2-8.4,0.5-10.3-3.2c-2-3.7-0.5-8.4,3.2-10.3c0,0,11.3-6,27-7.5 C-20.5,302.9-15.2,302.7-11,302.6z M-3.6,340.2c4.2,0,7.7,3.4,7.7,7.7s-3.4,7.7-7.7,7.7c0,0-12.4-0.1-20,0.7 c-12.7,1.3-21.4,5.9-21.4,5.9c-3.7,2-8.4,0.5-10.3-3.2c-2-3.7-0.5-8.4,3.2-10.3c0,0,11.3-6,27-7.5C-16,340.1-3.6,340.2-3.6,340.2z" />
+          <path
+            fill="currentColor"
+            d="M39.2,391.3c-4.2,0.6-7.1,4.4-6.5,8.5c0.4,3,2.6,5.5,5.5,6.3 c0,0,18.5,6.1,50,8.7c25.3,2.1,54-1.8,54-1.8c4.2-0.1,7.5-3.6,7.4-7.8c-0.1-4.2-3.6-7.5-7.8-7.4c-0.5,0-1,0.1-1.5,0.2 c0,0-28.1,3.5-50.9,1.6c-30.1-2.4-46.5-7.9-46.5-7.9C41.7,391.3,40.4,391.1,39.2,391.3z M39.2,353.6c-4.2,0.6-7.1,4.4-6.5,8.5 c0.4,3,2.6,5.5,5.5,6.3c0,0,18.5,6.1,50,8.7c25.3,2.1,54-1.8,54-1.8c4.2-0.1,7.5-3.6,7.4-7.8c-0.1-4.2-3.6-7.5-7.8-7.4 c-0.5,0-1,0.1-1.5,0.2c0,0-28.1,3.5-50.9,1.6c-30.1-2.4-46.5-7.9-46.5-7.9C41.7,353.6,40.4,353.4,39.2,353.6z M39.2,315.9 c-4.2,0.6-7.1,4.4-6.5,8.5c0.4,3,2.6,5.5,5.5,6.3c0,0,18.5,6.1,50,8.7c25.3,2.1,54-1.8,54-1.8c4.2-0.1,7.5-3.6,7.4-7.8 c-0.1-4.2-3.6-7.5-7.8-7.4c-0.5,0-1,0.1-1.5,0.2c0,0-28.1,3.5-50.9,1.6c-30.1-2.4-46.5-7.9-46.5-7.9 C41.7,315.9,40.4,315.8,39.2,315.9z M39.2,278.3c-4.2,0.6-7.1,4.4-6.5,8.5c0.4,3,2.6,5.5,5.5,6.3c0,0,18.5,6.1,50,8.7 c25.3,2.1,54-1.8,54-1.8c4.2-0.1,7.5-3.6,7.4-7.8c-0.1-4.2-3.6-7.5-7.8-7.4c-0.5,0-1,0.1-1.5,0.2c0,0-28.1,3.5-50.9,1.6 c-30.1-2.4-46.5-7.9-46.5-7.9C41.7,278.2,40.4,278.1,39.2,278.3z M-13.6,238.5c-39.6,0.3-54.3,12.5-54.3,12.5v295.7 c0,0,14.4-12.4,60.8-10.5s55.9,18.2,112.9,19.3s71.3-8.8,71.3-8.8l0.8-301.4c0,0-25.6,7.3-75.6,7.7c-49.9,0.4-61.9-12.7-107.7-14.2 C-8.2,238.6-10.9,238.5-13.6,238.5z M19.5,257.8c0,0,24,7.9,68.3,10.1c37.5,1.9,75-3.7,75-3.7v267.9c0,0-19,10-66.5,6.6 C59.5,536.1,19,522.1,19,522.1L19.5,257.8z M-3.6,264.8c4.2,0,7.7,3.4,7.7,7.7c0,4.2-3.4,7.7-7.7,7.7c0,0-12.4,0.1-20,0.8 c-12.7,1.3-21.4,5.9-21.4,5.9c-3.7,2-8.4,0.5-10.3-3.2c-2-3.7-0.5-8.4,3.2-10.3c0,0,0,0,0,0c0,0,11.3-6,27-7.5 C-16,264.9-3.6,264.8-3.6,264.8z M-11,302.6c4.2-0.1,7.4,0,7.4,0c4.2,0.5,7.2,4.3,6.7,8.5c-0.4,3.5-3.2,6.3-6.7,6.7 c0,0-12.4,0.1-20,0.8c-12.7,1.3-21.4,5.9-21.4,5.9c-3.7,2-8.4,0.5-10.3-3.2c-2-3.7-0.5-8.4,3.2-10.3c0,0,11.3-6,27-7.5 C-20.5,302.9-15.2,302.7-11,302.6z M-3.6,340.2c4.2,0,7.7,3.4,7.7,7.7s-3.4,7.7-7.7,7.7c0,0-12.4-0.1-20,0.7 c-12.7,1.3-21.4,5.9-21.4,5.9c-3.7,2-8.4,0.5-10.3-3.2c-2-3.7-0.5-8.4,3.2-10.3c0,0,11.3-6,27-7.5C-16,340.1-3.6,340.2-3.6,340.2z"
+          />
         </svg>
       </a>
-      {%- endif -%}
-      {#- Show GitHub repository home -#}
-      {%- if READTHEDOCS and display_github and github_user != "None" and github_repo != "None" -%}
-      <a class="muted-link" href="https://github.com/{{ github_user }}/{{ github_repo }}" aria-label="On GitHub">
-        <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
-          <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+      {%- endif -%} {#- Show GitHub repository home -#} {%- if READTHEDOCS and
+      display_github and github_user != "None" and github_repo != "None" -%}
+      <a
+        class="muted-link"
+        href="https://github.com/{{ github_user }}/{{ github_repo }}"
+        aria-label="On GitHub"
+      >
+        <svg
+          stroke="currentColor"
+          fill="currentColor"
+          stroke-width="0"
+          viewBox="0 0 16 16"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+          ></path>
         </svg>
       </a>
-      {%- endif -%}
-      {%- endif %}
+      {%- endif -%} {%- endif %}
     </div>
     {%- endif %}
   </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,16 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import urlparse
 
-import cnsplots as cns
+_conf_dir = Path(__file__).resolve().parent
+_active_docs_dir = Path(
+    os.environ.get("SPHINX_MULTIVERSION_SOURCEDIR", str(_conf_dir))
+).resolve()
+_active_repo_root = _active_docs_dir.parent
+
+sys.path.insert(0, str(_active_repo_root / "src"))
+sys.path.insert(0, str(_conf_dir / "_ext"))
+
+import cnsplots as cns  # noqa: E402
 
 # -- Project information -----------------------------------------------------
 
@@ -19,6 +28,12 @@ author = "Farid Rashidi"
 version = cns.__version__
 release = cns.__version__
 site_url = "https://cnsplots.farid.one/"
+dev_docs_name = "dev"
+_active_docs_version_name = os.environ.get("SPHINX_MULTIVERSION_NAME", "").strip()
+_latest_release_name = os.environ.get("CNSPLOTS_DOCS_LATEST_VERSION", "").strip()
+_is_archived_release_build = bool(_active_docs_version_name) and (
+    _active_docs_version_name not in {dev_docs_name, _latest_release_name}
+)
 site_description = (
     "Publication-ready scientific visualizations for Cell, Nature, and Science "
     "journals built on matplotlib and seaborn."
@@ -27,10 +42,9 @@ social_preview_image = f"{site_url.rstrip('/')}/_static/images/overview.png"
 
 # -- General configuration ---------------------------------------------------
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "_ext"))
-
 extensions = [
     "sphinx_gallery.gen_gallery",
+    "sphinx_multiversion",
     "sphinx_design",
     "myst_parser",
     "sphinx_copybutton",
@@ -69,6 +83,12 @@ typehints_defaults = "braces"
 todo_include_todos = False
 numpydoc_show_class_members = False
 annotate_defaults = True  # scanpydoc option, look into why we need this
+smv_branch_whitelist = rf"^{dev_docs_name}$"
+smv_tag_whitelist = r"^v\d+\.\d+\.\d+$"
+smv_remote_whitelist = None
+smv_released_pattern = r"^refs/tags/v\d+\.\d+\.\d+$"
+smv_outputdir_format = "{ref.name}"
+smv_latest_version = _latest_release_name or dev_docs_name
 myst_enable_extensions = [
     "colon_fence",
     "dollarmath",
@@ -200,8 +220,9 @@ class GalleryExampleOrder:
 sphinx_gallery_conf = {
     "filename_pattern": r"/.*\.py$",
     "ignore_pattern": "/todo_",
-    "examples_dirs": "../examples",  # path to your example scripts
+    "examples_dirs": str(_active_repo_root / "examples"),
     "gallery_dirs": "examples",  # path to where to save gallery generated output
+    "only_warn_on_example_error": _is_archived_release_build,
     "within_subsection_order": GalleryExampleOrder,
     "backreferences_dir": "gen_modules/backreferences",  # Where to store backreferences
     "doc_module": ("cnsplots",),  # The module containing your functions
@@ -243,7 +264,7 @@ html_js_files = [
     "js/repo-stats.js",
     "js/release-notes.js",
 ]
-html_baseurl = site_url
+html_baseurl = site_url.rstrip("/")
 html_copy_source = False
 html_context = repo_stats_context.copy()
 sitemap_url_scheme = "{link}"
@@ -287,31 +308,56 @@ html_theme_options = {
 
 def git(*args):
     """Run git command and return output as string."""
-    return subprocess.check_output(["git", *args]).strip().decode()
+    return (
+        subprocess.check_output(["git", *args], stderr=subprocess.DEVNULL)
+        .strip()
+        .decode()
+    )
 
 
-# https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
-# Current git reference. Uses branch/tag name if found, otherwise uses commit hash
-git_ref = None
-try:
-    git_ref = git("name-rev", "--name-only", "--no-undefined", "HEAD")
-    git_ref = re.sub(r"^(remotes/[^/]+|tags)/", "", git_ref)
-except Exception:  # noqa: B902
-    pass
+def _published_site_baseurl(version_name: str | None = None) -> str:
+    """Return the public base URL for a docs version."""
+    name = (version_name or "").strip()
+    baseurl = site_url.rstrip("/")
+    if name:
+        return f"{baseurl}/{name}"
+    return baseurl
 
-# (if no name found or relative ref, use commit hash instead)
-if not git_ref or re.search(r"[\^~]", git_ref):
+
+def _resolve_git_ref(version_name: str | None = None) -> str:
+    """Return the GitHub ref that matches the published docs version."""
+    name = (version_name or "").strip()
+    if name:
+        if name == dev_docs_name:
+            return "main"
+        return name
+
+    # https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
+    # Current git reference. Uses branch/tag name if found, otherwise commit hash
+    git_ref = None
     try:
-        git_ref = git("rev-parse", "HEAD")
+        git_ref = git("name-rev", "--name-only", "--no-undefined", "HEAD")
+        git_ref = re.sub(r"^(remotes/[^/]+|tags)/", "", git_ref)
     except Exception:  # noqa: B902
-        git_ref = "main"
+        pass
+
+    if not git_ref or re.search(r"[\^~]", git_ref):
+        try:
+            git_ref = git("rev-parse", "HEAD")
+        except Exception:  # noqa: B902
+            git_ref = "main"
+
+    return git_ref
+
+
+git_ref = _resolve_git_ref(_active_docs_version_name)
 
 # https://github.com/DisnakeDev/disnake/blob/7853da70b13fcd2978c39c0b7efa59b34d298186/docs/conf.py#L192
 _cnsplots_tools_module_path = os.path.dirname(
     importlib.util.find_spec("cnsplots").origin
 )
-_docs_dir = Path(__file__).resolve().parent
-_repo_root = _docs_dir.parent
+_docs_dir = _active_docs_dir
+_repo_root = _active_repo_root
 
 
 def _resolve_gallery_source_path(pagename: str) -> str | None:
@@ -571,12 +617,89 @@ def _inject_page_seo(
     context["seo_title"] = seo_title
     context["seo_description"] = _build_page_description(pagename, title)
     context["seo_canonical_url"] = _build_page_url(app, pagename)
-    context["seo_image_url"] = social_preview_image
+    context["seo_image_url"] = (
+        f"{app.config.html_baseurl.rstrip('/')}/_static/images/overview.png"
+    )
     context["seo_image_alt"] = "Overview of cnsplots visualizations"
     context["seo_robots"] = (
         "noindex, nofollow" if pagename in noindex_pages else "index, follow"
     )
     context["seo_og_type"] = "website" if pagename == "index" else "article"
+
+
+def _configure_active_docs_build(app, config) -> None:
+    """Apply version-aware URLs and source refs after config values are loaded."""
+    del app
+
+    version_name = (config.smv_current_version or _active_docs_version_name).strip()
+    config.html_baseurl = _published_site_baseurl(version_name)
+    config.html_extra_path = [] if version_name else ["robots.txt"]
+
+    global social_preview_image, git_ref
+    social_preview_image = (
+        f"{config.html_baseurl.rstrip('/')}/_static/images/overview.png"
+    )
+    git_ref = _resolve_git_ref(version_name)
+
+
+def _parse_release_name(name: str) -> tuple[int, int, int]:
+    """Return a semantic sort key for release tags."""
+    match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", name)
+    if match is None:
+        return (-1, -1, -1)
+    return tuple(int(part) for part in match.groups())
+
+
+def _inject_version_navigation(
+    app, pagename: str, templatename, context: dict[str, Any], doctree
+):
+    """Add ordered version-switcher and banner context for multiversion builds."""
+    del app, pagename, templatename, doctree
+
+    current_version = context.get("current_version")
+    latest_version = context.get("latest_version")
+    versions = context.get("versions")
+
+    if current_version is None or latest_version is None or versions is None:
+        context["docs_release_versions"] = []
+        context["docs_development_version"] = None
+        context["docs_version_banner"] = None
+        context["docs_current_version_label"] = None
+        return
+
+    release_versions = sorted(
+        versions.releases,
+        key=lambda item: _parse_release_name(item.name),
+        reverse=True,
+    )
+    development_version = next(
+        (item for item in versions.in_development if item.name == dev_docs_name),
+        None,
+    )
+
+    context["docs_release_versions"] = release_versions
+    context["docs_development_version"] = development_version
+    context["docs_current_version_label"] = (
+        "dev (main)" if current_version.name == dev_docs_name else current_version.name
+    )
+
+    banner = None
+    if current_version.name == dev_docs_name and latest_version is not None:
+        banner = {
+            "kind": "development",
+            "title": "You are reading the development documentation.",
+            "url": latest_version.url,
+            "label": f"View the latest stable release ({latest_version.name})",
+        }
+    elif current_version.is_released and current_version.name != latest_version.name:
+        banner = {
+            "kind": "outdated",
+            "title": "You are reading an older release of the documentation.",
+            "url": latest_version.url,
+            "label": f"View the latest stable release ({latest_version.name})",
+        }
+
+    context["docs_version_banner"] = banner
 
 
 def linkcode_resolve(domain, info):
@@ -604,5 +727,7 @@ def linkcode_resolve(domain, info):
 def setup(app):
     """Register Sphinx hooks for page metadata and source link overrides."""
     app.connect("env-before-read-docs", _regroup_flat_gallery_index)
+    app.connect("config-inited", _configure_active_docs_build, priority=800)
     app.connect("html-page-context", _override_source_links)
     app.connect("html-page-context", _inject_page_seo)
+    app.connect("html-page-context", _inject_version_navigation, priority=800)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ cnsplots is a Python visualization library built on matplotlib and fully compati
 ```{image} _static/images/overview.png
 :alt: Overview of cnsplots visualizations
 :align: center
-:target: https://cnsplots.farid.one/examples/showcase.html#figure-1
+:target: examples/showcase.html#figure-1
 ```
 
 ## Key Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "sphinx-copybutton",
     "sphinx-design",
     "sphinx-gallery",
+    "sphinx-multiversion",
     "sphinx-sitemap",
 ]
 

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 import matplotlib as mpl
 import matplotlib.colorbar  # noqa: F401  # ensure submodule is importable for isinstance checks
+import matplotlib.legend  # noqa: F401  # ensure submodule is importable for isinstance checks
 import matplotlib.pyplot as plt
 import num2tex
 import numpy as np

--- a/tests/test_docs_build_script.py
+++ b/tests/test_docs_build_script.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import importlib.util
+from contextlib import contextmanager
+from pathlib import Path
+
+
+def _load_docs_build_script():
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "docs"
+        / "_scripts"
+        / "build_versioned_docs.py"
+    )
+    spec = importlib.util.spec_from_file_location("docs_build_script", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_main_build_bootstraps_when_gh_pages_branch_is_missing(tmp_path, monkeypatch):
+    docs_build = _load_docs_build_script()
+    bootstrap_calls = []
+
+    monkeypatch.setattr(docs_build, "_fetch_remote_branch", lambda branch_name: None)
+    monkeypatch.setattr(
+        docs_build,
+        "_build_bootstrap_site",
+        lambda output_dir, latest_release_tag: bootstrap_calls.append(
+            (output_dir, latest_release_tag)
+        ),
+    )
+
+    output_dir = tmp_path / "site"
+    docs_build._build_main_site(output_dir, "v0.1.0")
+
+    assert bootstrap_calls == [(output_dir, "v0.1.0")]
+
+
+def test_main_build_bootstraps_when_latest_alias_is_missing(tmp_path, monkeypatch):
+    docs_build = _load_docs_build_script()
+    published_site = tmp_path / "published"
+    (published_site / "v0.1.0").mkdir(parents=True)
+    bootstrap_calls = []
+
+    monkeypatch.setattr(
+        docs_build, "_fetch_remote_branch", lambda branch_name: "origin/gh-pages"
+    )
+
+    @contextmanager
+    def fake_worktree(ref):
+        assert ref == "origin/gh-pages"
+        yield published_site
+
+    monkeypatch.setattr(docs_build, "_temporary_worktree", fake_worktree)
+    monkeypatch.setattr(
+        docs_build,
+        "_dump_multiversion_metadata",
+        lambda output_dir, latest_release_tag: {
+            "dev": {"name": "dev", "outputdir": "unused"},
+            "v0.1.0": {"name": "v0.1.0", "outputdir": "unused"},
+        },
+    )
+    monkeypatch.setattr(
+        docs_build,
+        "_build_bootstrap_site",
+        lambda output_dir, latest_release_tag: bootstrap_calls.append(
+            (output_dir, latest_release_tag)
+        ),
+    )
+
+    output_dir = tmp_path / "site"
+    docs_build._build_main_site(output_dir, "v0.1.0")
+
+    assert bootstrap_calls == [(output_dir, "v0.1.0")]
+
+
+def test_main_build_preserves_release_directories(tmp_path, monkeypatch):
+    docs_build = _load_docs_build_script()
+    published_site = tmp_path / "published"
+    for version_name in ("latest", "v0.1.0", "v0.0.4"):
+        version_dir = published_site / version_name
+        version_dir.mkdir(parents=True)
+        (version_dir / "index.html").write_text(
+            f"<html>{version_name}</html>", encoding="utf-8"
+        )
+        (version_dir / "sitemap.xml").write_text("<xml />", encoding="utf-8")
+
+    metadata = {
+        "dev": {
+            "name": "dev",
+            "outputdir": "unused",
+            "docnames": ["index"],
+        },
+        "v0.1.0": {
+            "name": "v0.1.0",
+            "outputdir": "unused",
+            "docnames": ["index"],
+        },
+        "v0.0.4": {
+            "name": "v0.0.4",
+            "outputdir": "unused",
+            "docnames": ["index"],
+        },
+    }
+    build_calls = {}
+
+    monkeypatch.setattr(
+        docs_build, "_fetch_remote_branch", lambda branch_name: "origin/gh-pages"
+    )
+
+    @contextmanager
+    def fake_worktree(ref):
+        assert ref == "origin/gh-pages"
+        yield published_site
+
+    monkeypatch.setattr(docs_build, "_temporary_worktree", fake_worktree)
+    monkeypatch.setattr(
+        docs_build,
+        "_dump_multiversion_metadata",
+        lambda output_dir, latest_release_tag: metadata,
+    )
+
+    def fake_build_single_version_docs(
+        version_name, version_output_dir, version_metadata, latest_release_tag
+    ):
+        build_calls["version_name"] = version_name
+        build_calls["metadata_names"] = set(version_metadata)
+        build_calls["latest_release_tag"] = latest_release_tag
+        version_output_dir.mkdir(parents=True)
+        (version_output_dir / "index.html").write_text(
+            "<html>dev</html>", encoding="utf-8"
+        )
+        (version_output_dir / "sitemap.xml").write_text("<xml />", encoding="utf-8")
+
+    monkeypatch.setattr(
+        docs_build, "_build_single_version_docs", fake_build_single_version_docs
+    )
+
+    output_dir = tmp_path / "site"
+    docs_build._build_main_site(output_dir, "v0.1.0")
+
+    assert build_calls == {
+        "version_name": "dev",
+        "metadata_names": {"dev", "v0.1.0", "v0.0.4"},
+        "latest_release_tag": "v0.1.0",
+    }
+    assert (output_dir / "latest" / "index.html").read_text(encoding="utf-8") == (
+        "<html>latest</html>"
+    )
+    assert (output_dir / "v0.1.0" / "index.html").read_text(encoding="utf-8") == (
+        "<html>v0.1.0</html>"
+    )
+    assert (output_dir / "v0.0.4" / "index.html").read_text(encoding="utf-8") == (
+        "<html>v0.0.4</html>"
+    )
+    assert (output_dir / "dev" / "index.html").read_text(encoding="utf-8") == (
+        "<html>dev</html>"
+    )
+    assert "latest/" in (output_dir / "index.html").read_text(encoding="utf-8")
+    assert (output_dir / "CNAME").read_text(encoding="utf-8").strip() == (
+        "cnsplots.farid.one"
+    )
+    assert (output_dir / ".nojekyll").exists()
+
+    sitemap = (output_dir / "sitemap.xml").read_text(encoding="utf-8")
+    assert "/latest/sitemap.xml" in sitemap
+    assert "/dev/sitemap.xml" in sitemap
+    assert "/v0.1.0/sitemap.xml" in sitemap
+    assert "/v0.0.4/sitemap.xml" in sitemap

--- a/uv.lock
+++ b/uv.lock
@@ -729,6 +729,7 @@ dev = [
     { name = "sphinx-design", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-gallery", version = "0.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx-gallery", version = "0.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sphinx-multiversion" },
     { name = "sphinx-sitemap" },
 ]
 
@@ -768,6 +769,7 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'dev'" },
     { name = "sphinx-design", marker = "extra == 'dev'" },
     { name = "sphinx-gallery", marker = "extra == 'dev'" },
+    { name = "sphinx-multiversion", marker = "extra == 'dev'" },
     { name = "sphinx-sitemap", marker = "extra == 'dev'" },
     { name = "statannotations" },
     { name = "statsmodels" },
@@ -5503,6 +5505,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/03/fd/de1685b6dab173dff31da24e0d3b29f02873fc24a1cdbb7678721ddc8581/sphinx_last_updated_by_git-0.3.8.tar.gz", hash = "sha256:c145011f4609d841805b69a9300099fc02fed8f5bb9e5bcef77d97aea97b7761", size = 10785, upload-time = "2024-08-11T07:15:54.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/fb/e496f16fa11fbe2dbdd0b5e306ede153dfed050aae4766fc89d500720dc7/sphinx_last_updated_by_git-0.3.8-py3-none-any.whl", hash = "sha256:6382c8285ac1f222483a58569b78c0371af5e55f7fbf9c01e5e8a72d6fdfa499", size = 8580, upload-time = "2024-08-11T07:15:53.244Z" },
+]
+
+[[package]]
+name = "sphinx-multiversion"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/10/25231164a97a9016bdc73a3530af8f4a6846bdc564af1460af2ff3e59a50/sphinx-multiversion-0.2.4.tar.gz", hash = "sha256:5cd1ca9ecb5eed63cb8d6ce5e9c438ca13af4fa98e7eb6f376be541dd4990bcb", size = 7024, upload-time = "2020-08-12T15:48:20.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/51/203bb30b3ce76373237288e92cb71fb66f80ee380473f36bfe8a9d299c5d/sphinx_multiversion-0.2.4-py2.py3-none-any.whl", hash = "sha256:5c38d5ce785a335d8c8d768b46509bd66bfb9c6252b93b700ca8c05317f207d6", size = 9597, upload-time = "2024-10-03T21:45:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ad/4989e6be165805694e93d09bc57425aa1368273b7de4fe3083fe4310803a/sphinx_multiversion-0.2.4-py3-none-any.whl", hash = "sha256:dec29f2a5890ad68157a790112edc0eb63140e70f9df0a363743c6258fbeb478", size = 9642, upload-time = "2020-08-12T15:48:19.649Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed
- add versioned documentation support with release banners, a version switcher, and the supporting Sphinx multiversion configuration
- migrate docs publishing to a single-commit `gh-pages` deployment that runs on pushes to `main` and release tags
- build only `/dev` on ordinary `main` pushes while preserving existing tagged docs and `/latest`, and keep bootstrap/release builds available for full site refreshes
- fix the version switcher Jinja regression and add tests for the new docs build modes

## How it was tested
- `make test`
- `make lint`
- `uv run python docs/_scripts/build_versioned_docs.py --mode bootstrap /tmp/cnsplots-docs-bootstrap`

## Risks or follow-ups
- GitHub Pages still needs a one-time settings change after merge: switch the Pages source to `Deploy from a Branch` and select `gh-pages`
- archived release builds still emit non-fatal Sphinx warnings from older docs/examples during full bootstrap builds