### PR TITLE
🐛 Fix main docs build after gh-pages bootstrap

### DIFF
--- a/docs/_scripts/build_versioned_docs.py
+++ b/docs/_scripts/build_versioned_docs.py
@@ -350,11 +350,13 @@ def _copy_preserved_versions(existing_site_dir: Path, output_dir: Path) -> list[
 
 
 def _rewrite_metadata_entry(
-    entry: dict[str, object], outputdir: Path
+    entry: dict[str, object], outputdir: Path, confdir: Path | None = None
 ) -> dict[str, object]:
     """Return a metadata entry that points to the assembled site tree."""
     rewritten = dict(entry)
     rewritten["outputdir"] = str(outputdir.resolve())
+    if confdir is not None:
+        rewritten["confdir"] = str(confdir.resolve())
     return rewritten
 
 
@@ -369,7 +371,9 @@ def _build_metadata_for_main_site(
 
     metadata = {
         DEV_DOCS_NAME: _rewrite_metadata_entry(
-            all_metadata[DEV_DOCS_NAME], output_dir / DEV_DOCS_NAME
+            all_metadata[DEV_DOCS_NAME],
+            output_dir / DEV_DOCS_NAME,
+            DOCS_DIR,
         )
     }
     for name in preserved_release_names:

--- a/tests/test_docs_build_script.py
+++ b/tests/test_docs_build_script.py
@@ -91,16 +91,19 @@ def test_main_build_preserves_release_directories(tmp_path, monkeypatch):
         "dev": {
             "name": "dev",
             "outputdir": "unused",
+            "confdir": str(tmp_path / "temp-dev-docs"),
             "docnames": ["index"],
         },
         "v0.1.0": {
             "name": "v0.1.0",
             "outputdir": "unused",
+            "confdir": str(tmp_path / "temp-v010-docs"),
             "docnames": ["index"],
         },
         "v0.0.4": {
             "name": "v0.0.4",
             "outputdir": "unused",
+            "confdir": str(tmp_path / "temp-v004-docs"),
             "docnames": ["index"],
         },
     }
@@ -127,6 +130,8 @@ def test_main_build_preserves_release_directories(tmp_path, monkeypatch):
     ):
         build_calls["version_name"] = version_name
         build_calls["metadata_names"] = set(version_metadata)
+        build_calls["dev_confdir"] = version_metadata["dev"]["confdir"]
+        build_calls["release_confdir"] = version_metadata["v0.1.0"]["confdir"]
         build_calls["latest_release_tag"] = latest_release_tag
         version_output_dir.mkdir(parents=True)
         (version_output_dir / "index.html").write_text(
@@ -144,6 +149,8 @@ def test_main_build_preserves_release_directories(tmp_path, monkeypatch):
     assert build_calls == {
         "version_name": "dev",
         "metadata_names": {"dev", "v0.1.0", "v0.0.4"},
+        "dev_confdir": str(docs_build.DOCS_DIR.resolve()),
+        "release_confdir": str(tmp_path / "temp-v010-docs"),
         "latest_release_tag": "v0.1.0",
     }
     assert (output_dir / "latest" / "index.html").read_text(encoding="utf-8") == (


### PR DESCRIPTION
## What changed
- rewrite the `dev` metadata entry used by `main`-mode docs builds so its `confdir` points at the live repository `docs/` directory instead of the temporary path emitted by `sphinx-multiversion --dump-metadata`
- keep preserved release metadata untouched apart from their output paths
- add regression coverage for the rewritten `confdir` so the incremental `main`-mode path would fail in tests if it regressed again

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- this is intentionally narrow and only fixes the incremental `main`-mode builder path that runs after `gh-pages` already exists
- after merge, rerunning `CI / Docs` on `main` should publish successfully without needing another bootstrap build