### PR TITLE
💄 Refine docs sidebar and center 404 pages

### DIFF
--- a/docs/_scripts/build_versioned_docs.py
+++ b/docs/_scripts/build_versioned_docs.py
@@ -151,6 +151,9 @@ def _render_root_404_page() -> str:
       body {
         margin: 0;
         min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
           "Segoe UI", sans-serif;
         background:
@@ -162,7 +165,12 @@ def _render_root_404_page() -> str:
       .page {
         width: min(1100px, calc(100% - 2rem));
         margin: 0 auto;
-        padding: 1.5rem 0 4rem;
+        min-height: 100vh;
+        padding: 2rem 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
       }
 
       .brand {
@@ -184,6 +192,7 @@ def _render_root_404_page() -> str:
       }
 
       .hero {
+        width: min(100%, 44rem);
         max-width: 44rem;
         margin-top: 1.5rem;
         padding: clamp(1.5rem, 4vw, 2.5rem);
@@ -217,7 +226,7 @@ def _render_root_404_page() -> str:
 
       .copy p {
         max-width: 38rem;
-        margin: 1rem 0 0;
+        margin: 1rem auto 0;
         color: var(--muted);
         font-size: 1.05rem;
         line-height: 1.7;
@@ -275,7 +284,7 @@ def _render_root_404_page() -> str:
       @media (max-width: 640px) {
         .page {
           width: min(100% - 1rem, 1100px);
-          padding-top: 1rem;
+          padding: 1rem 0;
         }
       }
     </style>

--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -754,10 +754,22 @@ article table.align-default {
   display: none;
 }
 
+article[role="main"]:has(.not-found-page) {
+  display: grid;
+  justify-items: center;
+  align-content: center;
+  min-height: calc(100vh - 16rem);
+  text-align: center;
+}
+
+article[role="main"]:has(.not-found-page) > h1 {
+  width: min(100%, 48rem);
+}
+
 .not-found-page {
   max-width: 48rem;
-  margin: 0 auto;
-  padding: 2rem 0 1rem;
+  margin: 0;
+  padding: 1rem 0 0;
 }
 
 .repo-stats,

--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -240,11 +240,7 @@ article[role="main"]
 }
 
 .release-notes-status[data-state="error"] {
-  border-color: color-mix(
-    in srgb,
-    #b42318 30%,
-    var(--color-foreground-border)
-  );
+  border-color: color-mix(in srgb, #b42318 30%, var(--color-foreground-border));
   background: color-mix(in srgb, #b42318 6%, var(--color-background-primary));
 }
 
@@ -322,11 +318,12 @@ article[role="main"]
 .release-notes-body blockquote {
   margin: 1rem 0;
   padding-left: 1rem;
-  border-left: 3px solid color-mix(
-    in srgb,
-    var(--color-brand-content) 35%,
-    var(--color-foreground-border)
-  );
+  border-left: 3px solid
+    color-mix(
+      in srgb,
+      var(--color-brand-content) 35%,
+      var(--color-foreground-border)
+    );
   color: var(--color-foreground-secondary);
 }
 
@@ -866,12 +863,10 @@ article table.align-default {
   border: 1px solid var(--color-background-border);
   border-left: 4px solid var(--color-brand-primary);
   border-radius: 0.75rem;
-  background: linear-gradient(135deg, rgba(0, 50, 98, 0.08), transparent);
 }
 
 .docs-version-banner--development {
   border-left-color: #8c510a;
-  background: linear-gradient(135deg, rgba(140, 81, 10, 0.1), transparent);
 }
 
 .docs-version-banner-title {
@@ -887,13 +882,7 @@ article table.align-default {
   margin: 1rem 0;
   padding: 0.95rem 1rem 1rem;
   border: 1px solid var(--color-background-border);
-  border-radius: 0.85rem;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--color-brand-primary) 5%, transparent),
-    var(--color-background-primary)
-  );
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--color-brand-primary) 7%, transparent);
+  border-radius: 0.5rem;
 }
 
 .docs-version-switcher-header {
@@ -916,11 +905,12 @@ article table.align-default {
   display: inline-flex;
   align-items: center;
   padding: 0.2rem 0.55rem;
-  border: 1px solid color-mix(
-    in srgb,
-    var(--color-brand-primary) 24%,
-    var(--color-background-border)
-  );
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--color-brand-primary) 24%,
+      var(--color-background-border)
+    );
   border-radius: 999px;
   background: color-mix(
     in srgb,
@@ -948,11 +938,12 @@ article table.align-default {
 .docs-version-switcher-select {
   width: 100%;
   padding: 0.82rem 2.8rem 0.82rem 0.95rem;
-  border: 1px solid color-mix(
-    in srgb,
-    var(--color-brand-primary) 18%,
-    var(--color-background-border)
-  );
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--color-brand-primary) 18%,
+      var(--color-background-border)
+    );
   border-radius: 0.8rem;
   background: color-mix(
     in srgb,

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -46,8 +46,8 @@ block right_sidebar %}
   <div class="toc-tree-container">
     <div class="toc-tree">{{ toc }}</div>
   </div>
-  {% endif %} {% include "components/version-switcher.html" %} {% include
-  "components/repo-stats.html" %}
+  {% endif %} {% include "components/repo-stats.html" %} {% include
+  "components/version-switcher.html" %}
 </div>
 {% endblock right_sidebar %} {% block footer %}
 <div class="related-pages">

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -37,7 +37,7 @@
 <meta name="twitter:image" content="{{ seo_image_url|e }}" />
 {% endblock extrahead %} {% block content %} {% include
 "components/version-banner.html" %} {{ super() }} {% endblock content %} {%
-block right_sidebar %}
+block right_sidebar %} {% if pagename != "404" %}
 <div class="toc-sticky toc-scroll">
   {% if not furo_hide_toc %}
   <div class="toc-title-container">
@@ -49,7 +49,7 @@ block right_sidebar %}
   {% endif %} {% include "components/repo-stats.html" %} {% include
   "components/version-switcher.html" %}
 </div>
-{% endblock right_sidebar %} {% block footer %}
+{% endif %} {% endblock right_sidebar %} {% block footer %}
 <div class="related-pages">
   {% if next -%}
   <a class="next-page" href="{{ next.link }}">


### PR DESCRIPTION
## What changed
- simplified the docs sidebar card styling by removing extra gradients and heavier chrome
- reordered the sidebar components so repo stats appear before the version switcher
- centered the docs 404 layout by hiding the sidebar on that page and centering the article content
- centered the generated root 404 page so the brand and hero content sit in the middle of the viewport

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- this was validated by automated checks; a quick browser pass on the docs 404 pages would confirm the final alignment on desktop and mobile
