### PR TITLE
💄 Update docs typography to Moranga, Inter, and JetBrains Mono

### DIFF
--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -1,4 +1,55 @@
+@font-face {
+  font-family: "Moranga";
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url("https://fonts.prefix.dev/moranga/MorangaLight/font.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "Moranga";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("https://fonts.prefix.dev/moranga/MorangaRegular/font.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "Moranga";
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url("https://fonts.prefix.dev/moranga/MorangaMedium/font.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "Moranga";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("https://fonts.prefix.dev/moranga/MorangaBold/font.woff2")
+    format("woff2");
+}
+
+@font-face {
+  font-family: "Moranga";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("https://fonts.prefix.dev/moranga/MorangaBlack/font.woff2")
+    format("woff2");
+}
+
 body {
+  --font-stack: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --font-stack--headings: "Moranga", "Iowan Old Style", "Palatino Linotype",
+    "Book Antiqua", Georgia, serif;
+  --font-stack--monospace: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas,
+    Monaco, "Liberation Mono", "Lucida Console", monospace;
   --code-block-radius: 12px;
   --code-block-padding: 1rem;
   --code-block-font-size: 0.96rem;

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -35,6 +35,12 @@
 <meta name="twitter:title" content="{{ seo_title|e }}" />
 <meta name="twitter:description" content="{{ seo_description|e }}" />
 <meta name="twitter:image" content="{{ seo_image_url|e }}" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link rel="preconnect" href="https://fonts.prefix.dev" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap"
+/>
 {% endblock extrahead %} {% block content %} {% include
 "components/version-banner.html" %} {{ super() }} {% endblock content %} {%
 block right_sidebar %} {% if pagename != "404" %}


### PR DESCRIPTION
## What changed
- load Inter and JetBrains Mono for the docs theme from Google Fonts
- add the full hosted Moranga family from fonts.prefix.dev
- override Furo font tokens so headings use Moranga, body text uses Inter, and code uses JetBrains Mono

## How it was tested
- CI=true make doc
- make test
- make lint

## Risks or follow-ups
- the docs now depend on external font hosts at fonts.prefix.dev, fonts.googleapis.com, and fonts.gstatic.com
- a browser-based visual pass is still worth doing to confirm the rendered typography in light and dark themes
- the docs build still reports two Sphinx warnings unrelated to the font changes