### PR TITLE
💄 Reduce heading sizes in docs pages

### DIFF
--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -230,6 +230,30 @@ body[data-theme="dark"] {
   }
 }
 
+article[role="main"] h1 {
+  font-size: 1.8em;
+}
+
+article[role="main"] h2 {
+  font-size: 1.6em;
+}
+
+article[role="main"] h3 {
+  font-size: 1.4em;
+}
+
+article[role="main"] h4 {
+  font-size: 1.2em;
+}
+
+article[role="main"] h5 {
+  font-size: 1.1em;
+}
+
+article[role="main"] h6 {
+  font-size: 1em;
+}
+
 article[role="main"] .highlight,
 article[role="main"] pre.literal-block {
   color: var(--syntax-text);
@@ -330,7 +354,6 @@ article[role="main"]
 
 .release-notes-title {
   margin: 0;
-  font-size: clamp(1.45rem, 1.3rem + 0.9vw, 2rem);
 }
 
 .release-notes-meta {


### PR DESCRIPTION
## What changed
- Reduced the docs content heading scale in `docs/_static/css/override.css`
- Set `h1` to `1.8em` and stepped `h2` through `h6` down to match
- Removed the custom release notes title size so it follows the shared docs heading scale

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- This is a visual-only change; after a docs preview we may want to fine-tune the intermediate `h2` to `h6` sizes if a different hierarchy feels better in practice