### PR TITLE
💄 Align release note dates with version titles

### DIFF
--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -346,7 +346,7 @@ article[role="main"]
 .release-notes-header {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 0.9rem;
   margin-bottom: 1rem;
@@ -415,6 +415,7 @@ article[role="main"]
 @media (max-width: 640px) {
   .release-notes-header {
     flex-direction: column;
+    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION
## What changed
- Centered the release notes header items so the release date aligns vertically with the version title on wider screens.
- Kept the stacked mobile layout left-aligned for screens below 640px.

## How it was tested
- make lint
- make test

## Risks or follow-ups
- This is a small docs-only CSS change, so the main risk is visual regression in the release notes header layout.