### PR TITLE
📝 Expand Gitmoji guidance in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,12 @@
 # AGENTS.md
 
+Use this file as the repo-specific operating manual for branch, validation, commit, and pull request behavior. When two rules appear to overlap, follow the more specific rule.
+
 ## Working branch rules
 
 - Never work directly on `main`.
 - If starting new work, create and switch to a new branch from `main` named `<type>/<short-name>` such as `feature/<short-name>`, `bugfix/<short-name>`, `docs/<short-name>`, `refactor/<short-name>`, or `chore/<short-name>`.
+- If you discover local changes while on `main`, create the new branch first and continue the work there.
 - If already on the intended work branch, continue there unless explicitly told to create a new branch.
 - Do not rename or delete branches unless explicitly asked.
 - Do not use `gh` to create branches; use `git`.
@@ -11,6 +14,7 @@
 ## Implementation rules
 
 - Follow the smallest-change approach that fully solves the task.
+- Keep the diff scoped to the task at hand. If you notice a separate issue, mention it instead of bundling it into the same change.
 - Do not make unrelated refactors or opportunistic cleanup unless explicitly asked.
 - Ask before:
   - adding or removing dependencies
@@ -23,9 +27,10 @@
 - Before opening a pull request, run:
   - `make test`
   - `make lint`
+- Run validation after the proposed changes are in place so the results match the branch you plan to submit.
 - If either command fails:
   - fix the issue when it is clearly in scope
-  - otherwise stop and report the failure clearly
+  - otherwise stop and report the failure clearly, including which command failed
 - Do not claim tests passed unless they were actually run successfully.
 
 ## Commit rules
@@ -34,9 +39,9 @@
 - Prefer a single commit for a small, self-contained change.
 - For larger work, use multiple logical commits rather than one large commit.
 - Do not amend, squash, or rewrite existing commits unless explicitly asked.
-- Each commit subject line must use the format `<emoji> <subject>`.
+- Each commit message must start with `<emoji> <subject>`.
 - Use a Unicode Gitmoji, not a shortcode.
-- Do not add a scope, colon, body, or trailing period.
+- In the subject line, do not add a scope, colon, or trailing period.
 - Base the subject only on the staged diff.
 - Do not infer intent from unstaged files, branch names, task titles, or unrelated context.
 - Prefer the smallest accurate claim.
@@ -44,79 +49,69 @@
 - Write in imperative mood.
 - Capitalize the first word unless syntax or style requires otherwise.
 - Keep the subject under 72 characters.
+- Add a body only when it meaningfully explains why, highlights follow-up work, or calls out a breaking change.
+- If you add a body, leave one blank line after the subject and keep the body concise.
 
 ## Gitmoji rules
 
-A gitmoji commit message is composed using the following pieces:
+Use one Gitmoji to communicate the primary intent of a commit or pull request title. Choose the emoji for the dominant change, not every kind of edit in the diff.
 
-- **intention**: The intention you want to express with the commit, using an emoji from the gitmoji list. In unicode format.
-- **message**: A brief explanation of the change.
+### Repo format
 
-### Format
+This repository uses:
 
 ```
-<intention> <message>
+<emoji> <subject>
 
 [optional body]
 ```
 
-### Reference
-
-Fetch all available gitmojis from: https://gitmoji.dev/api/gitmojis.
+- The subject line is required.
+- The body is optional.
+- This repository intentionally uses a space after the emoji instead of the scoped `emoji(scope):` style you may see in other Gitmoji examples.
+- The full Gitmoji catalog is available at: https://gitmoji.dev/api/gitmojis.
 
 ### Selecting the correct emoji
 
-1. **Identify the primary purpose** of the commit
-2. **Choose the most specific emoji** that matches the change
-3. **Use only one emoji** per commit for clarity
-4. **Prioritize by impact**: Breaking changes (💥) > Features (✨) > Fixes (🐛) > Refactoring (♻️)
+1. **Identify the primary purpose** of the staged diff for a commit, or of the full diff against `main` for a pull request title
+2. **Choose the most specific emoji** that matches that dominant change
+3. **Use only one emoji** for clarity
+4. **Prioritize by impact** when several fit: Breaking changes (💥) > Features (✨) > Fixes (🐛) > Refactoring (♻️)
+5. **Prefer purpose-specific emojis** over broad fallbacks when the diff is clearly dominated by one type of work
 
 ### Examples
 
 ```
-✨ Add user authentication system
-
-Implement JWT-based authentication with login and registration endpoints.
-Closes #123
+📝 Clarify pull request label rules
 ```
 
 ```
-🐛 Resolve null pointer exception in user service
-
-Added null check before accessing user properties to prevent crashes.
+🐛 Prevent crash when input data is empty
 ```
 
 ```
-📝 Update installation instructions
-
-Added step-by-step guide for setting up the development environment.
+♻️ Simplify plot configuration parsing
 ```
 
 ```
-⚡️ Optimize user query with indexing
+💥 Remove legacy export format
 
-Reduced query time from 500ms to 50ms by adding composite index.
+Clients must switch to the new export path before upgrading.
 ```
 
-```
-💥 Update API response format to REST specification
+### Best practices
 
-All API endpoints now return data in a standardized envelope format.
-Clients must update their response parsing logic.
-```
-
-### Best Practices
-
-1. **Be atomic**: One emoji, one purpose, one commit
-2. **Write clear subjects**: Keep under 60 characters, imperative mood
-3. **Use the body**: Explain "why" not "what" for complex changes
-4. **Reference issues**: Include issue numbers when applicable
-5. **Indicate breaking changes**: Use 💥.
+1. **Be atomic**: one emoji, one purpose, one commit
+2. **Write clear subjects**: keep them imperative and specific
+3. **Use the body for context**: explain why, risk, or follow-up work when needed
+4. **Reference issues when helpful**: include issue numbers when they add useful context
+5. **Use 💥 for breaking changes**: make the impact explicit in the body when applicable
 
 ## Pull request rules
 
 - Use `gh pr create`.
 - When creating a PR, add exactly one release label with `gh pr create --label <label>`.
+- Choose the release label from the overall diff against `main`, not from the most recent commit alone.
 - Use the release label that matches the dominant change:
   - `bug` for bug fixes
   - `enhancement` for user-facing features or improvements
@@ -128,13 +123,14 @@ Clients must update their response parsing logic.
 - Push the branch before creating the pull request.
 - PR title must use the format `<emoji> <descriptive subject>`.
 - Use a Unicode Gitmoji, not a shortcode.
-- Do not add a scope, colon, body, or trailing period.
+- In the title line, do not add a scope, colon, or trailing period.
 - Base the PR title on the overall diff against `main`, not only the staged diff.
 - Prefer the smallest accurate claim and make the PR title more specific than the commit subject by naming the dominant change and affected area or behavior in a single phrase.
 - Write in imperative mood.
 - Capitalize the first word unless syntax or style requires otherwise.
 - Keep the title under 72 characters.
-- Use the same allowed Gitmoji choices and tie-break rules as commit subjects.
+- Use the same Gitmoji selection and tie-break rules as commit subjects.
+- Use the same `<emoji> <subject>` format as commit subjects.
 - PR body must include:
   - what changed
   - how it was tested

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,6 @@
 - Prefer a single commit for a small, self-contained change.
 - For larger work, use multiple logical commits rather than one large commit.
 - Do not amend, squash, or rewrite existing commits unless explicitly asked.
-
-## Commit subject format
-
 - Each commit subject line must use the format `<emoji> <subject>`.
 - Use a Unicode Gitmoji, not a shortcode.
 - Do not add a scope, colon, body, or trailing period.
@@ -48,33 +45,73 @@
 - Capitalize the first word unless syntax or style requires otherwise.
 - Keep the subject under 72 characters.
 
-## Allowed Gitmoji choices
+## Gitmoji rules
 
-- ✨ feature
-- 🐛 bug fix
-- ♻️ refactor
-- 📝 docs or text
-- ✅ tests
-- 🔧 config or tooling
-- ⬆️ upgrade dependencies
-- ⬇️ downgrade dependencies
-- ➕ add dependency
-- ➖ remove dependency
-- 🔥 remove code or files
-- 🚚 move or rename
-- 💄 UI or style
-- 🚨 lint or warnings
-- ⚡️ performance
-- 👷 CI or build
-- 🔒️ security
+A gitmoji commit message is composed using the following pieces:
 
-## Gitmoji tie-break rules
+- **intention**: The intention you want to express with the commit, using an emoji from the gitmoji list. In unicode format.
+- **message**: A brief explanation of the change.
 
-- Choose 🐛 or ✨ over ♻️ when the main intent is a fix or feature.
-- Use dependency emojis only for dependency-only diffs.
-- Use 🔧 for config-only or tooling-only diffs.
-- Use ✅ only when the change is primarily test-related.
-- Use 📝 only when the change is primarily documentation or text-related.
+### Format
+
+```
+<intention> <message>
+
+[optional body]
+```
+
+### Reference
+
+Fetch all available gitmojis from: https://gitmoji.dev/api/gitmojis.
+
+### Selecting the correct emoji
+
+1. **Identify the primary purpose** of the commit
+2. **Choose the most specific emoji** that matches the change
+3. **Use only one emoji** per commit for clarity
+4. **Prioritize by impact**: Breaking changes (💥) > Features (✨) > Fixes (🐛) > Refactoring (♻️)
+
+### Examples
+
+```
+✨ Add user authentication system
+
+Implement JWT-based authentication with login and registration endpoints.
+Closes #123
+```
+
+```
+🐛 Resolve null pointer exception in user service
+
+Added null check before accessing user properties to prevent crashes.
+```
+
+```
+📝 Update installation instructions
+
+Added step-by-step guide for setting up the development environment.
+```
+
+```
+⚡️ Optimize user query with indexing
+
+Reduced query time from 500ms to 50ms by adding composite index.
+```
+
+```
+💥 Update API response format to REST specification
+
+All API endpoints now return data in a standardized envelope format.
+Clients must update their response parsing logic.
+```
+
+### Best Practices
+
+1. **Be atomic**: One emoji, one purpose, one commit
+2. **Write clear subjects**: Keep under 60 characters, imperative mood
+3. **Use the body**: Explain "why" not "what" for complex changes
+4. **Reference issues**: Include issue numbers when applicable
+5. **Indicate breaking changes**: Use 💥.
 
 ## Pull request rules
 


### PR DESCRIPTION
## What changed
- Replaced the short allowed-emoji and tie-break sections in `AGENTS.md` with fuller Gitmoji guidance.
- Added commit message format details, emoji selection rules, examples, and best practices.
- Linked contributors to the Gitmoji API reference for the complete emoji list.

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- This is a documentation-only change, so there is no runtime risk.
- If the upstream Gitmoji reference changes, the examples or guidance may need a future refresh.