### PR TITLE
💥 Standardize legend font sizing on legend_fontsize

### DIFF
--- a/examples/figure_setup.py
+++ b/examples/figure_setup.py
@@ -200,7 +200,7 @@ ax.set_title("Manual Setup")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 cns.setup_matplotlib(
     title_fontsize=10,
-    fontsize_legend=8,
+    legend_fontsize=8,
     axes_linewidth=0.8,
 )
 fig, ax = plt.subplots(figsize=(2, 1.5))

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -70,7 +70,7 @@ cns.settings.palette_qual = "Set2"
 cns.settings.palette_seq = "parula"
 cns.settings.title_fontsize = 10
 cns.settings.title_fontweight = "normal"
-cns.settings.fontsize_legend = 9
+cns.settings.legend_fontsize = 9
 cns.settings.axes_linewidth = 1.0
 
 cns.figure()

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     import numpy as np
@@ -573,7 +573,9 @@ def prerank(
     rnk["Gene"] = rnk["Gene"].str.strip().str.upper()
     gsea_res = gp.prerank(
         rnk=rnk,
-        gene_sets=gene_sets,  # type: ignore[arg-type]  # gseapy accepts dict[str, list[str]] at runtime
+        gene_sets=cast(
+            Any, gene_sets
+        ),  # gseapy accepts dict[str, list[str]] at runtime
         min_size=15,
         max_size=1000,
         permutation_num=permutation_num,

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -203,11 +203,6 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
         lambda value: _validate_fontweight("title_fontweight", value),
         "Font weight for titles.",
     ),
-    "fontsize_legend": _spec(
-        7,
-        lambda value: _validate_number("fontsize_legend", value, positive=True),
-        "Font size for tick labels and legend-adjacent helper text.",
-    ),
     "axes_linewidth": _spec(
         0.5,
         lambda value: _validate_number("axes_linewidth", value, positive=True),
@@ -319,9 +314,9 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
         "Default y-axis margin.",
     ),
     "legend_fontsize": _spec(
-        None,
+        7,
         lambda value: _validate_optional_number("legend_fontsize", value),
-        "Default legend text size. Use None to inherit title_fontsize.",
+        "Default font size for legend text, tick labels, colorbar ticks, and legend-adjacent helper text. Use None to inherit title_fontsize.",
     ),
     "legend_title_fontsize": _spec(
         None,

--- a/src/cnsplots/_setup.py
+++ b/src/cnsplots/_setup.py
@@ -15,6 +15,7 @@ import cnsplots as cns
 
 _HELVETICA_BOLD_REGISTERED = False
 ColorCycle = Union[str, list[str]]
+_UNSET = object()
 
 
 def _ensure_helvetica_bold() -> None:
@@ -88,17 +89,23 @@ def _font_rcparams() -> dict[str, object]:
 
 def _resolve_legend_fontsizes(
     title_fontsize: int | float,
+    legend_fontsize: int | float | None | object = _UNSET,
 ) -> tuple[int | float, int | float]:
     """Resolve legend font sizes while preserving title-font inheritance."""
-    legend_fontsize = cns.settings.legend_fontsize
-    if legend_fontsize is None:
-        legend_fontsize = title_fontsize
+    if legend_fontsize is _UNSET:
+        resolved_legend_fontsize = cns.settings.legend_fontsize
+    elif legend_fontsize is None or isinstance(legend_fontsize, (int, float)):
+        resolved_legend_fontsize = legend_fontsize
+    else:
+        raise TypeError("legend_fontsize must be a number or None")
+    if resolved_legend_fontsize is None:
+        resolved_legend_fontsize = title_fontsize
 
     legend_title_fontsize = cns.settings.legend_title_fontsize
     if legend_title_fontsize is None:
         legend_title_fontsize = title_fontsize
 
-    return legend_fontsize, legend_title_fontsize
+    return resolved_legend_fontsize, legend_title_fontsize
 
 
 def setup_matplotlib(
@@ -106,7 +113,7 @@ def setup_matplotlib(
     color_map: str | None = None,
     title_fontsize: int | float | None = None,
     title_fontweight: str | int | None = None,
-    fontsize_legend: int | float | None = None,
+    legend_fontsize: int | float | None | object = _UNSET,
     axes_linewidth: float | None = None,
 ) -> None:
     """
@@ -134,9 +141,9 @@ def setup_matplotlib(
     title_fontweight : str | int, default: None
         Font weight for titles.
         If None, uses cns.settings.title_fontweight.
-    fontsize_legend : int, default: None
-        Font size for tick labels and legend text.
-        If None, uses cns.settings.fontsize_legend.
+    legend_fontsize : int | None, default: cns.settings.legend_fontsize
+        Font size for legend text, tick labels, and colorbar ticks.
+        Use None to inherit title_fontsize.
     axes_linewidth : float, default: None
         Line width for axis spines.
         If None, uses cns.settings.axes_linewidth.
@@ -159,7 +166,7 @@ def setup_matplotlib(
     **Fonts:**
     - Family: Sans-serif (Helvetica)
     - Math text: Custom fontset
-    - Sizes: title=8pt, legend=7pt (by default)
+    - Sizes: title=8pt, legend/ticks=7pt (by default)
     - Title weight: bold (by default)
 
     **Axes:**
@@ -202,7 +209,7 @@ def setup_matplotlib(
     ...     color_map="parula",
     ...     title_fontsize=10,
     ...     title_fontweight="normal",
-    ...     fontsize_legend=8,
+    ...     legend_fontsize=8,
     ... )
     """
     # Use settings values if parameters are not provided
@@ -215,13 +222,13 @@ def setup_matplotlib(
     if title_fontweight is None:
         title_fontweight = cns.settings.title_fontweight
     title_fontweight = _validate_title_fontweight(title_fontweight)
-    if fontsize_legend is None:
-        fontsize_legend = cns.settings.fontsize_legend
     if axes_linewidth is None:
         axes_linewidth = cns.settings.axes_linewidth
 
     _ensure_helvetica_bold()
-    legend_fontsize, legend_title_fontsize = _resolve_legend_fontsizes(title_fontsize)
+    resolved_legend_fontsize, legend_title_fontsize = _resolve_legend_fontsizes(
+        title_fontsize, legend_fontsize
+    )
 
     def config() -> dict[str, object]:
         """
@@ -261,21 +268,21 @@ def setup_matplotlib(
             "axes.ymargin": cns.settings.axes_ymargin,
             "axes.prop_cycle": mpl.cycler(color=cns.palettes(color_cycle)),
             "image.cmap": color_map,
-            "legend.fontsize": legend_fontsize,
+            "legend.fontsize": resolved_legend_fontsize,
             "legend.title_fontsize": legend_title_fontsize,
             "legend.frameon": cns.settings.legend_frameon,
             "legend.markerscale": cns.settings.legend_markerscale,
             "legend.handlelength": cns.settings.legend_handlelength,
             "legend.handleheight": cns.settings.legend_handleheight,
             "legend.handletextpad": cns.settings.legend_handletextpad,
-            "xtick.labelsize": fontsize_legend,
+            "xtick.labelsize": resolved_legend_fontsize,
             "xtick.bottom": cns.settings.xtick_bottom,
             "xtick.color": cns.settings.xtick_color,
             "xtick.major.size": cns.settings.xtick_major_size,
             "xtick.major.width": cns.settings.xtick_major_width,
             "xtick.major.pad": cns.settings.xtick_major_pad,
             "xtick.alignment": cns.settings.xtick_alignment,
-            "ytick.labelsize": fontsize_legend,
+            "ytick.labelsize": resolved_legend_fontsize,
             "ytick.left": cns.settings.ytick_left,
             "ytick.color": cns.settings.ytick_color,
             "ytick.major.size": cns.settings.ytick_major_size,
@@ -388,7 +395,7 @@ def setup_ax(
     ax: Axes,
     title_fontsize: int | float | None = None,
     title_fontweight: str | int | None = None,
-    fontsize_legend: int | float | None = None,
+    legend_fontsize: int | float | None | object = _UNSET,
     axes_linewidth: float | None = None,
     colorbar_label: str | None = None,
 ) -> None:
@@ -408,9 +415,9 @@ def setup_ax(
     title_fontweight : str | int, default: None
         Font weight for the title.
         If None, uses cns.settings.title_fontweight.
-    fontsize_legend : int, default: None
-        Font size for tick labels and colorbar labels.
-        If None, uses cns.settings.fontsize_legend.
+    legend_fontsize : int | None, default: cns.settings.legend_fontsize
+        Font size for tick labels and colorbar ticks.
+        Use None to inherit title_fontsize.
     axes_linewidth : float, default: None
         Line width for axis spines.
         If None, uses cns.settings.axes_linewidth.
@@ -434,7 +441,7 @@ def setup_ax(
 
     **Font settings:**
     - Family: Sans-serif (Helvetica)
-    - Sizes: title=8pt, tick labels=7pt (by default)
+    - Sizes: title=8pt, tick/colorbar labels=7pt (by default)
     - Title weight: bold (by default)
     - Color: Black
 
@@ -468,7 +475,7 @@ def setup_ax(
 
     >>> # Format with custom sizes and title weight
     >>> cns.setup_ax(
-    ...     ax, title_fontsize=10, title_fontweight="normal", fontsize_legend=9
+    ...     ax, title_fontsize=10, title_fontweight="normal", legend_fontsize=9
     ... )
 
     >>> # Format axes from external library
@@ -482,14 +489,15 @@ def setup_ax(
     if title_fontweight is None:
         title_fontweight = cns.settings.title_fontweight
     title_fontweight = _validate_title_fontweight(title_fontweight)
-    if fontsize_legend is None:
-        fontsize_legend = cns.settings.fontsize_legend
     if axes_linewidth is None:
         axes_linewidth = cns.settings.axes_linewidth
     if colorbar_label is None:
         colorbar_label = cns.settings.setup_ax_colorbar_label
 
     _ensure_helvetica_bold()
+    resolved_legend_fontsize, _ = _resolve_legend_fontsizes(
+        title_fontsize, legend_fontsize
+    )
 
     mpl.rcParams.update(_font_rcparams())
     title_props = ax.title.get_fontproperties().copy()
@@ -520,7 +528,7 @@ def setup_ax(
         ax.spines[spine_name].set_color(cns.settings.axes_edgecolor)
     ax.tick_params(
         axis="x",
-        labelsize=fontsize_legend,
+        labelsize=resolved_legend_fontsize,
         colors=cns.settings.xtick_color,
         length=cns.settings.xtick_major_size,
         width=cns.settings.xtick_major_width,
@@ -530,7 +538,7 @@ def setup_ax(
     )
     ax.tick_params(
         axis="y",
-        labelsize=fontsize_legend,
+        labelsize=resolved_legend_fontsize,
         colors=cns.settings.ytick_color,
         length=cns.settings.ytick_major_size,
         width=cns.settings.ytick_major_width,
@@ -546,7 +554,10 @@ def setup_ax(
     ax.margins(x=cns.settings.axes_xmargin, y=cns.settings.axes_ymargin)
     cbar = ax.collections[0].colorbar if ax.collections else None
     if cbar is not None:
-        cbar.ax.tick_params(labelsize=fontsize_legend, colors=cns.settings.ytick_color)
+        cbar.ax.tick_params(
+            labelsize=resolved_legend_fontsize,
+            colors=cns.settings.ytick_color,
+        )
         if colorbar_label:
             cbar.set_label(
                 colorbar_label,

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -415,8 +415,9 @@ def kdeplot(data: pd.DataFrame, x: str, add_mode: bool = True, **kwargs: Any) ->
     legend = ax.get_legend()
     if legend is not None:
         for handle in legend.legend_handles:
-            if hasattr(handle, "set_linewidth"):
-                handle.set_linewidth(1.7)  # type: ignore[call-non-callable]
+            set_linewidth = getattr(handle, "set_linewidth", None)
+            if callable(set_linewidth):
+                set_linewidth(1.7)
 
     return ax
 

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -35,15 +35,23 @@ from cnsplots._validation import (
 )
 
 
+def _legend_fontsize() -> int | float:
+    legend_fontsize = cns.settings.legend_fontsize
+    if legend_fontsize is None:
+        return cns.settings.title_fontsize
+    return legend_fontsize
+
+
 def _style_plotter_colorbars(cbars: list[Any]) -> None:
     font_family = mpl.rcParams.get("font.family")
+    legend_fontsize = _legend_fontsize()
     for cbar in cbars:
         if not isinstance(cbar, mpl.colorbar.Colorbar):
             continue
         cbar.outline.set_linewidth(0.3)
         cbar.ax.tick_params(
             size=0,
-            labelsize=cns.settings.fontsize_legend,
+            labelsize=legend_fontsize,
             colors=cns.settings.ytick_color,
             pad=cns.settings.ytick_major_pad,
         )

--- a/src/cnsplots/plots/_regression.py
+++ b/src/cnsplots/plots/_regression.py
@@ -384,7 +384,8 @@ def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str) -> Axes:
         ncol=2,
     )
     for handle in lgd.legend_handles:
-        if hasattr(handle, "set_sizes"):
-            handle.set_sizes([12])  # type: ignore[union-attr]
+        set_sizes = getattr(handle, "set_sizes", None)
+        if callable(set_sizes):
+            set_sizes([12])
 
     return ax

--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -18,6 +18,13 @@ import seaborn as sns
 import cnsplots as cns
 
 
+def _legend_fontsize() -> int | float:
+    legend_fontsize = cns.settings.legend_fontsize
+    if legend_fontsize is None:
+        return cns.settings.title_fontsize
+    return legend_fontsize
+
+
 def _normalize_text_position(text: Any) -> None:
     """Coerce singleton array coordinates from upsetplot into scalar positions."""
 
@@ -150,14 +157,15 @@ def upsetplot(
     axes["shading"].tick_params(axis="y", which="both", length=0, left=False)
     cns.setup_ax(axes["intersections"])
     axes["matrix"].tick_params(axis="both", which="both", length=0)
+    legend_fontsize = _legend_fontsize()
     for txt in axes["intersections"].texts:
         _normalize_text_position(txt)
-        txt.set_size(cns.settings.fontsize_legend)
+        txt.set_size(legend_fontsize)
     if ax_tot is not None:
         cns.setup_ax(ax_tot)
         for txt in ax_tot.texts:
             _normalize_text_position(txt)
-            txt.set_size(cns.settings.fontsize_legend)
+            txt.set_size(legend_fontsize)
         pos_mat = ax_tot.get_position()
         dx = 0.03
         new_pos = [pos_mat.x0 + dx, pos_mat.y0, pos_mat.width, pos_mat.height]
@@ -219,18 +227,20 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
     import matplotlib_venn as venn
 
     lists = [s if isinstance(s, AbstractSet) else set(s) for s in lists]
-    func: Any
     if len(lists) == 2:
         areas = ["10", "01", "11"]
-        func = venn.venn2
         names = ["A", "B"]
-        colors = sns.color_palette(n_colors=2)
+        colors = tuple(sns.color_palette(n_colors=2))
+        subsets = (lists[0], lists[1])
+        label_tuple = (labels[0], labels[1])
+        ax = venn.venn2(subsets, label_tuple, set_colors=colors, alpha=0.8)
     else:
         areas = ["100", "010", "001", "110", "101", "011", "111"]
-        func = venn.venn3
         names = ["A", "B", "C"]
-        colors = sns.color_palette(n_colors=3)
-    ax = func(lists, tuple(labels), set_colors=colors, alpha=0.8)  # type: ignore[arg-type]
+        colors = tuple(sns.color_palette(n_colors=3))
+        subsets = (lists[0], lists[1], lists[2])
+        label_tuple = (labels[0], labels[1], labels[2])
+        ax = venn.venn3(subsets, label_tuple, set_colors=colors, alpha=0.8)
     for area in areas:
         try:
             ax.get_label_by_id(area).set_fontsize(6)

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -505,7 +505,8 @@ def rocplot(
     legend = ax.get_legend()
     if legend is not None:
         for handle in legend.legend_handles:
-            if hasattr(handle, "set_linewidth"):
-                handle.set_linewidth(1.7)  # type: ignore[call-non-callable]
+            set_linewidth = getattr(handle, "set_linewidth", None)
+            if callable(set_linewidth):
+                set_linewidth(1.7)
 
     return ax

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,7 +135,6 @@ def test_settings_behavior() -> None:
     settings.palette_seq = "parula"
     settings.title_fontsize = 10
     settings.title_fontweight = "normal"
-    settings.fontsize_legend = 9
     settings.axes_linewidth = 1.0
     settings.verbosity = 0
     settings.mathtext_fontset = "stix"
@@ -284,11 +283,18 @@ def test_settings_behavior() -> None:
         with settings.context(linewidth_axes=1.0):
             pass
     with pytest.raises(AttributeError, match="not a valid setting"):
+        settings.fontsize_legend = 9
+    with pytest.raises(AttributeError, match="not a valid setting"):
+        with settings.context(fontsize_legend=9):
+            pass
+    with pytest.raises(AttributeError, match="not a valid setting"):
         _ = settings.fontsize_title
     with pytest.raises(AttributeError, match="not a valid setting"):
         _ = settings.fontweight_title
     with pytest.raises(AttributeError, match="not a valid setting"):
         _ = settings.linewidth_axes
+    with pytest.raises(AttributeError, match="not a valid setting"):
+        _ = settings.fontsize_legend
     with pytest.raises(AttributeError, match="not a valid setting"):
         setattr(settings, "fontsize_title", 10)
     with pytest.raises(AttributeError, match="not a valid setting"):
@@ -311,9 +317,9 @@ def test_settings_behavior() -> None:
     with pytest.raises(TypeError, match="title_fontweight must be a string or integer"):
         settings.title_fontweight = 1.5
     with pytest.raises(TypeError):
-        settings.fontsize_legend = "1"
+        settings.legend_fontsize = "1"
     with pytest.raises(ValueError):
-        settings.fontsize_legend = 0
+        settings.legend_fontsize = 0
     with pytest.raises(TypeError):
         settings.axes_linewidth = "1"
     with pytest.raises(ValueError):
@@ -328,7 +334,7 @@ def test_settings_behavior() -> None:
     assert settings.title_fontweight == "bold"
     assert settings.savefig_bbox == "tight"
     assert settings.savefig_transparent is True
-    assert settings.legend_fontsize is None
+    assert settings.legend_fontsize == 7
     assert settings.scanpy_figsize == (2.5, 2.5)
     assert settings.panel_pad_left == 0
     assert settings.panel_pad_top == 0
@@ -365,9 +371,9 @@ def test_settings_validation_errors() -> None:
     with pytest.raises(TypeError, match="title_fontweight must be a string or integer"):
         settings.title_fontweight = 1.5
     with pytest.raises(TypeError):
-        settings.fontsize_legend = "1"
+        settings.legend_fontsize = "1"
     with pytest.raises(ValueError):
-        settings.fontsize_legend = 0
+        settings.legend_fontsize = 0
     with pytest.raises(TypeError):
         settings.axes_linewidth = "1"
     with pytest.raises(ValueError):
@@ -483,6 +489,8 @@ def test_setup_functions(monkeypatch: pytest.MonkeyPatch) -> None:
         _setup.setup_matplotlib()
         assert mpl.rcParams["legend.fontsize"] == 11
         assert mpl.rcParams["legend.title_fontsize"] == 12
+        assert mpl.rcParams["xtick.labelsize"] == 11
+        assert mpl.rcParams["ytick.labelsize"] == 11
         assert mpl.rcParams["axes.titlelocation"] == "left"
         assert mpl.rcParams["axes.grid"] is True
         assert mpl.rcParams["axes.spines.top"] is True
@@ -504,30 +512,42 @@ def test_setup_functions(monkeypatch: pytest.MonkeyPatch) -> None:
         color_map="parula",
         title_fontsize=9,
         title_fontweight="normal",
-        fontsize_legend=8,
+        legend_fontsize=8,
         axes_linewidth=1.2,
     )
     assert mpl.rcParams["axes.labelsize"] == 9
     assert mpl.rcParams["axes.titleweight"] == "normal"
     assert mpl.rcParams["image.cmap"] == "parula"
+    assert mpl.rcParams["legend.fontsize"] == 8
+    assert mpl.rcParams["xtick.labelsize"] == 8
+    assert mpl.rcParams["ytick.labelsize"] == 8
     with cns.settings.context(
         title_fontsize=13,
-        legend_fontsize=None,
+        legend_fontsize=11,
         legend_title_fontsize=None,
     ):
-        _setup.setup_matplotlib(title_fontsize=14)
+        _setup.setup_matplotlib(title_fontsize=14, legend_fontsize=None)
         assert mpl.rcParams["legend.fontsize"] == 14
         assert mpl.rcParams["legend.title_fontsize"] == 14
+        assert mpl.rcParams["xtick.labelsize"] == 14
+        assert mpl.rcParams["ytick.labelsize"] == 14
+    legacy_setup_matplotlib = cast(Any, _setup.setup_matplotlib)
     with pytest.raises(TypeError, match="title_fontweight must be a string or integer"):
-        _setup.setup_matplotlib(title_fontweight=1.5)  # type: ignore[arg-type]
+        legacy_setup_matplotlib(title_fontweight=1.5)
+    with pytest.raises(TypeError, match="legend_fontsize must be a number or None"):
+        legacy_setup_matplotlib(legend_fontsize="big")
+    with pytest.raises(
+        TypeError, match="unexpected keyword argument 'fontsize_legend'"
+    ):
+        legacy_setup_matplotlib(fontsize_legend=8)
     with pytest.raises(TypeError, match="unexpected keyword argument 'fontsize_title'"):
-        _setup.setup_matplotlib(fontsize_title=9)  # type: ignore[call-arg]
+        legacy_setup_matplotlib(fontsize_title=9)
     with pytest.raises(
         TypeError, match="unexpected keyword argument 'fontweight_title'"
     ):
-        _setup.setup_matplotlib(fontweight_title="normal")  # type: ignore[call-arg]
+        legacy_setup_matplotlib(fontweight_title="normal")
     with pytest.raises(TypeError, match="unexpected keyword argument 'linewidth_axes'"):
-        _setup.setup_matplotlib(linewidth_axes=1.2)  # type: ignore[call-arg]
+        legacy_setup_matplotlib(linewidth_axes=1.2)
 
     fig, ax = plt.subplots()
     heat = ax.pcolormesh(np.array([[1, 2], [3, 4]]))
@@ -566,7 +586,7 @@ def test_setup_functions(monkeypatch: pytest.MonkeyPatch) -> None:
             ax,
             title_fontsize=10,
             title_fontweight="normal",
-            fontsize_legend=9,
+            legend_fontsize=9,
             axes_linewidth=1.1,
         )
         fig.canvas.draw()
@@ -577,20 +597,30 @@ def test_setup_functions(monkeypatch: pytest.MonkeyPatch) -> None:
         assert ax.spines["top"].get_visible() is True
         assert ax.spines["right"].get_visible() is True
         assert ax.spines["bottom"].get_edgecolor() == mpl.colors.to_rgba("green")
+        assert {tick.get_fontsize() for tick in ax.get_xticklabels()} == {9}
+        assert {tick.get_fontsize() for tick in ax.get_yticklabels()} == {9}
         assert ax.get_xticklabels()[0].get_ha() == "right"
         assert ax.get_yticklabels()[0].get_va() == "top"
         assert heat.colorbar.ax.get_ylabel() == "Configured"
         assert heat.colorbar.ax.yaxis.label.get_color() == "purple"
+        assert {tick.get_fontsize() for tick in heat.colorbar.ax.get_yticklabels()} == {
+            9
+        }
+    legacy_setup_ax = cast(Any, _setup.setup_ax)
     with pytest.raises(TypeError, match="title_fontweight must be a string or integer"):
-        _setup.setup_ax(ax, title_fontweight=1.5)  # type: ignore[arg-type]
+        legacy_setup_ax(ax, title_fontweight=1.5)
+    with pytest.raises(
+        TypeError, match="unexpected keyword argument 'fontsize_legend'"
+    ):
+        legacy_setup_ax(ax, fontsize_legend=9)
     with pytest.raises(TypeError, match="unexpected keyword argument 'fontsize_title'"):
-        _setup.setup_ax(ax, fontsize_title=10)  # type: ignore[call-arg]
+        legacy_setup_ax(ax, fontsize_title=10)
     with pytest.raises(
         TypeError, match="unexpected keyword argument 'fontweight_title'"
     ):
-        _setup.setup_ax(ax, fontweight_title="normal")  # type: ignore[call-arg]
+        legacy_setup_ax(ax, fontweight_title="normal")
     with pytest.raises(TypeError, match="unexpected keyword argument 'linewidth_axes'"):
-        _setup.setup_ax(ax, linewidth_axes=1.1)  # type: ignore[call-arg]
+        legacy_setup_ax(ax, linewidth_axes=1.1)
 
     fig2, ax2 = plt.subplots()
     ax2.plot([0, 1], [0, 1])
@@ -1608,13 +1638,14 @@ def test_multipanel_update_left_layout_metrics_skips_missing_entries(
 
 def test_multipanel_panel_rejects_margin_tuple_argument() -> None:
     mp = cns.multipanel(max_width=150)
+    legacy_panel = cast(Any, mp.panel)
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'margin'"):
-        mp.panel("A", width=60, height=40, margin=(0, 0, 10, 10))  # type: ignore[call-arg]
+        legacy_panel("A", width=60, height=40, margin=(0, 0, 10, 10))
     with pytest.raises(TypeError, match="unexpected keyword argument 'label_left'"):
-        mp.panel("A", width=60, height=40, label_left=10)  # type: ignore[call-arg]
+        legacy_panel("A", width=60, height=40, label_left=10)
     with pytest.raises(TypeError, match="unexpected keyword argument 'label_top'"):
-        mp.panel("A", width=60, height=40, label_top=12)  # type: ignore[call-arg]
+        legacy_panel("A", width=60, height=40, label_top=12)
 
 
 def test_multipanel_linked_helper_capture_guard_without_figure() -> None:
@@ -1816,12 +1847,13 @@ def test_multipanel_title_invalid_loc_raises() -> None:
 
 
 def test_multipanel_title_invalid_fontweight_raises() -> None:
+    legacy_multipanel = cast(Any, cns.multipanel)
     with pytest.raises(TypeError, match="title_fontweight must be a string or integer"):
-        cns.multipanel(title="Overview", title_fontweight=1.5)  # type: ignore[arg-type]
+        legacy_multipanel(title="Overview", title_fontweight=1.5)
     with pytest.raises(
         TypeError, match="unexpected keyword argument 'fontweight_title'"
     ):
-        cns.multipanel(title="Overview", fontweight_title="normal")  # type: ignore[call-arg]
+        legacy_multipanel(title="Overview", fontweight_title="normal")
 
 
 def test_multipanel_below_aligns_to_parent_column() -> None:

--- a/tests/test_methods_and_helpers.py
+++ b/tests/test_methods_and_helpers.py
@@ -151,12 +151,13 @@ def test_phylo_helper_functions(phylo_adata: ad.AnnData) -> None:
     assert out_ax is ax
     assert set(cmap) == {"A", "B"}
 
+    legacy_heatmap = cast(Any, _phylo._heatmap)
     with pytest.raises(TypeError, match="Unable to work with data"):
-        _phylo._heatmap("bad")  # type: ignore[arg-type]
+        legacy_heatmap("bad")
     with pytest.raises(TypeError, match="Unable to interpret colormap"):
-        _phylo._heatmap(pd.DataFrame({"group": ["A", "B"]}), cmap="bad")  # type: ignore[arg-type]
+        legacy_heatmap(pd.DataFrame({"group": ["A", "B"]}), cmap="bad")
     with pytest.raises(TypeError, match="leg_ax must be matplotlib axes"):
-        _phylo._heatmap(pd.DataFrame({"group": ["A", "B"]}), leg_ax="bad")  # type: ignore[arg-type]
+        legacy_heatmap(pd.DataFrame({"group": ["A", "B"]}), leg_ax="bad")
 
     assert _phylo._is_categorical(pd.DataFrame({"a": [1, 2]})) == [False]
     with pytest.raises(TypeError):
@@ -178,7 +179,7 @@ def test_phylo_helper_functions(phylo_adata: ad.AnnData) -> None:
     with pytest.raises(ValueError, match="at least as many colors"):
         _phylo._gen_colors(["red"], 2)
     with pytest.raises(TypeError, match="Unable to generate colors"):
-        _phylo._gen_colors(1, 2)  # type: ignore[arg-type]
+        cast(Any, _phylo._gen_colors)(1, 2)
 
 
 def test_cluster_map_plotter_new_collect_legends() -> None:

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -306,7 +306,7 @@ def test_heatmap_and_dotplot(
             size="pct_expr",
         )
 
-    with cns.settings.context(fontsize_legend=13, ytick_color="#cc2233"):
+    with cns.settings.context(legend_fontsize=13, ytick_color="#cc2233"):
         cns.figure(180, 180)
         cmp3 = cns.heatmapplot(
             heatmap_adata,
@@ -339,6 +339,20 @@ def test_heatmap_and_dotplot(
         assert {tick.get_color() for tick in dotplot_cbar.ax.get_yticklabels()} == {
             "#cc2233"
         }
+
+    with cns.settings.context(legend_fontsize=None, title_fontsize=12):
+        cns.figure(180, 180)
+        cmp4 = cns.heatmapplot(
+            heatmap_adata,
+            layer="scaled",
+            row_annotation=["cluster"],
+            col_annotation=["pathway"],
+            cmap="parula",
+        )
+        inherited_cbar = next(cbar for cbar in cmp4.cbars if isinstance(cbar, Colorbar))
+        assert {
+            tick.get_fontsize() for tick in inherited_cbar.ax.get_yticklabels()
+        } == {12}
 
 
 def test_dotplot_respects_multipanel_bounds(dotplot_df: pd.DataFrame) -> None:
@@ -779,7 +793,7 @@ def test_genomics_plots(
     assert {text.get_text() for text in ax4.texts} == {"GENE1", "GENE6"}
 
     with pytest.raises(TypeError, match="Parameter 'n_show' must be an integer"):
-        cns.volcanoplot(volcano_df, n_show=1.5)  # type: ignore[arg-type]
+        cast(Any, cns.volcanoplot)(volcano_df, n_show=1.5)
 
     with pytest.raises(ValueError, match="Parameter 'n_show' must be non-negative"):
         cns.volcanoplot(volcano_df, n_show=-1)
@@ -814,12 +828,14 @@ def test_genomics_plots(
 
 
 def test_sets_validation_errors(sets_fixture: dict[str, set[int]]) -> None:
+    legacy_upsetplot = cast(Any, cns.upsetplot)
+    legacy_vennplot = cast(Any, cns.vennplot)
     with pytest.raises(TypeError, match="must be a dictionary"):
-        cns.upsetplot([])  # type: ignore[arg-type]
+        legacy_upsetplot([])
     with pytest.raises(ValueError, match="cannot be empty"):
         cns.upsetplot({})
     with pytest.raises(TypeError, match="must be a list"):
-        cns.vennplot(tuple(sets_fixture.values()), labels=["A", "B"])  # type: ignore[arg-type]
+        legacy_vennplot(tuple(sets_fixture.values()), labels=["A", "B"])
     with pytest.raises(ValueError, match="must contain 2 or 3 sets"):
         cns.vennplot([set()], labels=["A"])
     with pytest.raises(ValueError, match="Length of 'labels'"):

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -321,7 +322,7 @@ def test_placeholderplot_renders_centered_placeholder() -> None:
 def test_placeholderplot_requires_string_description() -> None:
     cns.figure(120, 120)
     with pytest.raises(TypeError, match="must be a string"):
-        cns.placeholderplot(123)  # type: ignore[arg-type]
+        cast(Any, cns.placeholderplot)(123)
 
 
 def test_sets_and_specialized_plots(
@@ -343,6 +344,14 @@ def test_sets_and_specialized_plots(
     embedded_axes = cns.upsetplot(sets_fixture, fig=fig, min_subset_size=1)
     assert all(ax is None or ax.figure is fig for ax in embedded_axes.values())
     assert fig.patch.get_facecolor()[-1] == 0
+
+    with cns.settings.context(legend_fontsize=None, title_fontsize=12):
+        cns.figure(120, 120)
+        inherited_axes = cns.upsetplot(sets_fixture, min_subset_size=1)
+        assert inherited_axes["intersections"].texts
+        assert {
+            text.get_fontsize() for text in inherited_axes["intersections"].texts
+        } == {12}
 
     custom_fig = plt.figure()
     custom_fig.patch.set_facecolor("red")


### PR DESCRIPTION
## What changed
- remove the public `fontsize_legend` setting and setup kwargs in favor of `legend_fontsize`
- apply `legend_fontsize` consistently to legend text, tick labels, colorbar ticks, and helper text
- change the default `legend_fontsize` to `7` while preserving explicit `legend_fontsize=None` as an override to inherit `title_fontsize`
- update examples and regression tests, and fix the remaining `ty` issues that were blocking `make lint`

## How it was tested
- `make lint`
- `make test`

## Risks or follow-ups
- breaking change: callers still using `fontsize_legend` must switch to `legend_fontsize`
- no compatibility alias was added by design