### PR TITLE
✨ Add p-value formatting and font size settings

### DIFF
--- a/examples/boxplot.py
+++ b/examples/boxplot.py
@@ -93,14 +93,15 @@ for index in range(tips["day"].nunique()):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``pairs="all"`` to perform Mann-Whitney U tests between all groups.
 # The ``addcount=True`` parameter adds sample sizes below each box.
-cns.figure(150, 100)
-ax = cns.boxplot(
-    data=iris,
-    x="species",
-    y="sepal_width",
-    pairs="all",
-    addcount=True,
-)
+with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
+    cns.figure(150, 100)
+    ax = cns.boxplot(
+        data=iris,
+        x="species",
+        y="sepal_width",
+        pairs="all",
+        addcount=True,
+    )
 ax.set_title("All Pairwise Comparisons\nwith Sample Counts")
 
 
@@ -108,13 +109,14 @@ ax.set_title("All Pairwise Comparisons\nwith Sample Counts")
 # Boxplot with specific pair comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Test only specific pairs by providing a list of tuples.
-cns.figure(150, 100)
-ax = cns.boxplot(
-    data=iris,
-    x="species",
-    y="sepal_width",
-    pairs=[("setosa", "virginica"), ("versicolor", "virginica")],
-)
+with cns.settings.context(pvalue_format="full", pvalue_fontsize=8):
+    cns.figure(150, 100)
+    ax = cns.boxplot(
+        data=iris,
+        x="species",
+        y="sepal_width",
+        pairs=[("setosa", "virginica"), ("versicolor", "virginica")],
+    )
 ax.set_title("Selected Pair Comparisons")
 
 
@@ -123,14 +125,15 @@ ax.set_title("Selected Pair Comparisons")
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``hue`` parameter to create side-by-side boxes for subgroups.
 # Statistical testing works across hue groups as well.
-cns.figure(180, 100)
-ax = cns.boxplot(
-    data=tips,
-    x="day",
-    y="total_bill",
-    hue="sex",
-    pairs=[(("Thur", "Male"), ("Fri", "Male"))],
-)
+with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
+    cns.figure(180, 100)
+    ax = cns.boxplot(
+        data=tips,
+        x="day",
+        y="total_bill",
+        hue="sex",
+        pairs=[(("Thur", "Male"), ("Fri", "Male"))],
+    )
 cns.take_legend_out()
 ax.set_title("Grouped Boxplot with\nCross-Group Comparison")
 
@@ -140,14 +143,15 @@ ax.set_title("Grouped Boxplot with\nCross-Group Comparison")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Create horizontal boxplots by swapping x and y.
 # Use ``order`` to specify the display order of categories.
-cns.figure(100, 150)
-ax = cns.boxplot(
-    data=iris,
-    x="sepal_width",
-    y="species",
-    pairs="all",
-    order=["versicolor", "setosa", "virginica"],
-)
+with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
+    cns.figure(100, 150)
+    ax = cns.boxplot(
+        data=iris,
+        x="sepal_width",
+        y="species",
+        pairs="all",
+        order=["versicolor", "setosa", "virginica"],
+    )
 ax.set_title("Horizontal Boxplot")
 
 
@@ -230,16 +234,17 @@ plt.setp(ax.get_xticklabels(), ha="right", rotation_mode="anchor")
 # Boxplot with grouped hue and all comparisons within groups
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # When using hue, you can compare all subgroups within a category.
-cns.figure(120, 180)
-ax = cns.boxplot(
-    data=tips,
-    x="day",
-    y="total_bill",
-    hue="smoker",
-    pairs=[
-        (("Sat", "Yes"), ("Sat", "No")),
-        (("Sun", "Yes"), ("Sun", "No")),
-    ],
-)
+with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
+    cns.figure(120, 180)
+    ax = cns.boxplot(
+        data=tips,
+        x="day",
+        y="total_bill",
+        hue="smoker",
+        pairs=[
+            (("Sat", "Yes"), ("Sat", "No")),
+            (("Sun", "Yes"), ("Sun", "No")),
+        ],
+    )
 cns.take_legend_out()
 ax.set_title("Within-Group Comparisons")

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -55,6 +55,7 @@ _LEGEND_LOCS = (
     "upper center",
     "center",
 )
+_P_VALUE_FORMATS = ("star", "threshold", "full")
 
 
 @dataclass(frozen=True)
@@ -170,6 +171,18 @@ def _validate_numeric_tuple(
 
 def _validate_optional_number(name: str, value: Any) -> int | float | None:
     return _validate_number(name, value, positive=True, allow_none=True)
+
+
+def _validate_fontsize(name: str, value: Any) -> str | int | float:
+    if isinstance(value, str):
+        if value == "":
+            raise ValueError(f"{name} must not be empty")
+        return value
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a positive number or string")
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
 
 
 def _spec(default: Any, validator: Callable[[Any], Any], doc: str) -> _SettingSpec:
@@ -322,6 +335,16 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
         None,
         lambda value: _validate_optional_number("legend_title_fontsize", value),
         "Default legend title size. Use None to inherit title_fontsize.",
+    ),
+    "pvalue_format": _spec(
+        "star",
+        lambda value: _validate_string_choice("pvalue_format", value, _P_VALUE_FORMATS),
+        "Default format for p-value annotations. Use 'star', 'threshold', or 'full'.",
+    ),
+    "pvalue_fontsize": _spec(
+        "small",
+        lambda value: _validate_fontsize("pvalue_fontsize", value),
+        "Default font size for p-value annotations. Accepts a positive number or matplotlib named size string.",
     ),
     "legend_frameon": _spec(
         False,

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
 import logging
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -18,12 +18,12 @@ import matplotlib as mpl
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
-from matplotlib.backends.backend_agg import FigureCanvasAgg
 import num2tex
 import palettable
 import pandas as pd
 import scipy.stats as stats
 import seaborn as sns
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 from statannotations.Annotator import Annotator
 from statannotations.PValueFormat import PValueFormat
 from statannotations.utils import DEFAULT
@@ -562,23 +562,28 @@ def _addcount_helper(data, attr, ax):
     ax.set_xticklabels(new_xtick_labels)
 
 
-def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format="star"):
-    # format {star, full}
+def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=None):
+    resolved_format = cns.settings.pvalue_format if format is None else format
+    if resolved_format not in {"star", "threshold", "full"}:
+        raise ValueError("format must be one of: 'star', 'threshold', 'full'")
+
+    pvalue_fontsize = cns.settings.pvalue_fontsize
+
     class PValueFormatNew(PValueFormat):
         def __init__(self):
             super(PValueFormat, self).__init__()
             self._pvalue_format_string = "{:.3e}"
             self._simple_format_string = "{:.2f}"
             self._text_format = "star"
-            self.fontsize = "small"
+            self.fontsize = pvalue_fontsize
             self._default_pvalue_thresholds = True
             self._pvalue_thresholds = self._get_pvalue_thresholds(DEFAULT)
             self._correction_format = "{star} ({suffix})"
             self.show_test_name = True
+            self.p_capitalized = True
 
-        if format == "full":
-
-            def format_data(self, result):
+        def format_data(self, result):
+            if resolved_format == "full":
                 text = f"{result.test_short_name} " if self.show_test_name else ""
                 if result.pvalue > 0.05:
                     return "ns"
@@ -587,6 +592,22 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format="s
                 ).format(
                     text, num2tex.num2tex(result.pvalue), result.significance_suffix
                 )
+
+            if resolved_format == "threshold":
+                pvalue_threshold_labels = (
+                    (1e-4, "P < 0.0001"),
+                    (1e-3, "P < 0.001"),
+                    (1e-2, "P < 0.01"),
+                    (0.05, "P < 0.05"),
+                )
+                for threshold, label in pvalue_threshold_labels:
+                    if result.pvalue <= threshold:
+                        adjust = getattr(result, "adjust", None)
+                        return adjust(label) if callable(adjust) else label
+                adjust = getattr(result, "adjust", None)
+                return adjust("P > 0.05") if callable(adjust) else "P > 0.05"
+
+            return super().format_data(result)
 
     x_is_numeric = pd.api.types.is_numeric_dtype(data[plotting["x"]])
     if x_is_numeric:
@@ -630,7 +651,7 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format="s
     annotator._pvalue_format = PValueFormatNew()
     annotator.configure(
         test=test if contingency is None else None,
-        text_format=format,
+        text_format="full" if resolved_format == "full" else "star",
         loc="inside",
         line_width=0.5,
         line_offset=0,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -158,6 +158,8 @@ def test_settings_behavior() -> None:
     settings.axes_ymargin = 0.2
     settings.legend_fontsize = 11
     settings.legend_title_fontsize = 12
+    settings.pvalue_format = "threshold"
+    settings.pvalue_fontsize = 9
     settings.legend_frameon = True
     settings.legend_markerscale = 1.2
     settings.legend_handlelength = 1.3
@@ -209,6 +211,8 @@ def test_settings_behavior() -> None:
     assert "title_fontweight='normal'" in repr(settings)
     assert "figure_width=180" in repr(settings)
     assert "font_sans_serif=('Arial', 'DejaVu Sans')" in repr(settings)
+    assert "pvalue_format='threshold'" in repr(settings)
+    assert "pvalue_fontsize=9" in repr(settings)
     assert "panel_label_left" not in repr(settings)
     assert "panel_label_top" not in repr(settings)
     assert "panel_label_offset_x" not in repr(settings)
@@ -239,6 +243,8 @@ def test_settings_behavior() -> None:
         title_fontweight=600,
         palette_qual="Dark2",
         legend_fontsize=None,
+        pvalue_format="full",
+        pvalue_fontsize="large",
         scanpy_figsize=(5.0, 4.0),
         panel_margin_top=6,
         panel_margin_bottom=8,
@@ -249,6 +255,8 @@ def test_settings_behavior() -> None:
         assert ctx.title_fontweight == 600
         assert settings.palette_qual == "Dark2"
         assert ctx.legend_fontsize is None
+        assert ctx.pvalue_format == "full"
+        assert ctx.pvalue_fontsize == "large"
         assert ctx.scanpy_figsize == (5.0, 4.0)
         assert ctx.panel_margin_top == 6
         assert ctx.panel_margin_bottom == 8
@@ -258,6 +266,8 @@ def test_settings_behavior() -> None:
     assert settings.title_fontweight == "normal"
     assert settings.palette_qual == "Set2"
     assert settings.legend_fontsize == 11
+    assert settings.pvalue_format == "threshold"
+    assert settings.pvalue_fontsize == 9
     assert settings.scanpy_figsize == (3.0, 4.0)
     assert settings.panel_margin_top == 2
     assert settings.panel_margin_bottom == 4
@@ -320,6 +330,16 @@ def test_settings_behavior() -> None:
         settings.legend_fontsize = "1"
     with pytest.raises(ValueError):
         settings.legend_fontsize = 0
+    with pytest.raises(ValueError):
+        settings.pvalue_format = "simple"
+    with pytest.raises(TypeError):
+        settings.pvalue_fontsize = None
+    with pytest.raises(TypeError):
+        settings.pvalue_fontsize = []
+    with pytest.raises(ValueError):
+        settings.pvalue_fontsize = 0
+    with pytest.raises(ValueError):
+        settings.pvalue_fontsize = ""
     with pytest.raises(TypeError):
         settings.axes_linewidth = "1"
     with pytest.raises(ValueError):
@@ -335,6 +355,8 @@ def test_settings_behavior() -> None:
     assert settings.savefig_bbox == "tight"
     assert settings.savefig_transparent is True
     assert settings.legend_fontsize == 7
+    assert settings.pvalue_format == "star"
+    assert settings.pvalue_fontsize == "small"
     assert settings.scanpy_figsize == (2.5, 2.5)
     assert settings.panel_pad_left == 0
     assert settings.panel_pad_top == 0
@@ -374,6 +396,20 @@ def test_settings_validation_errors() -> None:
         settings.legend_fontsize = "1"
     with pytest.raises(ValueError):
         settings.legend_fontsize = 0
+    with pytest.raises(ValueError, match="pvalue_format must be one of"):
+        settings.pvalue_format = "simple"
+    with pytest.raises(
+        TypeError, match="pvalue_fontsize must be a positive number or string"
+    ):
+        settings.pvalue_fontsize = None
+    with pytest.raises(
+        TypeError, match="pvalue_fontsize must be a positive number or string"
+    ):
+        settings.pvalue_fontsize = []
+    with pytest.raises(ValueError, match="pvalue_fontsize must be positive"):
+        settings.pvalue_fontsize = 0
+    with pytest.raises(ValueError, match="pvalue_fontsize must not be empty"):
+        settings.pvalue_fontsize = ""
     with pytest.raises(TypeError):
         settings.axes_linewidth = "1"
     with pytest.raises(ValueError):
@@ -1035,9 +1071,14 @@ def test_utils_helpers_and_showcase_data(
     assert "(n=" in ax4.get_xticklabels()[0].get_text()
 
     class DummyResult:
-        pvalue = 0.01
         test_short_name = "T"
         significance_suffix = ""
+
+        def __init__(self, pvalue: float) -> None:
+            self.pvalue = pvalue
+
+        def adjust(self, text: str) -> str:
+            return text
 
     class DummyAnnotator:
         last: "DummyAnnotator | None" = None
@@ -1088,9 +1129,33 @@ def test_utils_helpers_and_showcase_data(
         format="full",
     )
     formatter = DummyAnnotator.last._pvalue_format
-    formatted = formatter.format_data(DummyResult())
+    formatted = formatter.format_data(DummyResult(0.01))
     assert formatted.startswith("$T P = ")
     assert r"\times 10^{-2}$" in formatted
+
+    with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=9):
+        _utils._p_value_helper(
+            "Mann-Whitney",
+            categorical_df,
+            ax5,
+            {"x": "group", "y": "value"},
+            "all",
+        )
+    formatter = DummyAnnotator.last._pvalue_format
+    assert formatter.fontsize == 9
+    assert formatter.format_data(DummyResult(0.2)) == "P > 0.05"
+    assert formatter.format_data(DummyResult(0.049)) == "P < 0.05"
+    assert formatter.format_data(DummyResult(0.009)) == "P < 0.01"
+    assert formatter.format_data(DummyResult(0.00008)) == "P < 0.0001"
+    with pytest.raises(ValueError, match="format must be one of"):
+        _utils._p_value_helper(
+            "Mann-Whitney",
+            categorical_df,
+            ax5,
+            {"x": "group", "y": "value"},
+            "all",
+            format="invalid",
+        )
 
     contingency = pd.DataFrame(
         [[3, 1], [1, 3]],


### PR DESCRIPTION
## What changed
- add `pvalue_format` and `pvalue_fontsize` settings to `cns.settings`
- update p-value annotation formatting to support `star`, `threshold`, and `full` output
- apply configurable p-value font sizing in statistical annotations
- extend tests and refresh boxplot examples to demonstrate the new settings

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- the change affects p-value annotation presentation only; broader user-facing docs may be worth expanding later if these settings should be highlighted outside the example script