### PR TITLE
🐛 Keep confusion plot counts readable across colormaps

### DIFF
--- a/examples/confusionplot.py
+++ b/examples/confusionplot.py
@@ -52,6 +52,7 @@ ax = cns.confusionplot(
     data=data2,
     x="truth",
     y="pred",
+    cmap="Reds",
     add_pvalue=True,
     pvalue_x_pad=0.35,
     pvalue_y_pad=1.5,

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -615,7 +615,16 @@ def confusionplot(
                         f"[confusionplot] Confusion matrix contains NaN at position [{i},{j}]. "
                         "All values must be valid numbers."
                     )
-                ax.text(j, i, str(int(cell_value)), ha="center", va="center")
+                r, g, b, _ = im.cmap(im.norm(cell_value))
+                luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+                ax.text(
+                    j,
+                    i,
+                    str(int(cell_value)),
+                    ha="center",
+                    va="center",
+                    color="white" if luminance < 0.5 else "black",
+                )
 
     # Remove colorbar to match your original style
     cb = fig.colorbar(im, ax=ax)

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -179,6 +179,14 @@ def test_confusionplot_metrics_and_errors(confusion_df: pd.DataFrame) -> None:
     stats_ax = plt.gcf().axes[1]
     assert len(stats_ax.texts) == 1
     assert stats_ax.texts[0].get_position() == pytest.approx((-0.25, -1.5))
+    text_colors = {
+        tuple(int(coord) for coord in text.get_position()): text.get_color()
+        for text in ax.texts
+    }
+    assert text_colors[(0, 0)] == "white"
+    assert text_colors[(1, 1)] == "white"
+    assert text_colors[(1, 0)] == "black"
+    assert text_colors[(0, 1)] == "black"
 
     cns.figure(120, 120)
     cns.confusionplot(


### PR DESCRIPTION
## What changed
- Switch confusion plot count text between black and white based on cell luminance
- Update the example colormap so the contrast fix is visible with darker tiles
- Add a regression test that asserts the text colors used for light and dark cells

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- The luminance threshold is heuristic and may need tuning if additional colormaps reveal edge cases