### PR TITLE
📝 Add dedicated API docs for cns.settings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -142,6 +142,33 @@ import cnsplots as cns
    setup_ggplot
 ```
 
+## Settings
+
+`cnsplots` exposes its package-wide defaults through `cns.settings`.
+Use it to inspect current defaults, set global styling and helper behavior,
+restore package defaults with `cns.settings.reset()`, or apply temporary
+overrides with `cns.settings.context(...)`.
+
+```python
+print(cns.settings)
+cns.settings.title_fontsize = 10
+
+with cns.settings.context(palette_qual="Dark2", figure_width=200):
+    ...
+
+cns.settings.reset()
+```
+
+See the {doc}`settings reference <settings>` for the full catalog of settings
+and the runnable {doc}`settings example <examples/settings>` for end-to-end
+usage.
+
+```{toctree}
+:hidden: true
+
+settings
+```
+
 ## Color Palettes
 
 ```{eval-rst}
@@ -168,17 +195,3 @@ The following color constants are available:
 - `GRAY` - #A3A3A3
 - `VIOLET` - #442288
 - `CHOCOLATE` - #662506
-
-Default settings:
-
-`cnsplots` exposes its configurable defaults through `cns.settings`.
-These include:
-
-- palettes and font defaults
-- matplotlib setup and export defaults
-- scanpy and ggplot helper defaults
-- figure sizing defaults
-- multipanel layout defaults
-- legend placement and panel label defaults
-
-See `examples/settings.py` for a runnable overview of the settings API.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,171 @@
+# Settings
+
+`cns.settings` is the public settings object for package-wide cnsplots defaults.
+Update its attributes to change styling, export behavior, setup helpers, figure
+helpers, and multipanel defaults for subsequent plotting calls.
+
+Changes to `cns.settings` are global until you either call
+`cns.settings.reset()` or temporarily override a subset of values inside
+`cns.settings.context(...)`.
+
+See the {doc}`API landing page <api>` for the broader API reference and the
+runnable {doc}`settings example <examples/settings>` for a gallery-backed tour
+of these defaults in practice.
+
+## Quickstart
+
+Inspect the current settings object:
+
+```python
+import cnsplots as cns
+
+print(cns.settings)
+```
+
+Assign a new global default:
+
+```python
+cns.settings.title_fontsize = 10
+cns.settings.palette_qual = "Set2"
+```
+
+Reset back to the package defaults:
+
+```python
+cns.settings.reset()
+```
+
+Apply temporary overrides inside a context manager:
+
+```python
+with cns.settings.context(
+    palette_qual="Dark2",
+    figure_width=200,
+    figure_height=120,
+):
+    ...
+```
+
+## Methods
+
+```{eval-rst}
+.. automethod:: cnsplots._settings.CNSSettings.reset
+
+.. automethod:: cnsplots._settings.CNSSettings.context
+```
+
+## Core Style And Typography
+
+These defaults shape the package-wide visual style, text rendering, and logging
+verbosity used by later helper and plotting calls.
+
+```{eval-rst}
+.. autoattribute:: cnsplots._settings.CNSSettings.palette_qual
+.. autoattribute:: cnsplots._settings.CNSSettings.palette_seq
+.. autoattribute:: cnsplots._settings.CNSSettings.title_fontsize
+.. autoattribute:: cnsplots._settings.CNSSettings.title_fontweight
+.. autoattribute:: cnsplots._settings.CNSSettings.verbosity
+.. autoattribute:: cnsplots._settings.CNSSettings.mathtext_fontset
+.. autoattribute:: cnsplots._settings.CNSSettings.font_family
+.. autoattribute:: cnsplots._settings.CNSSettings.font_sans_serif
+```
+
+## Export And Backend Defaults
+
+These settings control the default save behavior and font embedding choices for
+exported figures.
+
+```{eval-rst}
+.. autoattribute:: cnsplots._settings.CNSSettings.savefig_bbox
+.. autoattribute:: cnsplots._settings.CNSSettings.savefig_pad_inches
+.. autoattribute:: cnsplots._settings.CNSSettings.savefig_dpi
+.. autoattribute:: cnsplots._settings.CNSSettings.savefig_transparent
+.. autoattribute:: cnsplots._settings.CNSSettings.svg_fonttype
+.. autoattribute:: cnsplots._settings.CNSSettings.pdf_fonttype
+```
+
+## Axes, Ticks, Legends, And P-Value Annotations
+
+These defaults are consumed by `setup_matplotlib()`, `setup_ax()`, plot
+formatting helpers, and annotation utilities.
+
+```{eval-rst}
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_linewidth
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_titlelocation
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_grid
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_spines_top
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_spines_right
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_edgecolor
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_labelcolor
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_labelpad
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_titlepad
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_xmargin
+.. autoattribute:: cnsplots._settings.CNSSettings.axes_ymargin
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_fontsize
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_title_fontsize
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_frameon
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_markerscale
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_handlelength
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_handleheight
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_handletextpad
+.. autoattribute:: cnsplots._settings.CNSSettings.pvalue_format
+.. autoattribute:: cnsplots._settings.CNSSettings.pvalue_fontsize
+.. autoattribute:: cnsplots._settings.CNSSettings.xtick_bottom
+.. autoattribute:: cnsplots._settings.CNSSettings.xtick_color
+.. autoattribute:: cnsplots._settings.CNSSettings.xtick_major_size
+.. autoattribute:: cnsplots._settings.CNSSettings.xtick_major_width
+.. autoattribute:: cnsplots._settings.CNSSettings.xtick_major_pad
+.. autoattribute:: cnsplots._settings.CNSSettings.xtick_alignment
+.. autoattribute:: cnsplots._settings.CNSSettings.xtick_labelrotation
+.. autoattribute:: cnsplots._settings.CNSSettings.ytick_left
+.. autoattribute:: cnsplots._settings.CNSSettings.ytick_color
+.. autoattribute:: cnsplots._settings.CNSSettings.ytick_major_size
+.. autoattribute:: cnsplots._settings.CNSSettings.ytick_major_width
+.. autoattribute:: cnsplots._settings.CNSSettings.ytick_major_pad
+.. autoattribute:: cnsplots._settings.CNSSettings.ytick_alignment
+.. autoattribute:: cnsplots._settings.CNSSettings.ytick_labelrotation
+.. autoattribute:: cnsplots._settings.CNSSettings.setup_ax_colorbar_label
+```
+
+## Scanpy / ggplot Integration Defaults
+
+These values feed the integration helpers that style scanpy figures and
+generate ggplot theme defaults.
+
+```{eval-rst}
+.. autoattribute:: cnsplots._settings.CNSSettings.scanpy_use_default_style
+.. autoattribute:: cnsplots._settings.CNSSettings.scanpy_figsize
+.. autoattribute:: cnsplots._settings.CNSSettings.scanpy_facecolor
+.. autoattribute:: cnsplots._settings.CNSSettings.ggplot_fontsize
+.. autoattribute:: cnsplots._settings.CNSSettings.ggplot_font_family
+.. autoattribute:: cnsplots._settings.CNSSettings.ggplot_font_face
+.. autoattribute:: cnsplots._settings.CNSSettings.ggplot_text_color
+```
+
+## Figure, Multipanel, And Helper Defaults
+
+These defaults power figure sizing, multipanel layout, panel labels, and
+legend-placement helpers when explicit arguments are omitted.
+
+```{eval-rst}
+.. autoattribute:: cnsplots._settings.CNSSettings.figure_width
+.. autoattribute:: cnsplots._settings.CNSSettings.figure_height
+.. autoattribute:: cnsplots._settings.CNSSettings.figure_dpi
+.. autoattribute:: cnsplots._settings.CNSSettings.multipanel_max_width
+.. autoattribute:: cnsplots._settings.CNSSettings.multipanel_title_loc
+.. autoattribute:: cnsplots._settings.CNSSettings.multipanel_title_height_min
+.. autoattribute:: cnsplots._settings.CNSSettings.multipanel_title_height_pad
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_width
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_height
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_pad_left
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_pad_top
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_margin_top
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_margin_bottom
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_margin_left
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_margin_right
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_label_fontname
+.. autoattribute:: cnsplots._settings.CNSSettings.panel_label_fontweight
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_out_bbox_to_anchor
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_out_loc
+.. autoattribute:: cnsplots._settings.CNSSettings.legend_out_markerscale
+```

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -612,7 +612,16 @@ def _make_setting_property(name: str, doc: str) -> property:
 
 
 class CNSSettings:
-    """Global settings for cnsplots."""
+    """Mutable container for package-wide cnsplots defaults.
+
+    The public settings instance is exposed as ``cns.settings``. Updating
+    attributes on that object changes the defaults used by later plotting,
+    setup, export, figure helper, and multipanel helper calls.
+
+    Assignments are validated immediately. Use :meth:`context` for temporary
+    overrides and :meth:`reset` to restore every setting to its package
+    default.
+    """
 
     _setting_specs = _SETTING_SPECS
     _defaults = {name: spec.default for name, spec in _SETTING_SPECS.items()}
@@ -641,13 +650,39 @@ class CNSSettings:
         self.reset()
 
     def reset(self) -> None:
-        """Reset all settings to their default values."""
+        """Reset all settings to their package defaults.
+
+        This mutates the shared ``cns.settings`` object in place and restores
+        every documented setting to the default declared by cnsplots.
+        """
         for name, spec in type(self)._setting_specs.items():
             setattr(self, name, deepcopy(spec.default))
 
     @contextmanager
     def context(self, **kwargs: Any) -> Generator[CNSSettings, None, None]:
-        """Temporarily override settings within a context manager."""
+        """Temporarily override settings within a context manager.
+
+        Parameters
+        ----------
+        **kwargs
+            Setting names and temporary values to apply to ``cns.settings``
+            for the duration of the ``with`` block.
+
+        Yields
+        ------
+        CNSSettings
+            The shared settings object with the temporary overrides applied.
+
+        Raises
+        ------
+        AttributeError
+            If any provided key is not a valid public setting name.
+
+        Notes
+        -----
+        Previous values are restored after the context exits, even if an
+        exception is raised inside the block.
+        """
         for key in kwargs:
             if key not in self._defaults:
                 raise AttributeError(self._invalid_setting_message(key))


### PR DESCRIPTION
## What changed
- add a dedicated `Settings` section to the API landing page
- add `docs/settings.md` as a grouped reference page for `cns.settings`
- expand `CNSSettings`, `reset()`, and `context()` docstrings so autodoc output reads clearly

## How it was tested
- `CI=true make doc`
- `make test`
- `make lint`
- `uv run pre-commit run --files docs/api.md docs/settings.md src/cnsplots/_settings.py`

## Risks or follow-ups
- `docs/settings.md` documents settings attributes via `cnsplots._settings.CNSSettings` only as a docs source; the public API remains `cns.settings`