### PR TITLE
🐛 Match pieplot percentage labels to legend fontsize

### DIFF
--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -23,6 +23,13 @@ from cnsplots._validation import (
 LollipopPair = Union[tuple[str, str], tuple[tuple[str, str], tuple[str, str]]]
 
 
+def _legend_fontsize() -> int | float:
+    legend_fontsize = cns.settings.legend_fontsize
+    if legend_fontsize is None:
+        return cns.settings.title_fontsize
+    return legend_fontsize
+
+
 def barplot(
     data: pd.DataFrame,
     x: str,
@@ -863,7 +870,7 @@ def pieplot(
         shadow=False,
         autopct="%1.0f%%",
         explode=[0] * df.shape[0],
-        textprops={"fontsize": 6, "color": "white"},
+        textprops={"fontsize": _legend_fontsize(), "color": "white"},
         labeldistance=None,
         wedgeprops={"linewidth": 0.3, "edgecolor": "white"},
         ax=ax,

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -219,6 +219,22 @@ def test_distribution_wrappers(
     assert ax6 is plt.gca()
 
 
+def test_pieplot_uses_legend_fontsize(categorical_df: pd.DataFrame) -> None:
+    with cns.settings.context(legend_fontsize=13):
+        cns.figure(120, 120)
+        ax = cns.pieplot(categorical_df, x="group")
+        assert {
+            text.get_fontsize() for text in ax.texts if text.get_text().endswith("%")
+        } == {13}
+
+    with cns.settings.context(legend_fontsize=None, title_fontsize=12):
+        cns.figure(120, 120)
+        ax = cns.pieplot(categorical_df, x="group")
+        assert {
+            text.get_fontsize() for text in ax.texts if text.get_text().endswith("%")
+        } == {12}
+
+
 def test_distribution_logging_respects_settings_verbosity(
     categorical_df: pd.DataFrame,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## What changed
- replaced the hardcoded `textprops` font size in `pieplot` with the resolved legend font size from `cns.settings`
- added a regression test covering both an explicit `legend_fontsize` and the `None` fallback to `title_fontsize`

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- this change is intentionally scoped to `pieplot`; other hardcoded `fontsize=6` uses were left unchanged because they do not use `textprops` in the pie chart path