### PR TITLE
🐛 Fix contrast-aware labels across pie, Venn, and confusion plots

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -110,6 +110,7 @@ formatting helpers, and annotation utilities.
 .. autoattribute:: cnsplots._settings.CNSSettings.legend_handletextpad
 .. autoattribute:: cnsplots._settings.CNSSettings.pvalue_format
 .. autoattribute:: cnsplots._settings.CNSSettings.pvalue_fontsize
+.. autoattribute:: cnsplots._settings.CNSSettings.annotation_auto_contrast
 .. autoattribute:: cnsplots._settings.CNSSettings.xtick_bottom
 .. autoattribute:: cnsplots._settings.CNSSettings.xtick_color
 .. autoattribute:: cnsplots._settings.CNSSettings.xtick_major_size

--- a/examples/pieplot.py
+++ b/examples/pieplot.py
@@ -84,6 +84,19 @@ ax.set_title("Set2 Palette")
 
 
 # %%
+# Pie chart with contrast-aware labels
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Percentage labels switch between white and black based on slice luminance.
+contrast_data = pd.DataFrame(
+    {"region": np.repeat(["Dark Region", "Light Region"], [7, 3])}
+)
+
+cns.figure(100, 100, ["#1F2937", "#F3F4F6"])
+ax = cns.pieplot(contrast_data, "region", hue_order=["Dark Region", "Light Region"])
+ax.set_title("Contrast-Aware Labels")
+
+
+# %%
 # Comparing pie charts side-by-side
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare composition across conditions.

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -44,6 +44,7 @@ print(f"scanpy_figsize: {cns.settings.scanpy_figsize}")
 print(f"multipanel_max_width: {cns.settings.multipanel_max_width}")
 print(f"panel defaults: {cns.settings.panel_width} x {cns.settings.panel_height} px")
 print(f"legend_out_bbox_to_anchor: {cns.settings.legend_out_bbox_to_anchor}")
+print(f"annotation_auto_contrast: {cns.settings.annotation_auto_contrast}")
 print(
     "panel_label_padding: "
     f"({cns.settings.panel_pad_left}, {cns.settings.panel_pad_top}) px"

--- a/examples/vennplot.py
+++ b/examples/vennplot.py
@@ -86,6 +86,18 @@ plt.title("Treatment vs Control Genes")
 
 
 # %%
+# Venn diagram with contrast-aware labels
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Region labels switch between white and black based on patch luminance.
+dark_set = set(range(1, 9))
+light_set = set(range(5, 13))
+
+cns.figure(100, 100, ["#111827", "#F3F4F6"])
+cns.vennplot([dark_set, light_set], ["Dark Set", "Light Set"])
+plt.title("Contrast-Aware Labels")
+
+
+# %%
 # Sample overlap example
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Compare samples passing different QC criteria.

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -346,6 +346,11 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
         lambda value: _validate_fontsize("pvalue_fontsize", value),
         "Default font size for p-value annotations. Accepts a positive number or matplotlib named size string.",
     ),
+    "annotation_auto_contrast": _spec(
+        True,
+        lambda value: _validate_bool("annotation_auto_contrast", value),
+        "Whether plot annotation text automatically switches between white and black based on background luminance. When False, annotation text stays white.",
+    ),
     "legend_frameon": _spec(
         False,
         lambda value: _validate_bool("legend_frameon", value),

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -44,6 +44,16 @@ PINK = "#E787E5"
 GRAY = "#A3A3A3"
 VIOLET = "#442288"
 CHOCOLATE = "#662506"
+
+
+def _annotation_text_color(color: Any) -> str:
+    """Return a readable annotation color for a background fill."""
+    if not cns.settings.annotation_auto_contrast:
+        return "white"
+
+    r, g, b, _ = mcolors.to_rgba(color)
+    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    return "white" if luminance < 0.5 else "black"
 
 
 def _chain_axes_sync_hook(

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from matplotlib.colors import to_rgba
 from matplotlib.patches import Patch
 
 import cnsplots as cns
@@ -28,6 +29,12 @@ def _legend_fontsize() -> int | float:
     if legend_fontsize is None:
         return cns.settings.title_fontsize
     return legend_fontsize
+
+
+def _annotation_text_color(color: Any) -> str:
+    r, g, b, _ = to_rgba(color)
+    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    return "white" if luminance < 0.5 else "black"
 
 
 def barplot(
@@ -877,6 +884,9 @@ def pieplot(
         ylabel="",
         legend=True,
     )
+    percent_texts = [text for text in ax.texts if text.get_text().endswith("%")]
+    for wedge, text in zip(ax.patches, percent_texts):
+        text.set_color(_annotation_text_color(wedge.get_facecolor()))
     legend_positions = {
         "right": {"loc": "upper left", "bbox_to_anchor": (1, 1.02)},
         "left": {"loc": "upper right", "bbox_to_anchor": (-0.02, 1.02)},

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from matplotlib.colors import to_rgba
 from matplotlib.patches import Patch
 
 import cnsplots as cns
@@ -29,12 +28,6 @@ def _legend_fontsize() -> int | float:
     if legend_fontsize is None:
         return cns.settings.title_fontsize
     return legend_fontsize
-
-
-def _annotation_text_color(color: Any) -> str:
-    r, g, b, _ = to_rgba(color)
-    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
-    return "white" if luminance < 0.5 else "black"
 
 
 def barplot(
@@ -886,7 +879,7 @@ def pieplot(
     )
     percent_texts = [text for text in ax.texts if text.get_text().endswith("%")]
     for wedge, text in zip(ax.patches, percent_texts):
-        text.set_color(_annotation_text_color(wedge.get_facecolor()))
+        text.set_color(cns.utils._annotation_text_color(wedge.get_facecolor()))
     legend_positions = {
         "right": {"loc": "upper left", "bbox_to_anchor": (1, 1.02)},
         "left": {"loc": "upper right", "bbox_to_anchor": (-0.02, 1.02)},

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -616,14 +616,13 @@ def confusionplot(
                         "All values must be valid numbers."
                     )
                 r, g, b, _ = im.cmap(im.norm(cell_value))
-                luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
                 ax.text(
                     j,
                     i,
                     str(int(cell_value)),
                     ha="center",
                     va="center",
-                    color="white" if luminance < 0.5 else "black",
+                    color=cns.utils._annotation_text_color((r, g, b, 1.0)),
                 )
 
     # Remove colorbar to match your original style

--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -14,7 +14,6 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
-from matplotlib.colors import to_rgba
 
 import cnsplots as cns
 
@@ -24,12 +23,6 @@ def _legend_fontsize() -> int | float:
     if legend_fontsize is None:
         return cns.settings.title_fontsize
     return legend_fontsize
-
-
-def _annotation_text_color(color: Any) -> str:
-    r, g, b, _ = to_rgba(color)
-    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
-    return "white" if luminance < 0.5 else "black"
 
 
 def _normalize_text_position(text: Any) -> None:
@@ -257,7 +250,7 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
             patch.set_linewidth(0.5)
             get_facecolor = getattr(patch, "get_facecolor", None)
             if callable(get_facecolor):
-                label.set_color(_annotation_text_color(get_facecolor()))
+                label.set_color(cns.utils._annotation_text_color(get_facecolor()))
         except AttributeError:
             pass
     for area in names:

--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -14,6 +14,7 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
+from matplotlib.colors import to_rgba
 
 import cnsplots as cns
 
@@ -23,6 +24,12 @@ def _legend_fontsize() -> int | float:
     if legend_fontsize is None:
         return cns.settings.title_fontsize
     return legend_fontsize
+
+
+def _annotation_text_color(color: Any) -> str:
+    r, g, b, _ = to_rgba(color)
+    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    return "white" if luminance < 0.5 else "black"
 
 
 def _normalize_text_position(text: Any) -> None:
@@ -243,9 +250,14 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
         ax = venn.venn3(subsets, label_tuple, set_colors=colors, alpha=0.8)
     for area in areas:
         try:
-            ax.get_label_by_id(area).set_fontsize(6)
-            ax.get_patch_by_id(area).set_edgecolor("black")
-            ax.get_patch_by_id(area).set_linewidth(0.5)
+            label = ax.get_label_by_id(area)
+            label.set_fontsize(6)
+            patch = ax.get_patch_by_id(area)
+            patch.set_edgecolor("black")
+            patch.set_linewidth(0.5)
+            get_facecolor = getattr(patch, "get_facecolor", None)
+            if callable(get_facecolor):
+                label.set_color(_annotation_text_color(get_facecolor()))
         except AttributeError:
             pass
     for area in names:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -130,6 +130,7 @@ def test_settings_behavior() -> None:
     assert settings.palette_qual == "Ecotyper1"
     assert settings.savefig_bbox == "tight"
     assert settings.savefig_transparent is True
+    assert settings.annotation_auto_contrast is True
     assert settings.scanpy_facecolor == "none"
     settings.palette_qual = "Set2"
     settings.palette_seq = "parula"
@@ -160,6 +161,7 @@ def test_settings_behavior() -> None:
     settings.legend_title_fontsize = 12
     settings.pvalue_format = "threshold"
     settings.pvalue_fontsize = 9
+    settings.annotation_auto_contrast = False
     settings.legend_frameon = True
     settings.legend_markerscale = 1.2
     settings.legend_handlelength = 1.3
@@ -213,6 +215,7 @@ def test_settings_behavior() -> None:
     assert "font_sans_serif=('Arial', 'DejaVu Sans')" in repr(settings)
     assert "pvalue_format='threshold'" in repr(settings)
     assert "pvalue_fontsize=9" in repr(settings)
+    assert "annotation_auto_contrast=False" in repr(settings)
     assert "panel_label_left" not in repr(settings)
     assert "panel_label_top" not in repr(settings)
     assert "panel_label_offset_x" not in repr(settings)
@@ -245,6 +248,7 @@ def test_settings_behavior() -> None:
         legend_fontsize=None,
         pvalue_format="full",
         pvalue_fontsize="large",
+        annotation_auto_contrast=True,
         scanpy_figsize=(5.0, 4.0),
         panel_margin_top=6,
         panel_margin_bottom=8,
@@ -257,6 +261,7 @@ def test_settings_behavior() -> None:
         assert ctx.legend_fontsize is None
         assert ctx.pvalue_format == "full"
         assert ctx.pvalue_fontsize == "large"
+        assert ctx.annotation_auto_contrast is True
         assert ctx.scanpy_figsize == (5.0, 4.0)
         assert ctx.panel_margin_top == 6
         assert ctx.panel_margin_bottom == 8
@@ -268,6 +273,7 @@ def test_settings_behavior() -> None:
     assert settings.legend_fontsize == 11
     assert settings.pvalue_format == "threshold"
     assert settings.pvalue_fontsize == 9
+    assert settings.annotation_auto_contrast is False
     assert settings.scanpy_figsize == (3.0, 4.0)
     assert settings.panel_margin_top == 2
     assert settings.panel_margin_bottom == 4
@@ -357,6 +363,7 @@ def test_settings_behavior() -> None:
     assert settings.legend_fontsize == 7
     assert settings.pvalue_format == "star"
     assert settings.pvalue_fontsize == "small"
+    assert settings.annotation_auto_contrast is True
     assert settings.scanpy_figsize == (2.5, 2.5)
     assert settings.panel_pad_left == 0
     assert settings.panel_pad_top == 0
@@ -438,6 +445,8 @@ def test_settings_validation_errors() -> None:
         settings.legend_fontsize = "big"
     with pytest.raises(ValueError):
         settings.legend_markerscale = -1
+    with pytest.raises(TypeError, match="annotation_auto_contrast must be a boolean"):
+        settings.annotation_auto_contrast = "yes"
     with pytest.raises(TypeError):
         settings.panel_margin_top = "big"
     with pytest.raises(ValueError):

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -848,3 +848,57 @@ def test_sets_validation_errors(sets_fixture: dict[str, set[int]]) -> None:
         cns.vennplot([set()], labels=["A"])
     with pytest.raises(ValueError, match="Length of 'labels'"):
         cns.vennplot([set(), set()], labels=["A"])
+
+
+def test_vennplot_uses_contrast_text_color(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeLabel:
+        def __init__(self) -> None:
+            self.fontsize: float | None = None
+            self.color: str | None = None
+
+        def set_fontsize(self, value: float) -> None:
+            self.fontsize = value
+
+        def set_color(self, value: str) -> None:
+            self.color = value
+
+    class FakePatch:
+        def __init__(self, color: tuple[float, float, float, float]) -> None:
+            self.color = color
+            self.edgecolor: str | None = None
+            self.linewidth: float | None = None
+
+        def set_edgecolor(self, value: str) -> None:
+            self.edgecolor = value
+
+        def set_linewidth(self, value: float) -> None:
+            self.linewidth = value
+
+        def get_facecolor(self) -> tuple[float, float, float, float]:
+            return self.color
+
+    subset_labels = {area: FakeLabel() for area in ["10", "01", "11"]}
+    set_labels = {area: FakeLabel() for area in ["A", "B"]}
+    patches = {
+        "10": FakePatch((0.1, 0.1, 0.1, 0.8)),
+        "01": FakePatch((0.9, 0.9, 0.9, 0.8)),
+        "11": FakePatch((0.2, 0.2, 0.2, 0.8)),
+    }
+    fake_venn_obj = types.SimpleNamespace(
+        get_label_by_id=lambda area: subset_labels.get(area, set_labels.get(area)),
+        get_patch_by_id=lambda area: patches.get(area),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "matplotlib_venn",
+        types.SimpleNamespace(venn2=lambda *args, **kwargs: fake_venn_obj),
+    )
+
+    cns.figure(120, 120)
+    cns.vennplot([{1, 2}, {2, 3}], labels=["A", "B"])
+
+    assert subset_labels["10"].color == "white"
+    assert subset_labels["01"].color == "black"
+    assert subset_labels["11"].color == "white"

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -188,6 +188,17 @@ def test_confusionplot_metrics_and_errors(confusion_df: pd.DataFrame) -> None:
     assert text_colors[(1, 0)] == "black"
     assert text_colors[(0, 1)] == "black"
 
+    with cns.settings.context(annotation_auto_contrast=False):
+        cns.figure(120, 120)
+        disabled_ax = cns.confusionplot(
+            confusion_df,
+            x="pred",
+            y="truth",
+            x_order=["neg", "pos"],
+            y_order=["neg", "pos"],
+        )
+    assert {text.get_color() for text in disabled_ax.texts} == {"white"}
+
     cns.figure(120, 120)
     cns.confusionplot(
         confusion_df,
@@ -879,17 +890,21 @@ def test_vennplot_uses_contrast_text_color(
         def get_facecolor(self) -> tuple[float, float, float, float]:
             return self.color
 
-    subset_labels = {area: FakeLabel() for area in ["10", "01", "11"]}
-    set_labels = {area: FakeLabel() for area in ["A", "B"]}
-    patches = {
-        "10": FakePatch((0.1, 0.1, 0.1, 0.8)),
-        "01": FakePatch((0.9, 0.9, 0.9, 0.8)),
-        "11": FakePatch((0.2, 0.2, 0.2, 0.8)),
-    }
-    fake_venn_obj = types.SimpleNamespace(
-        get_label_by_id=lambda area: subset_labels.get(area, set_labels.get(area)),
-        get_patch_by_id=lambda area: patches.get(area),
-    )
+    def build_fake_venn_obj() -> tuple[dict[str, FakeLabel], types.SimpleNamespace]:
+        subset_labels = {area: FakeLabel() for area in ["10", "01", "11"]}
+        set_labels = {area: FakeLabel() for area in ["A", "B"]}
+        patches = {
+            "10": FakePatch((0.1, 0.1, 0.1, 0.8)),
+            "01": FakePatch((0.9, 0.9, 0.9, 0.8)),
+            "11": FakePatch((0.2, 0.2, 0.2, 0.8)),
+        }
+        fake_venn_obj = types.SimpleNamespace(
+            get_label_by_id=lambda area: subset_labels.get(area, set_labels.get(area)),
+            get_patch_by_id=lambda area: patches.get(area),
+        )
+        return subset_labels, fake_venn_obj
+
+    subset_labels, fake_venn_obj = build_fake_venn_obj()
     monkeypatch.setitem(
         sys.modules,
         "matplotlib_venn",
@@ -901,4 +916,18 @@ def test_vennplot_uses_contrast_text_color(
 
     assert subset_labels["10"].color == "white"
     assert subset_labels["01"].color == "black"
+    assert subset_labels["11"].color == "white"
+
+    subset_labels, fake_venn_obj = build_fake_venn_obj()
+    monkeypatch.setitem(
+        sys.modules,
+        "matplotlib_venn",
+        types.SimpleNamespace(venn2=lambda *args, **kwargs: fake_venn_obj),
+    )
+    with cns.settings.context(annotation_auto_contrast=False):
+        cns.figure(120, 120)
+        cns.vennplot([{1, 2}, {2, 3}], labels=["A", "B"])
+
+    assert subset_labels["10"].color == "white"
+    assert subset_labels["01"].color == "white"
     assert subset_labels["11"].color == "white"

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
+from cycler import cycler
 from matplotlib.colors import to_hex, to_rgba
 from matplotlib.patches import Circle, FancyBboxPatch, Polygon, Wedge
 
@@ -233,6 +234,17 @@ def test_pieplot_uses_legend_fontsize(categorical_df: pd.DataFrame) -> None:
         assert {
             text.get_fontsize() for text in ax.texts if text.get_text().endswith("%")
         } == {12}
+
+
+def test_pieplot_uses_contrast_text_color() -> None:
+    data = pd.DataFrame({"group": ["dark"] * 3 + ["light"] * 2})
+
+    cns.figure(120, 120)
+    with plt.rc_context({"axes.prop_cycle": cycler(color=["#111111", "#eeeeee"])}):
+        ax = cns.pieplot(data, x="group", hue_order=["dark", "light"])
+
+    percent_texts = [text for text in ax.texts if text.get_text().endswith("%")]
+    assert [text.get_color() for text in percent_texts] == ["white", "black"]
 
 
 def test_distribution_logging_respects_settings_verbosity(

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -246,6 +246,14 @@ def test_pieplot_uses_contrast_text_color() -> None:
     percent_texts = [text for text in ax.texts if text.get_text().endswith("%")]
     assert [text.get_color() for text in percent_texts] == ["white", "black"]
 
+    with cns.settings.context(annotation_auto_contrast=False):
+        cns.figure(120, 120)
+        with plt.rc_context({"axes.prop_cycle": cycler(color=["#111111", "#eeeeee"])}):
+            ax = cns.pieplot(data, x="group", hue_order=["dark", "light"])
+
+    percent_texts = [text for text in ax.texts if text.get_text().endswith("%")]
+    assert [text.get_color() for text in percent_texts] == ["white", "white"]
+
 
 def test_distribution_logging_respects_settings_verbosity(
     categorical_df: pd.DataFrame,


### PR DESCRIPTION
## What changed
- add `cns.settings.annotation_auto_contrast` so annotation text can auto-switch between white and black or stay white when disabled
- apply the setting to `pieplot`, `vennplot`, and `confusionplot`
- add tests, examples, and settings docs for the new behavior

## How it was tested
- `make lint`
- `make test`

## Risks or follow-ups
- the toggle currently affects annotation text in these three plot types only; other plot text keeps its existing behavior