### PR TITLE
🐛 Use addcount labels in stackplot tick labels

### DIFF
--- a/examples/stackplot.py
+++ b/examples/stackplot.py
@@ -25,9 +25,11 @@ tips = sns.load_dataset("tips")
 # Basic stacked bar plot (normalized)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Shows proportions that sum to 100% within each bar.
-# Use ``addtip=True`` to display percentage labels.
+# Use ``addcount=True`` to display total counts in the tick labels.
 cns.figure(120, 100)
-ax = cns.stackplot(data=tips, x="sex", y="day", width=0.4, normalize=True, addtip=True)
+ax = cns.stackplot(
+    data=tips, x="sex", y="day", width=0.4, normalize=True, addcount=True
+)
 ax.set_title("Basic Stacked Plot")
 
 
@@ -159,7 +161,7 @@ mp.get_axes("B").set_title("BlueRed")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Stack plots work with multiple categories in the y variable.
 cns.figure(150, 100, "Ecotyper1")
-ax = cns.stackplot(data=tips, x="sex", y="time", normalize=True, addtip=True)
+ax = cns.stackplot(data=tips, x="sex", y="time", normalize=True, addcount=True)
 ax.set_title("Multiple Stack Categories")
 
 
@@ -199,9 +201,9 @@ ax.set_ylabel("Proportion")
 
 
 # %%
-# Horizontal stacked bar with percentage labels
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Combine horizontal orientation with percentage labels.
+# Horizontal stacked bar with count labels
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Combine horizontal orientation with count labels on the category axis.
 cns.figure(120, 100, "Pastel1")
 ax = cns.stackplot(
     data=tips,
@@ -209,7 +211,7 @@ ax = cns.stackplot(
     y="sex",
     horizontal=True,
     normalize=True,
-    addtip=True,
+    addcount=True,
     width=0.6,
 )
 ax.set_title("Horizontal with Labels")
@@ -229,6 +231,6 @@ mp.get_axes("A").set_ylabel("Count")
 mp.newline()
 
 mp.panel("B", 80, 130, margin_top=10)
-cns.stackplot(data=tips, x="day", y="sex", normalize=True, addtip=True)
+cns.stackplot(data=tips, x="day", y="sex", normalize=True, addcount=True)
 mp.get_axes("B").set_title("Normalized Proportions")
 mp.get_axes("B").set_ylabel("Proportion")

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -561,15 +561,28 @@ def apply_unicode_font(ax=None, font="DejaVu Sans"):
             text_obj.set_fontfamily(font)
 
 
-def _addcount_helper(data, attr, ax):
-    xtick_labels = ax.get_xticklabels()
-    tick_positions = ax.get_xticks()
-    new_xtick_labels = []
-    for label in xtick_labels:
-        n = len(data[data[attr] == label.get_text()])
-        new_xtick_labels.append(f"{label.get_text()}\n(n={n})")
-    ax.set_xticks(tick_positions)
-    ax.set_xticklabels(new_xtick_labels)
+def _addcount_helper(data, attr, ax, axis="x"):
+    counts = data[attr].astype(str).value_counts()
+    if axis == "x":
+        tick_labels = ax.get_xticklabels()
+        tick_positions = ax.get_xticks()
+        set_ticks = ax.set_xticks
+        set_ticklabels = ax.set_xticklabels
+    elif axis == "y":
+        tick_labels = ax.get_yticklabels()
+        tick_positions = ax.get_yticks()
+        set_ticks = ax.set_yticks
+        set_ticklabels = ax.set_yticklabels
+    else:
+        raise ValueError("axis must be 'x' or 'y'")
+
+    new_tick_labels = []
+    for label in tick_labels:
+        label_text = label.get_text()
+        n = int(counts.get(label_text, 0))
+        new_tick_labels.append(f"{label_text}\n(n={n})")
+    set_ticks(tick_positions)
+    set_ticklabels(new_tick_labels)
 
 
 def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=None):

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -577,7 +577,7 @@ def stackplot(
     width: float = 0.5,
     normalize: bool = True,
     pairs: list[tuple[str, str]] | None = None,
-    addtip: bool = False,
+    addcount: bool = False,
     n_factor: int | float = 1,
 ) -> Axes:
     """
@@ -607,8 +607,9 @@ def stackplot(
         Whether to normalize counts to frequencies (proportions summing to 1).
     pairs : list of tuple of str, optional
         List of pairs of category names from x for pairwise statistical comparisons.
-    addtip : bool, default: False
-        Whether to add total count labels above/beside each bar when normalize=True.
+    addcount : bool, default: False
+        Whether to append total counts to the category tick labels in the
+        format ``n=...``.
     n_factor : int or float, default: 1
         Scaling factor to divide all values.
 
@@ -674,33 +675,10 @@ def stackplot(
         ax.set_ylabel(value_label)
         ax.set_xlabel("")
     cns.take_legend_out()
-    if addtip and normalize:
-        tips = (
-            contingency.sum(axis=1).astype(int).reindex(index=bar_order).reset_index()
-        )
-        tips = tips.rename(columns={0: "value"})
-        for _, row in tips.iterrows():
-            if horizontal:
-                ax.text(
-                    1 + 0.02,
-                    row.name,
-                    row["value"],
-                    color="black",
-                    ha="left",
-                    va="center",
-                    rotation=0,
-                    size=6,
-                )
-            else:
-                ax.text(
-                    row.name,
-                    1 + 0.02,
-                    row["value"],
-                    color="black",
-                    ha="center",
-                    rotation=0,
-                    size=6,
-                )
+    if addcount:
+        count_attr = y if horizontal else x
+        count_axis = "y" if horizontal else "x"
+        cns.utils._addcount_helper(data, count_attr, ax, axis=count_axis)
     if pairs is not None:
         if horizontal:
             plotting = {"data": data2, "x": "count", "y": y, "order": bar_order}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1078,6 +1078,8 @@ def test_utils_helpers_and_showcase_data(
     sns.boxplot(data=categorical_df, x="group", y="value", ax=ax4)
     _utils._addcount_helper(categorical_df, "group", ax4)
     assert "(n=" in ax4.get_xticklabels()[0].get_text()
+    with pytest.raises(ValueError, match="axis must be 'x' or 'y'"):
+        _utils._addcount_helper(categorical_df, "group", ax4, axis="z")
 
     class DummyResult:
         test_short_name = "T"

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -791,7 +791,7 @@ def test_plot_internal_coverage(
         y="response",
         horizontal=True,
         normalize=True,
-        addtip=True,
+        addcount=True,
         bar_order=["A", "B", "C"],
     )
 

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -137,12 +137,18 @@ def test_stack_strip_pie_and_donut_plots(
         x="treatment",
         y="response",
         normalize=True,
-        addtip=True,
+        addcount=True,
         pairs=[("A", "B")],
         bar_order=["A", "B", "C"],
         stack_order=["Yes", "No"],
     )
     assert ax.get_ylabel() == "Frequency"
+    assert [tick.get_text() for tick in ax.get_xticklabels()] == [
+        "A\n(n=4)",
+        "B\n(n=4)",
+        "C\n(n=4)",
+    ]
+    assert not ax.texts
 
     cns.figure(120, 120)
     ax2 = cns.stackplot(
@@ -156,6 +162,21 @@ def test_stack_strip_pie_and_donut_plots(
         stack_order=["No", "Yes"],
     )
     assert ax2.get_xlabel() == "Count"
+
+    cns.figure(120, 120)
+    ax2b = cns.stackplot(
+        stack_df,
+        x="treatment",
+        y="response",
+        horizontal=True,
+        normalize=False,
+        addcount=True,
+    )
+    assert {tick.get_text() for tick in ax2b.get_yticklabels()} == {
+        "No\n(n=6)",
+        "Yes\n(n=6)",
+    }
+    assert not ax2b.texts
 
     cns.figure(120, 120)
     ax3 = cns.stripplot(

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import inspect
 import re
 import sys
 import types
@@ -57,6 +58,12 @@ def test_public_namespace_contract() -> None:
     assert namespace["savefig"] is cns.savefig
     assert cns.save is cns.savefig
     assert namespace["validation"] is cns.validation
+
+
+def test_public_stackplot_signature_contract() -> None:
+    parameters = inspect.signature(cns.stackplot).parameters
+    assert "addcount" in parameters
+    assert "addtip" not in parameters
 
 
 def test_public_validation_contract(heatmap_adata: object) -> None:


### PR DESCRIPTION
## What changed
- replace `stackplot(addtip=...)` with `addcount`
- move stackplot count display from floating text annotations to category tick labels in `Label\n(n=...)` format
- support count labels on the y-axis for horizontal stackplots and update examples/tests accordingly

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- this is a hard public API rename for `stackplot`, so callers still using `addtip` will need to update to `addcount`