### PR TITLE
🐛 Show non-significant p-values in full annotations

### DIFF
--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -608,8 +608,6 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=No
         def format_data(self, result):
             if resolved_format == "full":
                 text = f"{result.test_short_name} " if self.show_test_name else ""
-                if result.pvalue > 0.05:
-                    return "ns"
                 return r"${}P = {}{}$".format(
                     "{}", self.pvalue_format_string, "{}"
                 ).format(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1143,6 +1143,9 @@ def test_utils_helpers_and_showcase_data(
     formatted = formatter.format_data(DummyResult(0.01))
     assert formatted.startswith("$T P = ")
     assert r"\times 10^{-2}$" in formatted
+    nonsig_formatted = formatter.format_data(DummyResult(0.2))
+    assert nonsig_formatted.startswith("$T P = ")
+    assert r"\times 10^{-1}$" in nonsig_formatted
 
     with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=9):
         _utils._p_value_helper(

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -496,7 +496,8 @@ def test_utils_internal_coverage(
         format="full",
     )
     formatted = CaptureAnnotator.last._pvalue_format.format_data(DummyResult(0.2))
-    assert formatted == "ns"
+    assert formatted.startswith("$T P = ")
+    assert r"\times 10^{-1}$" in formatted
 
     with pytest.raises(ValueError, match="requires a hue column"):
         _utils._p_value_helper(


### PR DESCRIPTION
## What changed
- Stop converting non-significant results to `ns` when `pvalue_format="full"` is used.
- Keep the existing full-format numeric rendering and add regression coverage for non-significant output.

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- Full-format output still uses the package's existing numeric style, including scientific notation when applicable.