### PR TITLE
✨ Add Google Analytics tracking to docs site

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -35,6 +35,18 @@
   rel="stylesheet"
   href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap"
 />
+<script
+  async
+  src="https://www.googletagmanager.com/gtag/js?id=G-V1JSNH5QX4"
+></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
+  gtag("config", "G-V1JSNH5QX4");
+</script>
 {% endblock extrahead %} {% block content %} {% include
 "components/version-banner.html" %} {{ super() }} {% endblock content %} {%
 block right_sidebar %} {% if pagename != "404" %}

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 import sys
 import types
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import anndata as ad
 import matplotlib.pyplot as plt
@@ -629,7 +629,7 @@ def test_helper_heatmap_internal_coverage(monkeypatch: pytest.MonkeyPatch) -> No
         plot=False,
         verbose=1,
     )
-    plotter3.data = np.array([[0, 1], [1, 0]])
+    plotter3.data = cast(Any, np.array([[0, 1], [1, 0]]))
     plotter3.ax = plt.gca()
     plotter3.yticklabels = []
     plotter3.collect_legends()
@@ -642,7 +642,7 @@ def test_helper_heatmap_internal_coverage(monkeypatch: pytest.MonkeyPatch) -> No
         plot=False,
         verbose=0,
     )
-    plotter4.data = np.array([[0, 1], [1, 0]])
+    plotter4.data = cast(Any, np.array([[0, 1], [1, 0]]))
     plotter4.ax = plt.gca()
     plotter4.yticklabels = []
     plotter4.collect_legends()


### PR DESCRIPTION
## What changed
- add the Google Analytics `gtag.js` snippet to the docs page template so published docs pages load measurement ID `G-V1JSNH5QX4`
- keep the internal coverage test branch that uses an `ndarray`, but cast that temporary assignment to satisfy the `ty` lint rule

## How it was tested
- `make lint`
- `make test`

## Risks or follow-ups
- this adds analytics to all docs pages that use the shared Sphinx page template
- if analytics should be environment-specific later, we can move the measurement ID into docs configuration instead of hardcoding it in the template