### PR TITLE
🐛 Preserve archived docs when main builds after a new tag

### DIFF
--- a/docs/_scripts/build_versioned_docs.py
+++ b/docs/_scripts/build_versioned_docs.py
@@ -624,6 +624,24 @@ def _copy_preserved_versions(
     return sorted(preserved_release_names, key=_version_sort_key), preserved_dev
 
 
+def _resolve_published_latest_release(
+    existing_site_dir: Path, preserved_release_names: list[str]
+) -> str | None:
+    """Return the stable release currently published as latest on gh-pages."""
+    latest_alias = existing_site_dir / LATEST_DOCS_NAME
+    if latest_alias.is_symlink():
+        target_name = Path(os.readlink(latest_alias)).name
+        if target_name in preserved_release_names and RELEASE_TAG_PATTERN.fullmatch(
+            target_name
+        ):
+            return target_name
+
+    if not preserved_release_names:
+        return None
+
+    return max(preserved_release_names, key=_version_sort_key)
+
+
 def _rewrite_metadata_entry(
     entry: dict[str, object], outputdir: Path, confdir: Path | None = None
 ) -> dict[str, object]:
@@ -743,14 +761,21 @@ def _build_main_site(output_dir: Path, latest_release_tag: str) -> None:
         _build_bootstrap_site(output_dir, latest_release_tag)
         return
 
-    all_metadata = _dump_multiversion_metadata(output_dir, latest_release_tag)
-    if latest_release_tag not in all_metadata:
-        raise RuntimeError(
-            f"Missing metadata for the latest release tag {latest_release_tag}."
-        )
-
     with _temporary_worktree(remote_ref) as existing_site_dir:
-        if not (existing_site_dir / latest_release_tag).exists():
+        preserved_release_names = sorted(
+            (
+                path.name
+                for path in existing_site_dir.iterdir()
+                if path.is_dir()
+                and not path.is_symlink()
+                and RELEASE_TAG_PATTERN.fullmatch(path.name)
+            ),
+            key=_version_sort_key,
+        )
+        published_latest_release_tag = _resolve_published_latest_release(
+            existing_site_dir, preserved_release_names
+        )
+        if published_latest_release_tag is None:
             _build_bootstrap_site(output_dir, latest_release_tag)
             return
 
@@ -758,25 +783,29 @@ def _build_main_site(output_dir: Path, latest_release_tag: str) -> None:
         preserved_release_names, _ = _copy_preserved_versions(
             existing_site_dir, output_dir
         )
-        if latest_release_tag not in preserved_release_names:
-            _build_bootstrap_site(output_dir, latest_release_tag)
-            return
 
-        metadata = _build_version_metadata(
-            all_metadata,
-            output_dir,
-            [DEV_DOCS_NAME, *preserved_release_names],
-            DEV_DOCS_NAME,
-            DOCS_DIR,
-        )
-        _build_single_version_docs(
-            DEV_DOCS_NAME,
-            output_dir / DEV_DOCS_NAME,
-            metadata,
-            latest_release_tag,
+    all_metadata = _dump_multiversion_metadata(output_dir, published_latest_release_tag)
+    if published_latest_release_tag not in all_metadata:
+        raise RuntimeError(
+            "Missing metadata for the latest published release tag "
+            f"{published_latest_release_tag}."
         )
 
-    _write_version_symlink(output_dir, LATEST_DOCS_NAME, latest_release_tag)
+    metadata = _build_version_metadata(
+        all_metadata,
+        output_dir,
+        [DEV_DOCS_NAME, *preserved_release_names],
+        DEV_DOCS_NAME,
+        DOCS_DIR,
+    )
+    _build_single_version_docs(
+        DEV_DOCS_NAME,
+        output_dir / DEV_DOCS_NAME,
+        metadata,
+        published_latest_release_tag,
+    )
+
+    _write_version_symlink(output_dir, LATEST_DOCS_NAME, published_latest_release_tag)
     _finalize_site(output_dir)
 
 

--- a/tests/test_docs_build_script.py
+++ b/tests/test_docs_build_script.py
@@ -239,6 +239,116 @@ def test_main_build_preserves_release_directories(tmp_path, monkeypatch):
     assert "/v0.0.4/sitemap.xml" in sitemap
 
 
+def test_main_build_keeps_published_latest_when_newer_tag_is_unpublished(
+    tmp_path, monkeypatch
+):
+    docs_build = _load_docs_build_script()
+    published_site = tmp_path / "published"
+    _write_version_dir(published_site, "v0.2.0")
+    _write_version_dir(published_site, "v0.1.0")
+    (published_site / "latest").symlink_to("v0.2.0")
+
+    metadata = {
+        "dev": {
+            "name": "dev",
+            "outputdir": "unused",
+            "confdir": str(tmp_path / "temp-dev-docs"),
+            "docnames": ["index"],
+        },
+        "v0.1.0": {
+            "name": "v0.1.0",
+            "outputdir": "unused",
+            "confdir": str(tmp_path / "temp-v010-docs"),
+            "docnames": ["index"],
+        },
+        "v0.2.0": {
+            "name": "v0.2.0",
+            "outputdir": "unused",
+            "confdir": str(tmp_path / "temp-v020-docs"),
+            "docnames": ["index"],
+        },
+        "v0.3.0": {
+            "name": "v0.3.0",
+            "outputdir": "unused",
+            "confdir": str(tmp_path / "temp-v030-docs"),
+            "docnames": ["index"],
+        },
+    }
+    bootstrap_calls = []
+    build_calls = []
+    metadata_requests = []
+
+    monkeypatch.setattr(
+        docs_build, "_fetch_remote_branch", lambda branch_name: "origin/gh-pages"
+    )
+
+    @contextmanager
+    def fake_worktree(ref):
+        assert ref == "origin/gh-pages"
+        yield published_site
+
+    monkeypatch.setattr(docs_build, "_temporary_worktree", fake_worktree)
+    monkeypatch.setattr(
+        docs_build,
+        "_dump_multiversion_metadata",
+        lambda output_dir, latest_release_tag: (
+            metadata_requests.append(latest_release_tag) or metadata
+        ),
+    )
+    monkeypatch.setattr(
+        docs_build,
+        "_build_bootstrap_site",
+        lambda output_dir, latest_release_tag: bootstrap_calls.append(
+            (output_dir, latest_release_tag)
+        ),
+    )
+
+    def fake_build_single_version_docs(
+        version_name,
+        version_output_dir,
+        version_metadata,
+        latest_release_tag,
+        **kwargs,
+    ):
+        build_calls.append(
+            {
+                "version_name": version_name,
+                "metadata_names": set(version_metadata),
+                "latest_release_tag": latest_release_tag,
+            }
+        )
+        version_output_dir.mkdir(parents=True)
+        (version_output_dir / "index.html").write_text(
+            "<html>dev</html>", encoding="utf-8"
+        )
+        (version_output_dir / "sitemap.xml").write_text("<xml />", encoding="utf-8")
+
+    monkeypatch.setattr(
+        docs_build, "_build_single_version_docs", fake_build_single_version_docs
+    )
+
+    output_dir = tmp_path / "site"
+    docs_build._build_main_site(output_dir, "v0.3.0")
+
+    assert bootstrap_calls == []
+    assert metadata_requests == ["v0.2.0"]
+    assert build_calls == [
+        {
+            "version_name": "dev",
+            "metadata_names": {"dev", "v0.2.0", "v0.1.0"},
+            "latest_release_tag": "v0.2.0",
+        }
+    ]
+    assert (output_dir / "latest").is_symlink()
+    assert (output_dir / "latest").readlink() == Path("v0.2.0")
+    assert (output_dir / "v0.2.0" / "index.html").read_text(encoding="utf-8") == (
+        "<html>v0.2.0</html>"
+    )
+    assert (output_dir / "v0.1.0" / "index.html").read_text(encoding="utf-8") == (
+        "<html>v0.1.0</html>"
+    )
+
+
 def test_release_build_preserves_dev_and_previous_releases(tmp_path, monkeypatch):
     docs_build = _load_docs_build_script()
     published_site = tmp_path / "published"


### PR DESCRIPTION
## What changed
- preserve the currently published stable release during `main` docs builds instead of switching to the newest git tag before its release docs exist
- keep rebuilding only `dev` on `main` while copying all published release folders forward from `gh-pages`
- add a regression test for the case where a newer tag exists in git but has not been published to `gh-pages` yet

## How it was tested
- `make test`
- `make lint`

## Risks or follow-ups
- this PR intentionally leaves the release-tag workflow behavior unchanged; tag builds should continue creating the new version folder and moving `latest`
