### PR TITLE
✨ Respect font size settings in plot annotations

### DIFF
--- a/src/cnsplots/helpers/_sankey.py
+++ b/src/cnsplots/helpers/_sankey.py
@@ -48,7 +48,7 @@ def sankeyplot(
     rightLabels: list[str] | None = None,
     aspect: int = 4,
     rightColor: bool = False,
-    fontsize: int = 14,
+    fontsize: int | float = 14,
     label_rotation: float = 0,
     figureName: str | None = None,
     closePlot: bool = False,
@@ -229,7 +229,7 @@ def determine_widths(
 def draw_vertical_bars(
     ax: Any,
     colorDict: dict[str, tuple[float, float, float]] | dict[str, str],
-    fontsize: int,
+    fontsize: int | float,
     leftLabels: list[str],
     leftWidths: dict,
     rightLabels: list[str],

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -138,7 +138,7 @@ def barplot(
                 color="black",
                 ha="center",
                 rotation=0,
-                size=6,
+                size=_legend_fontsize(),
             )
     if pairs is not None:
         cns.utils._p_value_helper("t-test_welch", data, ax, plotting, pairs)
@@ -351,7 +351,7 @@ def lollipopplot(
                         color="black",
                         ha="center",
                         va="bottom",
-                        fontsize=6,
+                        fontsize=_legend_fontsize(),
                     )
         else:
             ax.hlines(
@@ -395,7 +395,7 @@ def lollipopplot(
                         color="black",
                         ha="left",
                         va="center",
-                        fontsize=6,
+                        fontsize=_legend_fontsize(),
                     )
     else:
         # Grouped: multiple stems per category
@@ -505,7 +505,7 @@ def lollipopplot(
                                 color="black",
                                 ha="center",
                                 va="bottom",
-                                fontsize=6,
+                                fontsize=_legend_fontsize(),
                             )
         else:
             ax.set_yticks(cat_positions)
@@ -525,7 +525,7 @@ def lollipopplot(
                                 color="black",
                                 ha="left",
                                 va="center",
-                                fontsize=6,
+                                fontsize=_legend_fontsize(),
                             )
 
     # Statistical annotations
@@ -925,7 +925,7 @@ def donutplot(
         legend=True,
         wedgeprops={"edgecolor": "black", "linewidth": 0.3, "width": 0.4},
     )
-    plt.annotate(x, (0, 0), size=7, ha="center", va="center")
+    plt.annotate(x, (0, 0), size=_legend_fontsize(), ha="center", va="center")
     cns.utils._remove_edge_from_legend_items(ax)
     legend_positions = {
         "right": {"loc": "upper left", "bbox_to_anchor": (1, 1.02)},

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -27,6 +27,13 @@ from cnsplots._validation import (
 logger = logging.getLogger(__name__)
 
 
+def _legend_fontsize() -> int | float:
+    legend_fontsize = cns.settings.legend_fontsize
+    if legend_fontsize is None:
+        return cns.settings.title_fontsize
+    return legend_fontsize
+
+
 def boxplot(
     data: pd.DataFrame,
     x: str,
@@ -407,7 +414,7 @@ def kdeplot(data: pd.DataFrame, x: str, add_mode: bool = True, **kwargs: Any) ->
                 f"{mode:.2f}",
                 ha="center",
                 va="bottom",
-                fontsize=7,
+                fontsize=_legend_fontsize(),
                 color=kde_color,
                 bbox=dict(facecolor="white", edgecolor="none", pad=2),
             )
@@ -555,7 +562,7 @@ def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes
             cat,
             ha="right",
             va="bottom",
-            fontsize=plt.rcParams.get("xtick.labelsize", 7),
+            fontsize=_legend_fontsize(),
         )
 
     ax.set_xlim(x_min, x_max)

--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -19,6 +19,13 @@ from cnsplots._validation import (
 )
 
 
+def _legend_fontsize() -> int | float:
+    legend_fontsize = cns.settings.legend_fontsize
+    if legend_fontsize is None:
+        return cns.settings.title_fontsize
+    return legend_fontsize
+
+
 def volcanoplot(
     data: pd.DataFrame,
     x: str = "log2FoldChange",
@@ -136,7 +143,7 @@ def volcanoplot(
                     t,
                     (x0, y0),
                     color=color,
-                    size=6,
+                    size=_legend_fontsize(),
                     path_effects=[pe.withStroke(linewidth=1, foreground="white")],
                 )
             )

--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -241,10 +241,11 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
         subsets = (lists[0], lists[1], lists[2])
         label_tuple = (labels[0], labels[1], labels[2])
         ax = venn.venn3(subsets, label_tuple, set_colors=colors, alpha=0.8)
+    legend_fontsize = _legend_fontsize()
     for area in areas:
         try:
             label = ax.get_label_by_id(area)
-            label.set_fontsize(6)
+            label.set_fontsize(legend_fontsize)
             patch = ax.get_patch_by_id(area)
             patch.set_edgecolor("black")
             patch.set_linewidth(0.5)
@@ -254,6 +255,6 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
         except AttributeError:
             pass
     for area in names:
-        ax.get_label_by_id(area).set_fontsize(7)
+        ax.get_label_by_id(area).set_fontsize(legend_fontsize)
 
     return ax

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -14,6 +14,7 @@ import seaborn as sns
 from matplotlib.patches import Circle, FancyBboxPatch, Polygon
 from sklearn.metrics import auc, roc_curve
 
+import cnsplots as cns
 import cnsplots.helpers._phylo as helper_phylo
 import cnsplots.helpers._sankey as helper_sankey
 from cnsplots._validation import (
@@ -23,6 +24,13 @@ from cnsplots._validation import (
     validate_dataframe,
     validate_dataframe_not_empty,
 )
+
+
+def _legend_fontsize() -> int | float:
+    legend_fontsize = cns.settings.legend_fontsize
+    if legend_fontsize is None:
+        return cns.settings.title_fontsize
+    return legend_fontsize
 
 
 def placeholderplot(description: str) -> Axes:
@@ -197,7 +205,7 @@ def sankeyplot(data: pd.DataFrame, x: str, y: str, label_rotation: float = 0) ->
     helper_sankey.sankeyplot(
         data[x],
         data[y],
-        fontsize=6,
+        fontsize=_legend_fontsize(),
         colorDict=color_dict,
         label_rotation=label_rotation,
         ax=ax,

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -846,6 +846,26 @@ def test_genomics_plots(
     assert ax5.get_xlabel() == "Normalized Enrichment Score (NES)"
 
 
+def test_volcanoplot_annotations_use_legend_fontsize(
+    volcano_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_adjust = types.SimpleNamespace(adjust_text=lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "adjustText", fake_adjust)
+
+    with cns.settings.context(legend_fontsize=13):
+        cns.figure(120, 120)
+        ax = cns.volcanoplot(volcano_df, n_show=1)
+        assert ax.texts
+        assert {text.get_fontsize() for text in ax.texts} == {13}
+
+    with cns.settings.context(legend_fontsize=None, title_fontsize=12):
+        cns.figure(120, 120)
+        ax = cns.volcanoplot(volcano_df, n_show=1)
+        assert ax.texts
+        assert {text.get_fontsize() for text in ax.texts} == {12}
+
+
 def test_sets_validation_errors(sets_fixture: dict[str, set[int]]) -> None:
     legacy_upsetplot = cast(Any, cns.upsetplot)
     legacy_vennplot = cast(Any, cns.vennplot)
@@ -931,3 +951,58 @@ def test_vennplot_uses_contrast_text_color(
     assert subset_labels["10"].color == "white"
     assert subset_labels["01"].color == "white"
     assert subset_labels["11"].color == "white"
+
+
+def test_vennplot_annotations_use_legend_fontsize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeLabel:
+        def __init__(self) -> None:
+            self.fontsize: float | None = None
+
+        def set_fontsize(self, value: float) -> None:
+            self.fontsize = value
+
+        def set_color(self, value: str) -> None:
+            pass
+
+    class FakePatch:
+        def set_edgecolor(self, value: str) -> None:
+            pass
+
+        def set_linewidth(self, value: float) -> None:
+            pass
+
+        def get_facecolor(self) -> tuple[float, float, float, float]:
+            return (0.1, 0.1, 0.1, 0.8)
+
+    def build_fake_venn_obj() -> tuple[dict[str, FakeLabel], dict[str, FakeLabel]]:
+        subset_labels = {area: FakeLabel() for area in ["10", "01", "11"]}
+        set_labels = {area: FakeLabel() for area in ["A", "B"]}
+        patches = {area: FakePatch() for area in subset_labels}
+        fake_venn_obj = types.SimpleNamespace(
+            get_label_by_id=lambda area: subset_labels.get(area, set_labels.get(area)),
+            get_patch_by_id=lambda area: patches.get(area),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "matplotlib_venn",
+            types.SimpleNamespace(venn2=lambda *args, **kwargs: fake_venn_obj),
+        )
+        return subset_labels, set_labels
+
+    subset_labels, set_labels = build_fake_venn_obj()
+    with cns.settings.context(legend_fontsize=13):
+        cns.figure(120, 120)
+        cns.vennplot([{1, 2}, {2, 3}], labels=["A", "B"])
+
+    assert {label.fontsize for label in subset_labels.values()} == {13}
+    assert {label.fontsize for label in set_labels.values()} == {13}
+
+    subset_labels, set_labels = build_fake_venn_obj()
+    with cns.settings.context(legend_fontsize=None, title_fontsize=12):
+        cns.figure(120, 120)
+        cns.vennplot([{1, 2}, {2, 3}], labels=["A", "B"])
+
+    assert {label.fontsize for label in subset_labels.values()} == {12}
+    assert {label.fontsize for label in set_labels.values()} == {12}

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -119,6 +119,36 @@ def test_barplot_and_lollipopplot(
     assert calls
 
 
+def test_categorical_annotations_use_legend_fontsize(
+    categorical_df: pd.DataFrame,
+) -> None:
+    with cns.settings.context(legend_fontsize=13):
+        cns.figure(120, 120)
+        bar_ax = cns.barplot(categorical_df, x="group", y="value", addtip=True)
+        assert {text.get_fontsize() for text in bar_ax.texts} == {13}
+
+        cns.figure(120, 120)
+        lollipop_ax = cns.lollipopplot(
+            categorical_df, x="group", y="value", addtip=True
+        )
+        assert {text.get_fontsize() for text in lollipop_ax.texts} == {13}
+
+        cns.figure(120, 120)
+        donut_ax = cns.donutplot(categorical_df, x="group")
+        center_label = next(
+            text for text in donut_ax.texts if text.get_text() == "group"
+        )
+        assert center_label.get_fontsize() == pytest.approx(13)
+
+    with cns.settings.context(legend_fontsize=None, title_fontsize=12):
+        cns.figure(120, 120)
+        donut_ax = cns.donutplot(categorical_df, x="group")
+        center_label = next(
+            text for text in donut_ax.texts if text.get_text() == "group"
+        )
+        assert center_label.get_fontsize() == pytest.approx(12)
+
+
 def test_stack_strip_pie_and_donut_plots(
     categorical_df: pd.DataFrame,
     stack_df: pd.DataFrame,
@@ -239,6 +269,27 @@ def test_distribution_wrappers(
     cns.figure(120, 120)
     ax6 = cns.qqplot(numeric_df, x="x")
     assert ax6 is plt.gca()
+
+
+def test_distribution_annotations_use_legend_fontsize(
+    numeric_df: pd.DataFrame,
+    categorical_df: pd.DataFrame,
+) -> None:
+    with cns.settings.context(legend_fontsize=13):
+        cns.figure(120, 120)
+        kde_ax = cns.kdeplot(numeric_df, x="x", add_mode=True)
+        assert kde_ax.texts
+        assert {text.get_fontsize() for text in kde_ax.texts} == {13}
+
+        cns.figure(120, 120)
+        ridge_ax = cns.ridgeplot(categorical_df, x="value", y="group")
+        assert {text.get_fontsize() for text in ridge_ax.texts} == {13}
+
+    with cns.settings.context(legend_fontsize=None, title_fontsize=12):
+        cns.figure(120, 120)
+        kde_ax = cns.kdeplot(numeric_df, x="x", add_mode=True)
+        assert kde_ax.texts
+        assert {text.get_fontsize() for text in kde_ax.texts} == {12}
 
 
 def test_pieplot_uses_legend_fontsize(categorical_df: pd.DataFrame) -> None:
@@ -441,3 +492,17 @@ def test_sets_and_specialized_plots(
     cns.figure(120, 120)
     ax3 = cns.rocplot(roc_df, "truth", ["model_a", "model_b"])
     assert len(ax3.lines) == 3
+
+
+def test_sankey_annotations_use_legend_fontsize(sankey_df: pd.DataFrame) -> None:
+    with cns.settings.context(legend_fontsize=13):
+        cns.figure(120, 120)
+        ax = cns.sankeyplot(sankey_df, x="source", y="target")
+        assert ax.texts
+        assert {text.get_fontsize() for text in ax.texts} == {13}
+
+    with cns.settings.context(legend_fontsize=None, title_fontsize=12):
+        cns.figure(120, 120)
+        ax = cns.sankeyplot(sankey_df, x="source", y="target")
+        assert ax.texts
+        assert {text.get_fontsize() for text in ax.texts} == {12}


### PR DESCRIPTION
## What changed
- Replaced remaining hard-coded helper annotation font sizes with `cns.settings.legend_fontsize` fallbacks across plot helpers.
- Kept `heatmapplot` and `dotplot` tick-label defaults unchanged.
- Added focused tests for configured `legend_fontsize` and `title_fontsize` fallback behavior.

## How tested
- `make test`
- `make lint`

## Risks or follow-ups
- Low risk; visual label sizes now change when users configure `legend_fontsize`.