### PR TITLE
✨ Add configurable CIF censor marks

### DIFF
--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 import logging
-from typing import TYPE_CHECKING, Any
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from matplotlib.axes import Axes
     import numpy as np
     import pandas as pd
+    from matplotlib.axes import Axes
 
 import matplotlib.pyplot as plt
 import num2tex
@@ -26,6 +26,87 @@ from cnsplots._validation import (
 )
 
 logger = logging.getLogger(__name__)
+
+CensorMarkPosition = Literal["line", "above", "below", "none"]
+VisibleCensorMarkPosition = Literal["line", "above", "below"]
+
+_CIF_Y_LIMITS = (-0.05, 1.01)
+_DEFAULT_CENSOR_MARK_LENGTH = 0.02
+_CENSOR_MARK_POSITIONS = ("line", "above", "below", "none")
+
+
+def _format_valid_censor_mark_positions() -> str:
+    return "', '".join(_CENSOR_MARK_POSITIONS)
+
+
+def _validate_censor_mark_position(
+    censor_mark_position: CensorMarkPosition | list[CensorMarkPosition],
+    hue_order: Sequence[Any],
+) -> None:
+    valid_positions = _format_valid_censor_mark_positions()
+    if isinstance(censor_mark_position, str):
+        if censor_mark_position not in _CENSOR_MARK_POSITIONS:
+            raise ValueError(
+                "[cumulativeincidenceplot] Parameter 'censor_mark_position' must be one "
+                f"of '{valid_positions}', got {censor_mark_position!r}"
+            )
+        return
+
+    if not isinstance(censor_mark_position, list):
+        raise TypeError(
+            "[cumulativeincidenceplot] Parameter 'censor_mark_position' must be a "
+            "string position or a list of positions"
+        )
+
+    if len(censor_mark_position) != len(hue_order):
+        raise ValueError(
+            "[cumulativeincidenceplot] Parameter 'censor_mark_position' must provide "
+            "one position per hue_order group when passing a list, got "
+            f"{len(censor_mark_position)} position(s) for {len(hue_order)} group(s)"
+        )
+
+    invalid_positions = {
+        index: position
+        for index, position in enumerate(censor_mark_position)
+        if position not in _CENSOR_MARK_POSITIONS
+    }
+    if invalid_positions:
+        raise ValueError(
+            "[cumulativeincidenceplot] Parameter 'censor_mark_position' contains "
+            f"invalid position(s) {invalid_positions!r}. Values must be one of "
+            f"'{valid_positions}'"
+        )
+
+
+def _resolve_censor_mark_position(
+    censor_mark_position: CensorMarkPosition | list[CensorMarkPosition],
+    group_index: int,
+) -> CensorMarkPosition:
+    if isinstance(censor_mark_position, str):
+        return censor_mark_position
+    return censor_mark_position[group_index]
+
+
+def _censor_mark_extents(
+    censor_y: np.ndarray,
+    position: VisibleCensorMarkPosition,
+    length: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    if position == "line":
+        offset = length / 2
+        ymin = censor_y - offset
+        ymax = censor_y + offset
+    elif position == "above":
+        ymin = censor_y
+        ymax = censor_y + length
+    else:
+        ymin = censor_y - length
+        ymax = censor_y
+
+    return (
+        np.clip(ymin, _CIF_Y_LIMITS[0], _CIF_Y_LIMITS[1]),
+        np.clip(ymax, _CIF_Y_LIMITS[0], _CIF_Y_LIMITS[1]),
+    )
 
 
 def survivalplot(
@@ -200,6 +281,8 @@ def cumulativeincidenceplot(
     risk_table_rows: tuple[str, ...] = ("At risk",),
     risk_table_ypos: float = -0.2,
     xticks: np.ndarray | Sequence[int | float] | None = None,
+    censor_mark_position: CensorMarkPosition | list[CensorMarkPosition] = "line",
+    censor_mark_length: float = _DEFAULT_CENSOR_MARK_LENGTH,
 ) -> Axes:
     """
     Create a cumulative incidence plot for competing risks analysis.
@@ -231,6 +314,16 @@ def cumulativeincidenceplot(
         Vertical position of the risk table relative to the plot.
     xticks : array-like, optional
         Specific x-axis tick positions.
+    censor_mark_position : {'line', 'above', 'below', 'none'} or list, default: 'line'
+        Where to draw censoring marks relative to each cumulative incidence curve.
+        ``'line'`` draws short vertical marks crossing the curve, ``'above'`` draws
+        marks from the curve upward, ``'below'`` draws marks up to the curve, and
+        ``'none'`` hides censoring marks. Pass a list with one value per hue group
+        to control groups separately, for example
+        ``['above', 'none', 'below']`` for ``hue_order=['A', 'B', 'C']``.
+    censor_mark_length : float, default: 0.02
+        Length of each vertical censoring mark in cumulative-incidence probability
+        units. The same length is used for all curves.
 
     Returns
     -------
@@ -277,12 +370,19 @@ def cumulativeincidenceplot(
     # Validate sufficient data
     validate_sufficient_data(data, duration, 2, "cumulativeincidenceplot")
 
+    if censor_mark_length < 0:
+        raise ValueError(
+            "[cumulativeincidenceplot] Parameter 'censor_mark_length' must be "
+            f"non-negative, got {censor_mark_length!r}"
+        )
+
     import lifelines as ll
     from lifelines.plotting import add_at_risk_counts
 
     ax: Any = None
     if hue_order is None or set(data[hue].unique()) != set(hue_order):
         hue_order = list(data[hue].unique())
+    _validate_censor_mark_position(censor_mark_position, hue_order)
     data[hue] = pd.Categorical(data[hue], categories=hue_order, ordered=True)
     data = data.sort_values(hue)
     fitters = []
@@ -307,9 +407,27 @@ def cumulativeincidenceplot(
         else:
             ax = fitter.plot(ax=ax, linewidth=1, ci_show=False)
         line_color = ax.get_lines()[-1].get_color()
-        ax.plot(df[duration], df["CIF_1"], "+", markersize=3, color=line_color)
+        group_censor_mark_position = _resolve_censor_mark_position(
+            censor_mark_position, i
+        )
+        if group_censor_mark_position != "none":
+            censor_df = df[[duration, "CIF_1"]].dropna()
+            if not censor_df.empty:
+                censor_y = censor_df["CIF_1"].to_numpy(dtype=float)
+                ymin, ymax = _censor_mark_extents(
+                    censor_y,
+                    group_censor_mark_position,
+                    censor_mark_length,
+                )
+                ax.vlines(
+                    censor_df[duration],
+                    ymin,
+                    ymax,
+                    colors=line_color,
+                    linewidth=1,
+                )
     assert ax is not None
-    ax.set_ylim(-0.05, 1.01)
+    ax.set_ylim(_CIF_Y_LIMITS)
     ax.set_ylabel("Cumulative incidence probability")
     ax.set_xlabel("Time (Years)")
     specified_xticks = None

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 import types
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import anndata as ad
 import matplotlib.pyplot as plt
@@ -12,6 +12,8 @@ import pandas as pd
 import pytest
 from matplotlib.axes import Axes
 from matplotlib.colorbar import Colorbar
+from matplotlib.collections import LineCollection
+from matplotlib.colors import to_rgba
 from matplotlib.legend import Legend
 
 import cnsplots as cns
@@ -32,6 +34,22 @@ def _linked_colorbar(ax: Axes) -> Colorbar | None:
         if isinstance(colorbar, Colorbar):
             return colorbar
     return None
+
+
+def _censor_mark_collections(ax: Axes) -> list[LineCollection]:
+    return [
+        collection
+        for collection in ax.collections
+        if isinstance(collection, LineCollection)
+    ]
+
+
+def _line_y_at_x(line: Any, x: float) -> float:
+    xdata = np.asarray(line.get_xdata(), dtype=float)
+    ydata = np.asarray(line.get_ydata(), dtype=float)
+    matches = np.flatnonzero(np.isclose(xdata, x))
+    assert matches.size > 0
+    return float(ydata[matches[-1]])
 
 
 def _relative_axes_bounds(
@@ -160,6 +178,156 @@ def test_survival_plots(
     single_group = competing_risk_df[competing_risk_df["group"] == "A"].copy()
     ax4 = cns.cumulativeincidenceplot(single_group, "time", "event", "group")
     assert ax4 is plt.gca()
+
+
+@pytest.mark.parametrize(
+    ("position", "lower_delta", "upper_delta"),
+    [
+        ("line", -0.01, 0.01),
+        ("above", 0.0, 0.02),
+        ("below", -0.02, 0.0),
+    ],
+)
+def test_cumulativeincidenceplot_censor_mark_positions(
+    competing_risk_df: pd.DataFrame,
+    position: Literal["line", "above", "below"],
+    lower_delta: float,
+    upper_delta: float,
+) -> None:
+    cns.figure(120, 120)
+    ax = cns.cumulativeincidenceplot(
+        competing_risk_df,
+        "time",
+        "event",
+        "group",
+        censor_mark_position=position,
+    )
+
+    curve_lines = ax.get_lines()
+    censor_collections = _censor_mark_collections(ax)
+
+    assert len(curve_lines) == 2
+    assert len(censor_collections) == 2
+
+    for line, collection in zip(curve_lines, censor_collections, strict=True):
+        assert collection.get_colors()[0] == pytest.approx(to_rgba(line.get_color()))
+        assert len(collection.get_segments()) == 2
+
+        for segment in collection.get_segments():
+            x = float(segment[0, 0])
+            y0 = float(segment[0, 1])
+            y1 = float(segment[1, 1])
+            curve_y = _line_y_at_x(line, x)
+
+            assert segment[1, 0] == pytest.approx(x)
+            assert y0 == pytest.approx(curve_y + lower_delta)
+            assert y1 == pytest.approx(curve_y + upper_delta)
+
+
+def test_cumulativeincidenceplot_censor_marks_can_be_hidden(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    cns.figure(120, 120)
+    ax = cns.cumulativeincidenceplot(
+        competing_risk_df,
+        "time",
+        "event",
+        "group",
+        censor_mark_position="none",
+    )
+
+    assert len(ax.get_lines()) == 2
+    assert _censor_mark_collections(ax) == []
+
+
+def test_cumulativeincidenceplot_censor_mark_positions_by_hue_order(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    group_c = competing_risk_df[competing_risk_df["group"] == "A"].copy()
+    group_c["group"] = "C"
+    three_group_df = pd.concat([competing_risk_df, group_c], ignore_index=True)
+
+    cns.figure(120, 120)
+    ax = cns.cumulativeincidenceplot(
+        three_group_df,
+        "time",
+        "event",
+        "group",
+        hue_order=["A", "B", "C"],
+        censor_mark_position=["above", "none", "below"],
+        censor_mark_length=0.04,
+    )
+
+    curve_lines = ax.get_lines()
+    censor_collections = _censor_mark_collections(ax)
+
+    assert len(curve_lines) == 3
+    assert len(censor_collections) == 2
+
+    expected_marks = [
+        (curve_lines[0], censor_collections[0], 0.0, 0.04),
+        (curve_lines[2], censor_collections[1], -0.04, 0.0),
+    ]
+    for line, collection, lower_delta, upper_delta in expected_marks:
+        assert collection.get_colors()[0] == pytest.approx(to_rgba(line.get_color()))
+        assert len(collection.get_segments()) == 2
+
+        for segment in collection.get_segments():
+            x = float(segment[0, 0])
+            curve_y = _line_y_at_x(line, x)
+            assert segment[0, 1] == pytest.approx(curve_y + lower_delta)
+            assert segment[1, 1] == pytest.approx(curve_y + upper_delta)
+
+
+def test_cumulativeincidenceplot_invalid_censor_mark_position_raises(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    cumulativeincidenceplot = cast(Any, cns.cumulativeincidenceplot)
+
+    with pytest.raises(ValueError, match="censor_mark_position"):
+        cumulativeincidenceplot(
+            competing_risk_df,
+            "time",
+            "event",
+            "group",
+            censor_mark_position="middle",
+        )
+
+    with pytest.raises(ValueError, match="invalid position"):
+        cumulativeincidenceplot(
+            competing_risk_df,
+            "time",
+            "event",
+            "group",
+            censor_mark_position=["above", "middle"],
+        )
+
+    with pytest.raises(ValueError, match="one position per hue_order group"):
+        cumulativeincidenceplot(
+            competing_risk_df,
+            "time",
+            "event",
+            "group",
+            censor_mark_position=["above"],
+        )
+
+    with pytest.raises(TypeError, match="string position or a list"):
+        cumulativeincidenceplot(
+            competing_risk_df,
+            "time",
+            "event",
+            "group",
+            censor_mark_position={"A": "above"},
+        )
+
+    with pytest.raises(ValueError, match="censor_mark_length"):
+        cumulativeincidenceplot(
+            competing_risk_df,
+            "time",
+            "event",
+            "group",
+            censor_mark_length=-0.01,
+        )
 
 
 def test_confusionplot_metrics_and_errors(confusion_df: pd.DataFrame) -> None:


### PR DESCRIPTION
## What changed
- Add `censor_mark_position` to cumulative incidence plots with `line`, `above`, `below`, and `none` options.
- Allow per-group censor mark positions with a list matched to `hue_order`.
- Add `censor_mark_length` as one shared scalar length for all curves.
- Replace plus markers with vertical censor mark segments that retain each curve color.

## How it was tested
- `make lint`
- `make test` 133 passed, 100% coverage

## Risks or follow-ups
- Default censor marks now render as vertical line segments instead of plus markers.