### PR TITLE
🐛 Correct statistical and plotting bugs

### DIFF
--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -15,6 +15,9 @@ import pandas as pd
 import patsy
 import sklearn as skl
 from sklearn.linear_model import LogisticRegressionCV
+from sklearn.model_selection import cross_val_predict
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
 
 
 class CoxModel:
@@ -325,22 +328,22 @@ class LogisticModel:
         Returns
         -------
         tuple of float
-            (auc_mean, lower_bound, upper_bound)
+            (auc_median, lower_bound, upper_bound)
         """
         aucs = []
-        np.random.seed(42)
+        rng = np.random.default_rng(42)
         n = len(y_true)
         for _ in range(n_bootstrap):
-            indices = np.random.choice(n, n, replace=True)
+            indices = rng.choice(n, n, replace=True)
             if len(np.unique(y_true[indices])) < 2:
                 continue
             auc = skl.metrics.roc_auc_score(y_true[indices], y_pred_proba[indices])
             aucs.append(auc)
         aucs = np.array(aucs)
-        auc_mean = skl.metrics.roc_auc_score(y_true, y_pred_proba)
+        auc_median = np.median(aucs)
         lower = np.percentile(aucs, 100 * alpha / 2)
         upper = np.percentile(aucs, 100 * (1 - alpha / 2))
-        return auc_mean, float(lower), float(upper)
+        return float(auc_median), float(lower), float(upper)
 
     def fit(self) -> None:
         """
@@ -366,8 +369,9 @@ class LogisticModel:
 
         For each model:
         1. Design matrix is created using Patsy (supports formulas)
-        2. LogisticRegressionCV fits with L1 penalty and 5-fold CV
-        3. AUC and 95% CI are computed via bootstrap (1000 iterations)
+        2. Predictors are standardized within each cross-validation fold
+        3. LogisticRegressionCV fits with L1 penalty and 5-fold CV
+        4. AUC and 95% CI are computed from out-of-fold predictions via bootstrap
 
         Runtime warnings are emitted for hue groups with no outcome variance.
         Errors during fitting are caught and surfaced as warnings.
@@ -388,16 +392,19 @@ class LogisticModel:
                 )
                 y = df[self.event].values
 
-                model = LogisticRegressionCV(
-                    cv=5,
-                    penalty="l1",
-                    solver="liblinear",
-                    random_state=42,
-                    scoring="roc_auc",
+                model = make_pipeline(
+                    StandardScaler(),
+                    LogisticRegressionCV(
+                        cv=5,
+                        penalty="l1",
+                        solver="liblinear",
+                        random_state=42,
+                        scoring="roc_auc",
+                    ),
                 )
-                model.fit(X, y)
-
-                y_pred_proba = model.predict_proba(X)[:, 1]
+                y_pred_proba = cross_val_predict(
+                    model, X, y, cv=5, method="predict_proba"
+                )[:, 1]
                 auc, auc_lower, auc_upper = self._compute_auc_ci(y, y_pred_proba)
 
                 model_result = {
@@ -426,15 +433,19 @@ class LogisticModel:
                                 stacklevel=2,
                             )
                             continue
-                        model = LogisticRegressionCV(
-                            cv=5,
-                            penalty="l1",
-                            solver="liblinear",
-                            random_state=42,
-                            scoring="roc_auc",
+                        model = make_pipeline(
+                            StandardScaler(),
+                            LogisticRegressionCV(
+                                cv=5,
+                                penalty="l1",
+                                solver="liblinear",
+                                random_state=42,
+                                scoring="roc_auc",
+                            ),
                         )
-                        model.fit(X, y)
-                        y_pred_proba = model.predict_proba(X)[:, 1]
+                        y_pred_proba = cross_val_predict(
+                            model, X, y, cv=5, method="predict_proba"
+                        )[:, 1]
                         auc, auc_lower, auc_upper = self._compute_auc_ci(
                             y, y_pred_proba
                         )

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -509,7 +509,7 @@ def _is_qualitative_cmap(cmap_name):
 
 
 def _get_hex_colors_from_colorbar(cmap_name, n_colors):
-    cmap = plt.cm.get_cmap(cmap_name)
+    cmap = mpl.colormaps[cmap_name]
     if _is_qualitative_cmap(cmap_name):
         colors = [mcolors.to_hex(cmap(i)) for i in range(0, n_colors)]
     else:
@@ -1462,4 +1462,4 @@ def palettes(color):
             ]
             return mpl.colors.LinearSegmentedColormap.from_list("parula", cm_data)
         else:
-            return RuntimeError("Wrong Choice!")
+            raise RuntimeError("Wrong Choice!")

--- a/src/cnsplots/helpers/_phylo.py
+++ b/src/cnsplots/helpers/_phylo.py
@@ -174,6 +174,8 @@ def _heatmap(
 
     if isinstance(data, pd.DataFrame):
         numerical_data = data.applymap(mapper)
+    elif isinstance(data, pd.Series):
+        numerical_data = data.map(mapper).to_frame()
     elif isinstance(data, np.ndarray):
         numerical_data = vfunc(data)
 

--- a/src/cnsplots/helpers/_sankey.py
+++ b/src/cnsplots/helpers/_sankey.py
@@ -408,7 +408,7 @@ def _get_positions_and_total_widths(
             weighted_sum = 0.02 * df[side + "Weight"].sum()
             label_widths["bottom"] = bottom_width + weighted_sum
             label_widths["top"] = label_widths["bottom"] + label_widths[side]
-            topEdge = label_widths["top"]
+        topEdge = label_widths["top"]
         widths[label] = label_widths
 
     return widths, topEdge

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -386,7 +386,7 @@ def kdeplot(data: pd.DataFrame, x: str, add_mode: bool = True, **kwargs: Any) ->
                 ha="right",
                 va="top",
             )
-            logger.info("P-value was determined by Anderson-Darling test.")
+            logger.info("P-value was determined by two-sided Kolmogorov-Smirnov test.")
     else:
         if add_mode and ax.get_lines():
             kde_data = ax.get_lines()[-1].get_data()

--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -261,7 +261,8 @@ def gseaplot(
     cbar_ax.yaxis.labelpad = 1
     cbar_ax.set_ylabel("")
     legend = ax.get_legend()
-    assert legend is not None
+    if legend is None:
+        raise RuntimeError("[gseaplot] GSEA plot did not produce a legend")
     handles = [h for h in legend.legend_handles if h is not None]
     labels = [t.get_text() for t in legend.get_texts()]
     title = legend.get_title().get_text()

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -279,7 +279,7 @@ def heatmapplot(
     col_split_val: Any = col_split
     if row_split is not None and not isinstance(row_split, int):
         row_split_val = adata.obs[row_split]
-    if col_split is not None and not isinstance(row_split, int):
+    if col_split is not None and not isinstance(col_split, int):
         col_split_val = adata.var[col_split]
 
     df = adata.to_df() if layer is None else adata.to_df(layer=layer)

--- a/src/cnsplots/plots/_regression.py
+++ b/src/cnsplots/plots/_regression.py
@@ -110,7 +110,7 @@ def regplot(
                 x=x,
                 y=y,
                 ax=ax,
-                color=palette[idx],
+                color=palette[idx % len(palette)],
                 label=hue_val,
                 **args,
             )
@@ -120,7 +120,7 @@ def regplot(
                 0.95 - 0.08 * idx,
                 rf"{hue_val}: $\rho$={rho:.2f},"
                 rf" P=${num2tex.num2tex(p_value, precision=2):.2g}$",
-                color=palette[idx],
+                color=palette[idx % len(palette)],
                 transform=ax.transAxes,
                 ha="left",
                 va="top",

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -176,6 +176,7 @@ def survivalplot(
     import lifelines as ll
     from lifelines.statistics import multivariate_logrank_test
 
+    data = data.copy()
     ax: Any = None
     if hue_order is None or set(data[hue].unique()) != set(hue_order):
         hue_order = list(data[hue].unique())
@@ -379,6 +380,7 @@ def cumulativeincidenceplot(
     import lifelines as ll
     from lifelines.plotting import add_at_risk_counts
 
+    data = data.copy()
     ax: Any = None
     if hue_order is None or set(data[hue].unique()) != set(hue_order):
         hue_order = list(data[hue].unique())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1216,9 +1216,9 @@ def test_utils_helpers_and_showcase_data(
     assert len(_utils.palettes("Nature")) == 10
     assert len(_utils.palettes("Science")) == 10
     assert _utils.palettes("BuRd_custom").name == "BuRd_custom"
-    assert isinstance(_utils.palettes("NPG"), RuntimeError)
-    assert isinstance(_utils.palettes("AAAS"), RuntimeError)
-    assert isinstance(_utils.palettes("Wrong Choice!"), RuntimeError)
+    for invalid_palette in ["NPG", "AAAS", "Wrong Choice!"]:
+        with pytest.raises(RuntimeError, match="Wrong Choice!"):
+            _utils.palettes(invalid_palette)
 
     fake_sns = types.SimpleNamespace(
         load_dataset=lambda name: (

--- a/tests/test_crash_regressions.py
+++ b/tests/test_crash_regressions.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import anndata as ad
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+import cnsplots as cns
+from cnsplots.helpers import _phylo, _sankey
+
+
+def test_heatmapplot_accepts_integer_col_split() -> None:
+    adata = ad.AnnData(
+        np.array([[1.0, 2.0], [3.0, 4.0]]),
+        var=pd.DataFrame(index=pd.Index(["gene_a", "gene_b"])),
+    )
+
+    plotter = cns.heatmapplot(adata, col_split=1, col_cluster=False)
+
+    assert plotter.col_split == 1
+
+
+def test_categorical_heatmap_accepts_series() -> None:
+    fig, ax = plt.subplots()
+
+    result_ax, cmap = _phylo._heatmap(pd.Series(["A", "B"]), ax=ax)
+
+    assert result_ax is ax
+    assert set(cmap) == {"A", "B"}
+
+
+def test_sankeyplot_accepts_one_label_per_side() -> None:
+    fig, ax = plt.subplots()
+
+    result_ax = _sankey.sankeyplot(["A", "A"], np.array(["B", "B"]), ax=ax)
+
+    assert result_ax is ax
+    assert len(ax.texts) == 2

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -1,0 +1,102 @@
+"""Regression tests for statistical model correctness."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.linear_model import LogisticRegressionCV
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+import cnsplots as cns
+from cnsplots import _methods
+
+
+def test_auc_ci_uses_bootstrap_median_without_changing_global_rng(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeGenerator:
+        def __init__(self) -> None:
+            self.samples = iter(
+                [
+                    np.array([0, 0, 0, 0]),
+                    np.array([1, 1, 2, 3]),
+                    np.array([1, 1, 2, 3]),
+                ]
+            )
+
+        def choice(self, n: int, size: int, replace: bool) -> np.ndarray:
+            assert (n, size, replace) == (4, 4, True)
+            return next(self.samples)
+
+    def fake_default_rng(seed: int) -> FakeGenerator:
+        assert seed == 42
+        return FakeGenerator()
+
+    monkeypatch.setattr(_methods.np.random, "default_rng", fake_default_rng)
+    model = cns.LogisticModel(
+        pd.DataFrame({"event": [0, 0, 1, 1]}), event="event", variates=["1"]
+    )
+    rng_state_before = repr(np.random.get_state())
+
+    auc, lower, upper = model._compute_auc_ci(
+        np.array([0, 0, 1, 1]),
+        np.array([0.1, 0.9, 0.8, 0.7]),
+        n_bootstrap=3,
+    )
+
+    rng_state_after = repr(np.random.get_state())
+    assert (auc, lower, upper) == (0.0, 0.0, 0.0)
+    assert rng_state_before == rng_state_after
+
+
+@pytest.mark.parametrize("hue", [None, "group"])
+def test_logistic_model_uses_scaled_out_of_fold_predictions(
+    monkeypatch: pytest.MonkeyPatch, hue: str | None
+) -> None:
+    data = pd.DataFrame(
+        {
+            "event": [0, 1] * 10,
+            "score": np.arange(20, dtype=float),
+            "group": ["A"] * 10 + ["B"] * 10,
+        }
+    )
+    seen_estimators: list[Pipeline] = []
+
+    def fake_cross_val_predict(
+        estimator: Pipeline,
+        X: pd.DataFrame,
+        y: np.ndarray,
+        *,
+        cv: int,
+        method: str,
+        **kwargs: Any,
+    ) -> np.ndarray:
+        assert cv == 5
+        assert method == "predict_proba"
+        assert kwargs == {}
+        seen_estimators.append(estimator)
+        probabilities = np.linspace(0.1, 0.9, len(y))
+        return np.column_stack((1 - probabilities, probabilities))
+
+    monkeypatch.setattr(_methods, "cross_val_predict", fake_cross_val_predict)
+    monkeypatch.setattr(
+        cns.LogisticModel,
+        "_compute_auc_ci",
+        lambda self, y, predictions: (0.5, 0.4, 0.6),
+    )
+
+    model = cns.LogisticModel(data, event="event", variates=["score"], hue=hue)
+    model.fit()
+
+    assert len(seen_estimators) == (1 if hue is None else 2)
+    for estimator in seen_estimators:
+        scaler, classifier = (step for _, step in estimator.steps)
+        assert isinstance(scaler, StandardScaler)
+        assert isinstance(classifier, LogisticRegressionCV)
+        assert classifier.penalty == "l1"
+        assert classifier.solver == "liblinear"
+        assert classifier.cv == 5

--- a/tests/test_plot_behavior_regressions.py
+++ b/tests/test_plot_behavior_regressions.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+def test_survival_plots_do_not_mutate_input_dataframes(
+    survival_df: pd.DataFrame,
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    survival_original = survival_df.copy(deep=True)
+    cns.figure(120, 120)
+    cns.survivalplot(survival_df, "time", "event", "group")
+    pd.testing.assert_frame_equal(survival_df, survival_original)
+
+    competing_risk_original = competing_risk_df.copy(deep=True)
+    cns.figure(120, 120)
+    cns.cumulativeincidenceplot(competing_risk_df, "time", "event", "group")
+    pd.testing.assert_frame_equal(competing_risk_df, competing_risk_original)
+
+
+def test_regplot_cycles_colors_when_hue_exceeds_palette() -> None:
+    palette_size = len(plt.rcParams["axes.prop_cycle"].by_key()["color"])
+    group_count = palette_size + 1
+    values_per_group = 4
+    data = pd.DataFrame(
+        {
+            "x": np.tile([0.0, 1.0, 2.0, 3.0], group_count),
+            "y": np.tile([0.0, 1.2, 1.8, 3.2], group_count)
+            + np.repeat(np.arange(group_count), values_per_group),
+            "group": np.repeat(
+                [f"group_{index}" for index in range(group_count)], values_per_group
+            ),
+        }
+    )
+
+    cns.figure(120, 120)
+    ax = cns.regplot(data, x="x", y="y", hue="group")
+
+    assert len(ax.texts) == group_count
+    assert ax.texts[0].get_color() == ax.texts[palette_size].get_color()
+
+
+def test_gseaplot_raises_when_backend_does_not_create_legend(
+    monkeypatch: pytest.MonkeyPatch,
+    gsea_plot_df: pd.DataFrame,
+) -> None:
+    fake_gseapy = types.SimpleNamespace(dotplot=lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "gseapy", fake_gseapy)
+
+    cns.figure(120, 120)
+    with pytest.raises(RuntimeError, match="did not produce a legend"):
+        cns.gseaplot(gsea_plot_df, y="Clean_Term")

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -256,7 +256,7 @@ def test_distribution_wrappers(
             categorical_df.rename(columns={"value": "score"}), x="score", hue="hue"
         )
     assert ax3.get_legend() is not None
-    assert "Anderson-Darling test" in caplog.text
+    assert "Kolmogorov-Smirnov test" in caplog.text
 
     cns.figure(120, 120)
     ax4 = cns.histplot(data=numeric_df, x="x", kde=True)
@@ -338,13 +338,13 @@ def test_distribution_logging_respects_settings_verbosity(
         caplog.clear()
         cns.figure(120, 120)
         cns.kdeplot(data, x="score", hue="hue")
-        assert "Anderson-Darling test" not in caplog.text
+        assert "Kolmogorov-Smirnov test" not in caplog.text
 
     with cns.settings.context(verbosity=1):
         caplog.clear()
         cns.figure(120, 120)
         cns.kdeplot(data, x="score", hue="hue")
-        assert "Anderson-Darling test" in caplog.text
+        assert "Kolmogorov-Smirnov test" in caplog.text
 
 
 def test_line_scatter_reg_and_slope_plots(


### PR DESCRIPTION
## What changed

- Calculate LogisticModel AUC from standardized out-of-fold predictions with coherent bootstrap confidence bounds and an isolated random generator.
- Fix palette, heatmap, phylo, Sankey, survival, KDE, regression, and legend error-handling edge cases.
- Add focused regression coverage for statistical correctness, caller-data preservation, and valid plotting inputs.

## Testing

- make test — 143 passed with 100% coverage
- make lint — all lint, formatting, type, and repository checks passed

## Risks and follow-ups

- LogisticModel now performs nested cross-validation, which increases fitting time in exchange for honest out-of-fold scoring.
- No public API changes or known follow-ups.