### PR TITLE
✅ Strengthen plotting correctness coverage

### DIFF
--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -14,7 +14,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
-from matplotlib.patches import PathPatch
+from matplotlib.collections import PathCollection, QuadMesh
+from matplotlib.patches import PathPatch, Wedge
 
 import cnsplots as cns
 from cnsplots import _methods, _setup, _svg, _utils, _validation
@@ -761,10 +762,27 @@ def test_plot_internal_coverage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cns.figure(120, 120)
-    cns.lollipopplot(categorical_df, x="group", y="value", addtip=True, errorbar="bad")
+    lollipop_ax = cns.lollipopplot(
+        categorical_df, x="group", y="value", addtip=True, errorbar="bad"
+    )
+    lollipop_points = [
+        collection
+        for collection in lollipop_ax.collections
+        if isinstance(collection, PathCollection)
+    ]
+    assert len(lollipop_points) == 1
+    np.testing.assert_allclose(
+        np.asarray(lollipop_points[0].get_offsets(), dtype=float),
+        [[0, 1.2], [1, 2.15], [2, 3.15]],
+    )
+    assert [text.get_text() for text in lollipop_ax.texts] == [
+        "1.20",
+        "2.15",
+        "3.15",
+    ]
 
     cns.figure(120, 120)
-    cns.lollipopplot(
+    grouped_lollipop_ax = cns.lollipopplot(
         categorical_df,
         x="group",
         y="value",
@@ -774,9 +792,23 @@ def test_plot_internal_coverage(
         hue_order=["H1", "H2"],
         pairs=[(("A", "H1"), ("A", "H2"))],
     )
+    grouped_lollipop_points = [
+        collection
+        for collection in grouped_lollipop_ax.collections
+        if isinstance(collection, PathCollection)
+    ]
+    assert len(grouped_lollipop_points) == 2
+    np.testing.assert_allclose(
+        np.asarray(grouped_lollipop_points[0].get_offsets(), dtype=float),
+        [[-0.2, 1.15], [0.8, 2.1], [1.8, 3.05]],
+    )
+    np.testing.assert_allclose(
+        np.asarray(grouped_lollipop_points[1].get_offsets(), dtype=float),
+        [[0.2, 1.25], [1.2, 2.2], [2.2, 3.25]],
+    )
 
     cns.figure(120, 120)
-    cns.lollipopplot(
+    horizontal_lollipop_ax = cns.lollipopplot(
         categorical_df.rename(columns={"group": "cat", "value": "num"}),
         x="num",
         y="cat",
@@ -784,17 +816,46 @@ def test_plot_internal_coverage(
         addtip=True,
         errorbar="se",
     )
+    horizontal_lollipop_points = [
+        collection
+        for collection in horizontal_lollipop_ax.collections
+        if isinstance(collection, PathCollection)
+    ]
+    assert len(horizontal_lollipop_points) == 2
+    np.testing.assert_allclose(
+        np.asarray(horizontal_lollipop_points[0].get_offsets(), dtype=float),
+        [[1.15, -0.2], [2.1, 0.8], [3.05, 1.8]],
+    )
+    np.testing.assert_allclose(
+        np.asarray(horizontal_lollipop_points[1].get_offsets(), dtype=float),
+        [[1.25, 0.2], [2.2, 1.2], [3.25, 2.2]],
+    )
+    assert [text.get_text() for text in horizontal_lollipop_ax.texts] == [
+        "1.15",
+        "2.10",
+        "3.05",
+        "1.25",
+        "2.20",
+        "3.25",
+    ]
 
     cns.figure(120, 120)
-    cns.stackplot(
+    stack_ax = cns.stackplot(
         stack_df,
         x="treatment",
         y="response",
         horizontal=True,
         normalize=True,
         addcount=True,
-        bar_order=["A", "B", "C"],
+        bar_order=["Yes", "No"],
     )
+    assert [patch.get_width() for patch in stack_ax.patches] == pytest.approx(
+        [1 / 3] * 6
+    )
+    assert [tick.get_text() for tick in stack_ax.get_yticklabels()] == [
+        "Yes\n(n=6)",
+        "No\n(n=6)",
+    ]
 
     class SizeHandle:
         def __init__(self) -> None:
@@ -812,48 +873,126 @@ def test_plot_internal_coverage(
     )
 
     cns.figure(120, 120)
-    cns.stripplot(categorical_df, x="group", y="value", hue="hue")
+    strip_ax = cns.stripplot(categorical_df, x="group", y="value", hue="hue")
+    strip_points = [
+        collection
+        for collection in strip_ax.collections
+        if isinstance(collection, PathCollection)
+    ]
+    np.testing.assert_allclose(
+        np.sort(
+            np.concatenate(
+                [
+                    np.asarray(points.get_offsets(), dtype=float)[:, 1]
+                    for points in strip_points
+                ]
+            )
+        ),
+        np.sort(categorical_df["value"].to_numpy()),
+    )
+    assert fake_legend.legend_handles[0].sizes == [4]
+
     cns.figure(120, 120)
-    cns.scatterplot(
-        categorical_df.rename(columns={"value": "x"}).assign(y=lambda df: df["x"] * 2),
+    scatter_data = categorical_df.rename(columns={"value": "x"}).assign(
+        y=lambda df: df["x"] * 2
+    )
+    scatter_ax = cns.scatterplot(
+        scatter_data,
         x="x",
         y="y",
         hue="hue",
     )
+    scatter_points = [
+        collection
+        for collection in scatter_ax.collections
+        if isinstance(collection, PathCollection)
+    ]
+    assert len(scatter_points) == 1
+    np.testing.assert_allclose(
+        np.asarray(scatter_points[0].get_offsets(), dtype=float),
+        scatter_data[["x", "y"]].to_numpy(),
+    )
+    assert fake_legend.legend_handles[0].sizes == [7]
+
     cns.figure(120, 120)
-    cns.regplot(
-        categorical_df.rename(columns={"value": "x"}).assign(
-            y=lambda df: df["x"] * 2, color_col=["A"] * 12
-        ),
+    regression_data = scatter_data.assign(color_col=["A"] * 12)
+    regression_ax = cns.regplot(
+        regression_data,
         x="x",
         y="y",
         color="color_col",
     )
+    regression_points = [
+        collection
+        for collection in regression_ax.collections
+        if isinstance(collection, PathCollection)
+    ]
+    assert len(regression_points) == 1
+    np.testing.assert_allclose(
+        np.asarray(regression_points[0].get_offsets(), dtype=float),
+        regression_data[["x", "y"]].to_numpy(),
+    )
+    np.testing.assert_allclose(
+        np.asarray(regression_ax.lines[0].get_ydata(), dtype=float),
+        2 * np.asarray(regression_ax.lines[0].get_xdata(), dtype=float),
+    )
+    assert [text.get_text() for text in regression_ax.texts] == [r"$\rho$=1.00, $P=0$"]
+    assert fake_legend.legend_handles[0].sizes == [6]
 
     monkeypatch.undo()
 
     cns.figure(120, 120)
-    cns.pieplot(categorical_df, x="group")
+    pie_ax = cns.pieplot(categorical_df, x="group")
+    pie_wedges = [patch for patch in pie_ax.patches if isinstance(patch, Wedge)]
+    assert len(pie_wedges) == 3
+    np.testing.assert_allclose(
+        [wedge.theta2 - wedge.theta1 for wedge in pie_wedges], [120] * 3
+    )
+    assert [text.get_text() for text in pie_ax.texts] == ["33%"] * 3
+
     cns.figure(120, 120)
-    cns.donutplot(categorical_df, x="group")
+    donut_ax = cns.donutplot(categorical_df, x="group")
+    donut_wedges = [patch for patch in donut_ax.patches if isinstance(patch, Wedge)]
+    assert len(donut_wedges) == 3
+    np.testing.assert_allclose(
+        [wedge.theta2 - wedge.theta1 for wedge in donut_wedges], [120] * 3
+    )
+    assert [wedge.width for wedge in donut_wedges] == pytest.approx([0.4] * 3)
+
+    class FakeArtist:
+        def __init__(self) -> None:
+            self.facecolor: object = (1, 0, 0, 1)
+            self.edgecolor: object = None
+
+        def get_facecolor(self) -> object:
+            return self.facecolor
+
+        def set_edgecolor(self, value: object) -> None:
+            self.edgecolor = value
+
+        def set_facecolor(self, value: object) -> None:
+            self.facecolor = value
+
+    class FakeLine:
+        def __init__(self) -> None:
+            self.color: object = None
+            self.marker_facecolor: object = None
+            self.marker_edgecolor: object = None
+
+        def set_color(self, value: object) -> None:
+            self.color = value
+
+        def set_mfc(self, value: object) -> None:
+            self.marker_facecolor = value
+
+        def set_mec(self, value: object) -> None:
+            self.marker_edgecolor = value
 
     class FakeAxes:
         def __init__(self) -> None:
             self.patches: list[PathPatch] = []
-            self.artists = [
-                types.SimpleNamespace(
-                    get_facecolor=lambda: (1, 0, 0, 1),
-                    set_edgecolor=lambda x: None,
-                    set_facecolor=lambda x: None,
-                )
-            ]
-            self.lines = [
-                types.SimpleNamespace(
-                    set_color=lambda x: None,
-                    set_mfc=lambda x: None,
-                    set_mec=lambda x: None,
-                )
-            ] * 5
+            self.artists = [FakeArtist()]
+            self.lines = [FakeLine() for _ in range(5)]
 
         def get_legend_handles_labels(self) -> tuple[list[object], list[str]]:
             return [], []
@@ -863,11 +1002,23 @@ def test_plot_internal_coverage(
 
     monkeypatch.setattr(dist_mod.sns, "boxplot", lambda **kwargs: FakeAxes())
     monkeypatch.setattr(cns.utils, "_remove_edge_from_legend_items", lambda ax: None)
-    cns.boxplot(categorical_df, x="group", y="value")
+    box_ax = cns.boxplot(categorical_df, x="group", y="value")
+    assert box_ax.artists[0].edgecolor == "None"
+    assert box_ax.artists[0].facecolor == (1, 0, 0, 1)
+    assert [line.color for line in box_ax.lines] == [
+        (1, 0, 0, 1),
+        (1, 0, 0, 1),
+        "white",
+        (1, 0, 0, 1),
+        (1, 0, 0, 1),
+    ]
 
     cns.figure(120, 120)
-    cns.histplot(
+    hist_ax = cns.histplot(
         data=categorical_df.rename(columns={"value": "x", "group": "y"}), y="x"
+    )
+    assert sum(patch.get_width() for patch in hist_ax.patches) == pytest.approx(
+        len(categorical_df)
     )
 
     adata_nan = heatmap_adata.copy()
@@ -875,7 +1026,8 @@ def test_plot_internal_coverage(
         ["A", None, "B"], index=adata_nan.obs_names, dtype=object
     )
     cns.figure(120, 120)
-    cns.heatmapplot(adata_nan, row_annotation=["cluster"], cmap=None)
+    heatmap = cns.heatmapplot(adata_nan, row_annotation=["cluster"], cmap=None)
+    pd.testing.assert_frame_equal(heatmap.data2d, adata_nan.to_df())
 
     with pytest.raises(ValueError, match="required cell for stats"):
         cns.confusionplot(
@@ -972,33 +1124,41 @@ def test_plot_internal_coverage(
 
     cns.figure(120, 120)
     cns.phyloplot(phylo_adata)
+    phylo_matrices = [
+        np.asarray(collection.get_array())
+        for axis in plt.gcf().axes
+        for collection in axis.collections
+        if isinstance(collection, QuadMesh)
+        and np.asarray(collection.get_array()).shape == phylo_adata.shape
+    ]
+    assert len(phylo_matrices) == 1
+    np.testing.assert_array_equal(
+        phylo_matrices[0], phylo_adata.layers["trisicell_output"]
+    )
 
-    fake_venn_obj = types.SimpleNamespace(
-        get_label_by_id=lambda area: (
-            (_ for _ in ()).throw(AttributeError())
-            if area in {"100", "110"}
-            else types.SimpleNamespace(set_fontsize=lambda size: None)
-        ),
-        get_patch_by_id=lambda area: (
-            (_ for _ in ()).throw(AttributeError())
-            if area in {"100", "110"}
-            else types.SimpleNamespace(
-                set_edgecolor=lambda color: None, set_linewidth=lambda width: None
-            )
-        ),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "matplotlib_venn",
-        types.SimpleNamespace(
-            venn2=lambda *args, **kwargs: fake_venn_obj,
-            venn3=lambda *args, **kwargs: fake_venn_obj,
-        ),
-    )
     cns.figure(120, 120)
-    assert (
-        cns.vennplot([{1, 2}, {2, 3}, {3, 4}], labels=["A", "B", "C"]) is fake_venn_obj
-    )
+    venn = cns.vennplot([{1, 2}, {2, 3}, {3, 4}], labels=["A", "B", "C"])
+    assert {
+        area: (
+            None
+            if venn.get_label_by_id(area) is None
+            else venn.get_label_by_id(area).get_text()
+        )
+        for area in ["100", "010", "001", "110", "101", "011", "111"]
+    } == {
+        "100": "1",
+        "010": "0",
+        "001": "1",
+        "110": "1",
+        "101": None,
+        "011": "1",
+        "111": None,
+    }
+    assert [venn.get_label_by_id(name).get_text() for name in ["A", "B", "C"]] == [
+        "A",
+        "B",
+        "C",
+    ]
 
 
 def test_remaining_visual_internal_coverage(

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -52,6 +52,13 @@ def _line_y_at_x(line: Any, x: float) -> float:
     return float(ydata[matches[-1]])
 
 
+def _line_xy(line: Any) -> tuple[np.ndarray, np.ndarray]:
+    return (
+        np.asarray(line.get_xdata(), dtype=float),
+        np.asarray(line.get_ydata(), dtype=float),
+    )
+
+
 def _relative_axes_bounds(
     host_ax: Axes, helper_ax: Axes
 ) -> tuple[float, float, float, float]:
@@ -132,7 +139,6 @@ def test_survival_plots(
     survival_df: pd.DataFrame,
     survival_three_group_df: pd.DataFrame,
     competing_risk_df: pd.DataFrame,
-    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     cns.figure(120, 120)
@@ -141,7 +147,27 @@ def test_survival_plots(
             survival_df, "time", "event", "group", hue_order=["Treatment", "Control"]
         )
     assert ax.get_ylabel() == "Overall survival probability"
-    assert "HR =" in ax.texts[0].get_text()
+    survival_lines = {
+        line.get_label(): line
+        for line in ax.lines
+        if line.get_drawstyle() == "steps-post"
+    }
+    treatment_x, treatment_y = _line_xy(survival_lines["Treatment (n=6)"])
+    control_x, control_y = _line_xy(survival_lines["Control (n=6)"])
+    np.testing.assert_allclose(
+        treatment_x,
+        [0, 4, 5, 6, 8, 9, 11],
+    )
+    np.testing.assert_allclose(
+        treatment_y,
+        [1, 5 / 6, 5 / 6, 5 / 8, 5 / 12, 5 / 12, 0],
+    )
+    np.testing.assert_allclose(control_x, [0, 5, 6, 7, 8, 10, 12])
+    np.testing.assert_allclose(
+        control_y,
+        [1, 5 / 6, 2 / 3, 2 / 3, 4 / 9, 4 / 9, 0],
+    )
+    assert ax.texts[0].get_text() == "HR = 0.68 (0.15-3.06)\nP = $0.6$"
     assert "multivariate log-rank test" in caplog.text
 
     cns.figure(120, 120)
@@ -151,14 +177,6 @@ def test_survival_plots(
     assert ax2.get_xlabel() == "Time (Years)"
     assert "trend" in caplog.text
 
-    added: dict[str, object] = {}
-    import lifelines.plotting as lifelines_plotting
-
-    monkeypatch.setattr(
-        lifelines_plotting,
-        "add_at_risk_counts",
-        lambda *fitters, **kwargs: added.update({"fitters": fitters, **kwargs}),
-    )
     cns.figure(120, 120)
     caplog.clear()
     with caplog.at_level(logging.INFO, logger="cnsplots"):
@@ -171,7 +189,25 @@ def test_survival_plots(
             xticks=[0, 2, 4, 6, 8],
         )
     assert list(ax3.get_xticks()) == [0, 2, 4, 6, 8]
-    assert added["rows_to_show"] == ["At risk"]
+    cif_lines = {line.get_label(): line for line in ax3.lines}
+    cif_a_x, cif_a_y = _line_xy(cif_lines["A"])
+    cif_b_x, cif_b_y = _line_xy(cif_lines["B"])
+    np.testing.assert_allclose(cif_a_x, [0, 1, 2, 3, 4, 5, 6])
+    np.testing.assert_allclose(
+        cif_a_y,
+        [0, 1 / 6, 1 / 6, 1 / 6, 3 / 8, 3 / 8, 3 / 8],
+    )
+    np.testing.assert_allclose(cif_b_x, [0, 2, 3, 4, 5, 6, 7])
+    np.testing.assert_allclose(
+        cif_b_y,
+        [0, 1 / 6, 1 / 6, 1 / 6, 7 / 18, 7 / 18, 7 / 18],
+    )
+    assert len(ax3.figure.axes) == 2
+    risk_table_labels = [
+        label.get_text() for label in ax3.figure.axes[1].get_xticklabels()
+    ]
+    assert risk_table_labels[0].split() == ["At", "risk", "A", "6", "B", "6"]
+    assert risk_table_labels[-1].split() == ["0", "0"]
     assert "Gray's test" in caplog.text
 
     cns.figure(120, 120)
@@ -343,10 +379,25 @@ def test_confusionplot_metrics_and_errors(confusion_df: pd.DataFrame) -> None:
         positive_y="pos",
     )
     assert ax.get_xlabel() == "pred"
+    np.testing.assert_array_equal(ax.images[0].get_array(), [[3, 1], [1, 3]])
+    assert {
+        tuple(int(coord) for coord in text.get_position()): text.get_text()
+        for text in ax.texts
+    } == {(0, 0): "3", (1, 0): "1", (0, 1): "1", (1, 1): "3"}
     assert len(plt.gcf().axes) == 2
     stats_ax = plt.gcf().axes[1]
     assert len(stats_ax.texts) == 1
     assert stats_ax.texts[0].get_position() == pytest.approx((-0.25, -1.5))
+    assert stats_ax.texts[0].get_text() == (
+        "\n        Specificity: 0.75\n"
+        "        Sensitivity: 0.75\n"
+        "        PPV: 0.75\n"
+        "        NPV: 0.75\n"
+        "        Cohen's kappa: 0.50\n"
+        "        Fisher's exact test: $0.49$\n"
+        "        Odds ratio: 9.00\n"
+        "        "
+    )
     text_colors = {
         tuple(int(coord) for coord in text.get_position()): text.get_color()
         for text in ax.texts
@@ -451,6 +502,10 @@ def test_heatmap_and_dotplot(
         cmap="parula",
     )
     assert cmp.ax_heatmap is not None
+    np.testing.assert_allclose(
+        np.sort(cmp.data2d.to_numpy().ravel()),
+        np.sort(np.asarray(heatmap_adata.layers["scaled"]).ravel()),
+    )
     heatmap_colorbars = [cbar for cbar in cmp.cbars if isinstance(cbar, Colorbar)]
     heatmap_legends = [obj for obj in cmp.cbars if isinstance(obj, Legend)]
     assert len(heatmap_colorbars) == 3
@@ -482,6 +537,25 @@ def test_heatmap_and_dotplot(
     assert dp.hm_ax is dp.heatmap_axes[-1, 0]
     assert dp.legend_ax is not None
     assert dp.cbar_ax is not None
+    pd.testing.assert_frame_equal(
+        dp.data2d,
+        pd.DataFrame(
+            [[1.0, 2.0], [3.0, 4.0]],
+            index=pd.Index(["G1", "G2"], name="gene"),
+            columns=pd.Index(["S1", "S2"], name="sample"),
+        ),
+    )
+    dots = dp.hm_ax.collections[0]
+    np.testing.assert_allclose(
+        np.asarray(dots.get_offsets(), dtype=float),
+        [[1, 1], [2, 1], [1, 2], [2, 2]],
+    )
+    np.testing.assert_allclose(
+        np.asarray(dots.get_array(), dtype=float), [0.2, 0.5, 0.7, 0.1]
+    )
+    np.testing.assert_array_equal(
+        np.argsort(dots.get_sizes()), np.argsort([10, 50, 80, 30])
+    )
 
     cns.figure(160, 160)
     with pytest.raises(ValueError, match="Length mismatch"):
@@ -988,30 +1062,22 @@ def test_genomics_plots(
     with pytest.raises(TypeError, match="Parameter 'n_show' must be an integer"):
         cns.volcanoplot(volcano_df, n_show=True)
 
-    def fake_dotplot(
-        data: pd.DataFrame,
-        cmap: str,
-        y: str,
-        x: str,
-        cutoff: float,
-        column: str,
-        ax: Axes,
-        top_term: int,
-        size: float,
-    ) -> None:
-        scatter = ax.scatter(data[x], np.arange(len(data)), c=data[column], s=20)
-        fig = plt.gcf()
-        cbar = fig.colorbar(scatter, ax=ax)
-        cbar.set_label(column)
-        handles = [plt.Line2D([], [], marker="o", linestyle="none", color="black")]
-        ax.legend(handles, ["20"], title="size")
-
-    monkeypatch.setitem(
-        sys.modules, "gseapy", types.SimpleNamespace(dotplot=fake_dotplot)
-    )
     cns.figure(160, 140)
-    ax5 = cns.gseaplot(gsea_plot_df, y="Clean_Term", color="NES", top_term=2)
+    ax5 = cns.gseaplot(gsea_plot_df, y="Clean_Term", color="NES", top_term=3)
     assert ax5.get_xlabel() == "Normalized Enrichment Score (NES)"
+    assert [tick.get_text() for tick in ax5.get_yticklabels()] == [
+        "Pathway B",
+        "Pathway C",
+        "Pathway A",
+    ]
+    gsea_dots = ax5.collections[0]
+    np.testing.assert_allclose(
+        np.asarray(gsea_dots.get_offsets(), dtype=float),
+        [[-1.8, 0], [1.6, 1], [2.1, 2]],
+    )
+    np.testing.assert_allclose(
+        np.asarray(gsea_dots.get_array(), dtype=float), [-1.8, 1.6, 2.1]
+    )
 
 
 def test_volcanoplot_annotations_use_legend_fontsize(

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -4,13 +4,21 @@ import logging
 from typing import Any, cast
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import pytest
 from cycler import cycler
 from matplotlib.colors import to_hex, to_rgba
-from matplotlib.patches import Circle, FancyBboxPatch, Polygon, Wedge
+from matplotlib.patches import Circle, FancyBboxPatch, PathPatch, Polygon, Wedge
 
 import cnsplots as cns
+
+
+def _line_xy(line: Any) -> tuple[np.ndarray, np.ndarray]:
+    return (
+        np.asarray(line.get_xdata(), dtype=float),
+        np.asarray(line.get_ydata(), dtype=float),
+    )
 
 
 def test_boxplot_and_violinplot(
@@ -39,6 +47,21 @@ def test_boxplot_and_violinplot(
     assert ax.get_xticklabels()[0].get_text().startswith("A")
     assert "minimum and maximum values" in caplog.text
     assert calls
+    box_patches = [patch for patch in ax.patches if isinstance(patch, PathPatch)]
+    box_quartiles = []
+    for patch in box_patches:
+        vertices = np.asarray(patch.get_path().vertices, dtype=float)
+        box_quartiles.append([vertices[:, 1].min(), vertices[:, 1].max()])
+    np.testing.assert_allclose(
+        box_quartiles,
+        [[1.075, 1.325], [2.075, 2.225], [3.075, 3.225]],
+    )
+    median_values = []
+    for line in ax.lines:
+        x_data, y_data = _line_xy(line)
+        if len(x_data) == 2 and np.ptp(x_data) > 0 and np.ptp(y_data) == 0:
+            median_values.append(float(y_data[0]))
+    np.testing.assert_allclose(median_values, [1.2, 2.15, 3.15])
 
     cns.figure(120, 120)
     ax2 = cns.violinplot(
@@ -81,6 +104,10 @@ def test_barplot_and_lollipopplot(
     )
     assert ax.get_legend() is not None
     assert ax.get_legend().get_title().get_text() == "palette_group"
+    np.testing.assert_allclose(
+        [patch.get_height() for patch in ax.patches], [1.2, 2.15, 3.15]
+    )
+    assert [text.get_text() for text in ax.texts] == ["1.2", "2.15", "3.15"]
 
     cns.figure(120, 120)
     ax2 = cns.lollipopplot(
@@ -178,6 +205,7 @@ def test_stack_strip_pie_and_donut_plots(
         "B\n(n=4)",
         "C\n(n=4)",
     ]
+    np.testing.assert_allclose([patch.get_height() for patch in ax.patches], [0.5] * 6)
     assert not ax.texts
 
     cns.figure(120, 120)
@@ -188,10 +216,11 @@ def test_stack_strip_pie_and_donut_plots(
         horizontal=True,
         normalize=False,
         pairs=[("A", "B")],
-        bar_order=["A", "B", "C"],
+        bar_order=["No", "Yes"],
         stack_order=["No", "Yes"],
     )
     assert ax2.get_xlabel() == "Count"
+    np.testing.assert_allclose([patch.get_width() for patch in ax2.patches], [2.0] * 6)
 
     cns.figure(120, 120)
     ax2b = cns.stackplot(
@@ -224,6 +253,10 @@ def test_stack_strip_pie_and_donut_plots(
         categorical_df, x="group", legend="left", hue_order=["C", "B", "A"]
     )
     assert ax4.get_legend() is not None
+    pie_wedges = [patch for patch in ax4.patches if isinstance(patch, Wedge)]
+    np.testing.assert_allclose(
+        [patch.theta2 - patch.theta1 for patch in pie_wedges], [120.0] * 3
+    )
 
     cns.figure(120, 120)
     ax5 = cns.donutplot(
@@ -232,7 +265,9 @@ def test_stack_strip_pie_and_donut_plots(
     assert ax5.get_legend() is not None
     assert any(text.get_text() == "group" for text in ax5.texts)
     donut_wedges = [patch for patch in ax5.patches if isinstance(patch, Wedge)]
-    assert donut_wedges
+    np.testing.assert_allclose(
+        [patch.theta2 - patch.theta1 for patch in donut_wedges], [120.0] * 3
+    )
     assert all(patch.width == pytest.approx(0.4) for patch in donut_wedges)
     assert calls
 
@@ -260,7 +295,9 @@ def test_distribution_wrappers(
 
     cns.figure(120, 120)
     ax4 = cns.histplot(data=numeric_df, x="x", kde=True)
-    assert ax4 is plt.gca()
+    assert sum(patch.get_height() for patch in ax4.patches) == pytest.approx(
+        len(numeric_df)
+    )
 
     cns.figure(120, 120)
     ax5 = cns.ridgeplot(categorical_df, x="value", y="group", cmap="viridis")
@@ -436,7 +473,6 @@ def test_placeholderplot_requires_string_description() -> None:
 def test_sets_and_specialized_plots(
     sets_fixture: dict[str, set[int]],
     sankey_df: pd.DataFrame,
-    roc_df: pd.DataFrame,
 ) -> None:
     cns.figure(120, 120)
     axes = cns.upsetplot(sets_fixture, min_subset_size=1)
@@ -469,7 +505,13 @@ def test_sets_and_specialized_plots(
 
     cns.figure(120, 120)
     venn = cns.vennplot(list(sets_fixture.values())[:2], labels=["A", "B"])
-    assert venn is not None
+    assert {
+        area: venn.get_label_by_id(area).get_text() for area in ["10", "01", "11"]
+    } == {"10": "1", "01": "1", "11": "2"}
+    assert [venn.get_label_by_id(area).get_text() for area in ["A", "B"]] == [
+        "A",
+        "B",
+    ]
 
     cns.figure(120, 120)
     ax = cns.sankeyplot(sankey_df, x="source", y="target")
@@ -485,13 +527,38 @@ def test_sets_and_specialized_plots(
     assert len(ax_rotated.texts) == len(ax.texts)
     assert all(text.get_rotation() == 90 for text in ax_rotated.texts)
 
+    roc_df = pd.DataFrame(
+        {
+            "truth": [0, 0, 1, 1],
+            "model_a": [0.1, 0.4, 0.35, 0.8],
+            "model_b": [0.1, 0.8, 0.4, 0.7],
+        }
+    )
     cns.figure(120, 120)
     ax2 = cns.rocplot(roc_df, "truth", "model_a")
-    assert len(ax2.lines) == 2
+    model_a_x, model_a_y = _line_xy(ax2.lines[0])
+    diagonal_x, diagonal_y = _line_xy(ax2.lines[1])
+    np.testing.assert_allclose(model_a_x, [0, 0, 0.5, 0.5, 1])
+    np.testing.assert_allclose(model_a_y, [0, 0.5, 0.5, 1, 1])
+    assert ax2.lines[0].get_label() == "model_a (AUC=0.75)"
+    np.testing.assert_allclose(diagonal_x, [0, 1])
+    np.testing.assert_allclose(diagonal_y, [0, 1])
 
     cns.figure(120, 120)
     ax3 = cns.rocplot(roc_df, "truth", ["model_a", "model_b"])
-    assert len(ax3.lines) == 3
+    assert [line.get_label() for line in ax3.lines[:2]] == [
+        "model_a (AUC=0.75)",
+        "model_b (AUC=0.50)",
+    ]
+    model_a_x, model_a_y = _line_xy(ax3.lines[0])
+    model_b_x, model_b_y = _line_xy(ax3.lines[1])
+    diagonal_x, diagonal_y = _line_xy(ax3.lines[2])
+    np.testing.assert_allclose(model_a_x, [0, 0, 0.5, 0.5, 1])
+    np.testing.assert_allclose(model_a_y, [0, 0.5, 0.5, 1, 1])
+    np.testing.assert_allclose(model_b_x, [0, 0.5, 0.5, 1])
+    np.testing.assert_allclose(model_b_y, [0, 0, 1, 1])
+    np.testing.assert_allclose(diagonal_x, [0, 1])
+    np.testing.assert_allclose(diagonal_y, [0, 1])
 
 
 def test_sankey_annotations_use_legend_fontsize(sankey_df: pd.DataFrame) -> None:

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -320,6 +320,44 @@ def test_public_prerank_contract(
     ]
 
 
+def test_public_prerank_and_gseaplot_use_real_gseapy_backend() -> None:
+    genes = [f"G{index:02d}" for index in range(60)]
+    ranked = pd.DataFrame(
+        {
+            "gene": [gene.lower() for gene in genes],
+            "rank": np.linspace(5, -5, len(genes)),
+        }
+    )
+    gene_sets = {
+        "HALLMARK_TOP_PATHWAY": genes[:20],
+        "GO_BOTTOM_PATHWAY": genes[-20:],
+    }
+
+    result = cns.prerank(
+        ranked,
+        gene_sets,
+        name_gene="gene",
+        name_rank="rank",
+        permutation_num=10,
+    )
+
+    assert set(result["Clean_Term"]) == {"Top Pathway", "Bottom Pathway"}
+    nes_by_term = result.set_index("Term")["NES"].astype(float)
+    assert nes_by_term["HALLMARK_TOP_PATHWAY"] > 1.5
+    assert nes_by_term["GO_BOTTOM_PATHWAY"] < -1.5
+    assert (result["FDR q-val"].astype(float) < 0.25).all()
+
+    cns.figure(160, 140)
+    ax = cns.gseaplot(result, y="Clean_Term", top_term=2)
+    offsets = np.asarray(ax.collections[0].get_offsets(), dtype=float)
+    rendered_nes = {
+        label.get_text(): offset[0]
+        for label, offset in zip(ax.get_yticklabels(), offsets, strict=True)
+    }
+    expected_nes = result.set_index("Clean_Term")["NES"].astype(float).to_dict()
+    assert rendered_nes == pytest.approx(expected_nes)
+
+
 def test_public_prerank_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
     real_import = builtins.__import__
 


### PR DESCRIPTION
## What changed

- Assert rendered data values and geometry across categorical, distribution, heatmap, ROC, survival, and phylogeny plots.
- Exercise real gseapy, matplotlib-venn, and lifelines happy paths while retaining focused failure stubs.
- Fix horizontal stack test ordering so it renders actual segments.

## How tested

- make test: 160 passed with 100% coverage
- make lint: passed

## Risks and follow-ups

- Test-only change; exact geometry assertions intentionally track the locked plotting and backend versions.
- No follow-up required.