### PR TITLE
📝 Set five-word Git title limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Use this file as the repo-specific operating manual for branch, validation, comm
 - When multiple edits exist, describe only the dominant change.
 - Write in imperative mood.
 - Capitalize the first word unless syntax or style requires otherwise.
-- Keep the subject under 72 characters.
+- For subject use at most five words, excluding the emoji.
 - Add a body only when it meaningfully explains why, highlights follow-up work, or calls out a breaking change.
 - If you add a body, leave one blank line after the subject and keep the body concise.
 
@@ -128,7 +128,7 @@ Clients must switch to the new export path before upgrading.
 - Prefer the smallest accurate claim and make the PR title more specific than the commit subject by naming the dominant change and affected area or behavior in a single phrase.
 - Write in imperative mood.
 - Capitalize the first word unless syntax or style requires otherwise.
-- Keep the title under 72 characters.
+- For title use at most five words, excluding the emoji.
 - Use the same Gitmoji selection and tie-break rules as commit subjects.
 - Use the same `<emoji> <subject>` format as commit subjects.
 - PR body must include:


### PR DESCRIPTION
## What changed

- Replace the 72-character commit subject limit with a five-word limit, excluding the emoji.
- Apply the same five-word limit to pull request titles.

## How it was tested

- `make test` (160 passed, 100% coverage)
- `make lint` (all hooks passed)

## Risks or follow-ups

- Low risk: this changes repository contribution guidance only.
- No follow-up work is required.