### PR TITLE
⚡️ Make cnsplots imports lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ cns.scatterplot(data=df2, x="x", y="y")
 pip install cnsplots
 ```
 
+This installs every supported plotting and scientific integration. Imports
+remain lazy, so those backends are loaded only when their APIs are first used.
+
 ### For Development
 
 First install [uv](https://docs.astral.sh/uv/), then:
@@ -112,9 +115,7 @@ cd cnsplots
 make install
 ```
 
-This installs the package with its development and documentation extras. Core
-scientific integrations such as `scanpy`, `lifelines`, and `gseapy` remain
-runtime dependencies of `cnsplots` itself.
+This installs the package with its development and documentation dependencies.
 
 ## Quick Start
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,9 @@ Install cnsplots using pip:
 pip install cnsplots
 ```
 
+This installs every supported plotting and scientific integration. Imports
+remain lazy, so those backends are loaded only when their APIs are first used.
+
 ## Verify Installation
 
 After installation, verify that cnsplots is correctly installed:
@@ -49,14 +52,9 @@ hooks.
 
 ## Dependencies
 
-cnsplots relies on the following main packages (installed automatically):
-
-- matplotlib, seaborn - Visualization
-- pandas, numpy - Data manipulation
-- scipy, scikit-learn - Statistical analysis
-- scanpy - Single-cell analysis
-- lifelines - Survival analysis
-- gseapy - Gene set enrichment analysis
+cnsplots installs Matplotlib, seaborn, pandas, NumPy, SciPy, Scanpy, Lifelines,
+GSEApy, Biopython, PyComplexHeatmap, and the set-plotting libraries
+automatically.
 
 For Illustrator-optimized SVG post-processing, you can optionally install
 MuPDF's `mutool`. Without it, `cns.savefig("figure.svg")` still works and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
 ]
 dependencies = [
     "adjustText",
+    "anndata",
     "biopython",
-    "glasbey",
     "gseapy",
     "lifelines>=0.30,<0.31",
     "lxml",
@@ -31,7 +31,6 @@ dependencies = [
     "matplotlib-venn",
     "natsort",
     "num2tex",
-    "numba>=0.58.1",
     "numpy",
     "palettable",
     "pandas",
@@ -50,6 +49,7 @@ dependencies = [
 dev = [
     "bump-my-version",
     "fastcluster",
+    "glasbey",
     "ipykernel",
     "pre-commit",
     "pytest",

--- a/src/cnsplots/__init__.py
+++ b/src/cnsplots/__init__.py
@@ -1,141 +1,97 @@
-"""CNSPlots Module."""
+"""CNSPlots public API."""
 
-import logging
-import warnings
-
-import cnsplots._methods as methods
-import cnsplots._utils as utils
-import cnsplots._validation as validation
-from cnsplots._methods import CoxModel, LogisticModel, prerank
-from cnsplots._multipanels import multipanel
-from cnsplots._settings import settings
-from cnsplots._setup import setup_ax, setup_ggplot, setup_matplotlib, setup_scanpy
-from cnsplots._utils import (
-    BLUE,
-    BROWN,
-    CHOCOLATE,
-    GRAY,
-    GREEN,
-    ORANGE,
-    PINK,
-    PURPLE,
-    RED,
-    VIOLET,
-    YELLOW,
-    add_panel_label,
-    apply_unicode_font,
-    figure,
-    get_hexcolors_from_apalette,
-    get_showcase_data,
-    palettes,
-    savefig,
-    take_legend_out,
-)
-from cnsplots.plots import (
-    barplot,
-    boxplot,
-    confusionplot,
-    cumulativeincidenceplot,
-    distplot,
-    donutplot,
-    dotplot,
-    forestplot,
-    gseaplot,
-    heatmapplot,
-    histplot,
-    kdeplot,
-    lineplot,
-    lollipopplot,
-    phyloplot,
-    placeholderplot,
-    pieplot,
-    qqplot,
-    regplot,
-    ridgeplot,
-    rocplot,
-    sankeyplot,
-    scatterplot,
-    slopeplot,
-    stackplot,
-    stripplot,
-    survivalplot,
-    upsetplot,
-    vennplot,
-    violinplot,
-    volcanoplot,
-)
+from importlib import import_module
 
 __version__ = "0.4.0"
-save = savefig
-__all__ = (
-    "utils",
-    "settings",
-    "validation",
-    "BLUE",
-    "BROWN",
-    "CHOCOLATE",
-    "GRAY",
-    "GREEN",
-    "ORANGE",
-    "PINK",
-    "PURPLE",
-    "RED",
-    "VIOLET",
-    "YELLOW",
-    "methods",
-    "CoxModel",
-    "LogisticModel",
-    "prerank",
-    "setup_ax",
-    "setup_ggplot",
-    "setup_matplotlib",
-    "setup_scanpy",
-    "add_panel_label",
-    "apply_unicode_font",
-    "figure",
-    "multipanel",
-    "save",
-    "savefig",
-    "palettes",
-    "take_legend_out",
-    "get_hexcolors_from_apalette",
-    "get_showcase_data",
-    "barplot",
-    "boxplot",
-    "confusionplot",
-    "cumulativeincidenceplot",
-    "distplot",
-    "donutplot",
-    "dotplot",
-    "forestplot",
-    "gseaplot",
-    "heatmapplot",
-    "histplot",
-    "kdeplot",
-    "lineplot",
-    "lollipopplot",
-    "phyloplot",
-    "placeholderplot",
-    "pieplot",
-    "qqplot",
-    "regplot",
-    "ridgeplot",
-    "rocplot",
-    "sankeyplot",
-    "scatterplot",
-    "slopeplot",
-    "stackplot",
-    "stripplot",
-    "survivalplot",
-    "upsetplot",
-    "vennplot",
-    "violinplot",
-    "volcanoplot",
-)
 
-warnings.filterwarnings("ignore", message="findfont: Font family 'Helvetica' not found")
+_LAZY_IMPORTS = {
+    "utils": ("cnsplots._utils", None),
+    "settings": ("cnsplots._settings", "settings"),
+    "validation": ("cnsplots._validation", None),
+    "BLUE": ("cnsplots._utils", "BLUE"),
+    "BROWN": ("cnsplots._utils", "BROWN"),
+    "CHOCOLATE": ("cnsplots._utils", "CHOCOLATE"),
+    "GRAY": ("cnsplots._utils", "GRAY"),
+    "GREEN": ("cnsplots._utils", "GREEN"),
+    "ORANGE": ("cnsplots._utils", "ORANGE"),
+    "PINK": ("cnsplots._utils", "PINK"),
+    "PURPLE": ("cnsplots._utils", "PURPLE"),
+    "RED": ("cnsplots._utils", "RED"),
+    "VIOLET": ("cnsplots._utils", "VIOLET"),
+    "YELLOW": ("cnsplots._utils", "YELLOW"),
+    "methods": ("cnsplots._methods", None),
+    "CoxModel": ("cnsplots._methods", "CoxModel"),
+    "LogisticModel": ("cnsplots._methods", "LogisticModel"),
+    "prerank": ("cnsplots._methods", "prerank"),
+    "setup_ax": ("cnsplots._setup", "setup_ax"),
+    "setup_ggplot": ("cnsplots._setup", "setup_ggplot"),
+    "setup_matplotlib": ("cnsplots._setup", "setup_matplotlib"),
+    "setup_scanpy": ("cnsplots._setup", "setup_scanpy"),
+    "add_panel_label": ("cnsplots._utils", "add_panel_label"),
+    "apply_unicode_font": ("cnsplots._utils", "apply_unicode_font"),
+    "figure": ("cnsplots._utils", "figure"),
+    "multipanel": ("cnsplots._multipanels", "multipanel"),
+    "save": ("cnsplots._utils", "savefig"),
+    "savefig": ("cnsplots._utils", "savefig"),
+    "palettes": ("cnsplots._utils", "palettes"),
+    "take_legend_out": ("cnsplots._utils", "take_legend_out"),
+    "get_hexcolors_from_apalette": (
+        "cnsplots._utils",
+        "get_hexcolors_from_apalette",
+    ),
+    "get_showcase_data": ("cnsplots._utils", "get_showcase_data"),
+    "barplot": ("cnsplots.plots._categorical", "barplot"),
+    "boxplot": ("cnsplots.plots._distribution", "boxplot"),
+    "confusionplot": ("cnsplots.plots._heatmap", "confusionplot"),
+    "cumulativeincidenceplot": (
+        "cnsplots.plots._survival",
+        "cumulativeincidenceplot",
+    ),
+    "distplot": ("cnsplots.plots._distribution", "distplot"),
+    "donutplot": ("cnsplots.plots._categorical", "donutplot"),
+    "dotplot": ("cnsplots.plots._heatmap", "dotplot"),
+    "forestplot": ("cnsplots.plots._specialized", "forestplot"),
+    "gseaplot": ("cnsplots.plots._genomics", "gseaplot"),
+    "heatmapplot": ("cnsplots.plots._heatmap", "heatmapplot"),
+    "histplot": ("cnsplots.plots._distribution", "histplot"),
+    "kdeplot": ("cnsplots.plots._distribution", "kdeplot"),
+    "lineplot": ("cnsplots.plots._regression", "lineplot"),
+    "lollipopplot": ("cnsplots.plots._categorical", "lollipopplot"),
+    "phyloplot": ("cnsplots.plots._specialized", "phyloplot"),
+    "placeholderplot": ("cnsplots.plots._specialized", "placeholderplot"),
+    "pieplot": ("cnsplots.plots._categorical", "pieplot"),
+    "qqplot": ("cnsplots.plots._distribution", "qqplot"),
+    "regplot": ("cnsplots.plots._regression", "regplot"),
+    "ridgeplot": ("cnsplots.plots._distribution", "ridgeplot"),
+    "rocplot": ("cnsplots.plots._specialized", "rocplot"),
+    "sankeyplot": ("cnsplots.plots._specialized", "sankeyplot"),
+    "scatterplot": ("cnsplots.plots._regression", "scatterplot"),
+    "slopeplot": ("cnsplots.plots._regression", "slopeplot"),
+    "stackplot": ("cnsplots.plots._categorical", "stackplot"),
+    "stripplot": ("cnsplots.plots._categorical", "stripplot"),
+    "survivalplot": ("cnsplots.plots._survival", "survivalplot"),
+    "upsetplot": ("cnsplots.plots._sets", "upsetplot"),
+    "vennplot": ("cnsplots.plots._sets", "vennplot"),
+    "violinplot": ("cnsplots.plots._distribution", "violinplot"),
+    "volcanoplot": ("cnsplots.plots._genomics", "volcanoplot"),
+}
 
-mpl_logger = logging.getLogger("matplotlib")
-mpl_logger.setLevel(logging.ERROR)
+__all__ = tuple(_LAZY_IMPORTS)
 
-logging.getLogger("fontTools").setLevel(logging.ERROR)
+
+def __getattr__(name: str):
+    """Load a public attribute on first access."""
+    try:
+        module_name, attribute_name = _LAZY_IMPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+    module = import_module(module_name)
+    value = module if attribute_name is None else getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return eager and lazy module attributes."""
+    return sorted(set(globals()) | set(__all__))

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 import re
 import warnings
 
-import lifelines as ll
 import numpy as np
 import pandas as pd
 import patsy
@@ -158,6 +157,8 @@ class CoxModel:
         >>> model.fit()
         >>> print(model.results[["display_label", "exp(coef)", "p"]])
         """
+        import lifelines as ll
+
         self.results = None
         validate_dataframe(self.data, "data", "CoxModel.fit")
         validate_dataframe_not_empty(self.data, "CoxModel.fit")

--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -14,7 +14,9 @@ if TYPE_CHECKING:
 import matplotlib.pyplot as plt
 from matplotlib import transforms as mtransforms
 
-import cnsplots as cns
+import cnsplots._utils as utils
+from cnsplots._settings import settings
+from cnsplots._setup import setup_matplotlib
 
 _LEFT_DECORATION_TOLERANCE_PX = 0.5
 _RELAYOUT_MAX_PASSES = 3
@@ -124,9 +126,9 @@ class multipanel:
         title_fontweight: str | int = "bold",
     ) -> None:
         if max_width is None:
-            max_width = cns.settings.multipanel_max_width
+            max_width = settings.multipanel_max_width
         if loc is None:
-            loc = cns.settings.multipanel_title_loc
+            loc = settings.multipanel_title_loc
         self._max_width = max_width
         self._title = title
         self._title_loc = _validate_title_loc(loc)
@@ -152,8 +154,8 @@ class multipanel:
         if self._title is None:
             return 0
         return max(
-            cns.settings.multipanel_title_height_min,
-            cns.settings.title_fontsize + cns.settings.multipanel_title_height_pad,
+            settings.multipanel_title_height_min,
+            settings.title_fontsize + settings.multipanel_title_height_pad,
         )
 
     def _get_left_decoration_width_px(self, panel: dict) -> float:
@@ -174,7 +176,7 @@ class multipanel:
 
     def _get_layout_scale(self) -> float:
         """Get the display-to-layout pixel scale used by multipanel geometry."""
-        dpi = self.fig.dpi if self.fig is not None else cns.settings.figure_dpi
+        dpi = self.fig.dpi if self.fig is not None else settings.figure_dpi
         return dpi / 72
 
     def _display_px_to_layout_px(self, value: float) -> float:
@@ -452,7 +454,7 @@ class multipanel:
             linked_axes = list(self._iter_linked_helper_axes(ax, panel))
             if not linked_axes:
                 continue
-            if cns.utils._capture_detached_axes_layout(ax, detached_axes=linked_axes):
+            if utils._capture_detached_axes_layout(ax, detached_axes=linked_axes):
                 captured = True
 
         if captured:
@@ -632,7 +634,7 @@ class multipanel:
 
         if self.fig is None:
             self.fig = plt.figure(
-                figsize=(fig_width, fig_height), dpi=cns.settings.figure_dpi
+                figsize=(fig_width, fig_height), dpi=settings.figure_dpi
             )
         else:
             self.fig.set_size_inches(fig_width, fig_height)
@@ -658,7 +660,7 @@ class multipanel:
                     x_positions[self._title_loc],
                     title_y_fig,
                     self._title,
-                    fontsize=cns.settings.title_fontsize,
+                    fontsize=settings.title_fontsize,
                     fontweight=self._title_fontweight,
                     va="center",
                     ha=self._title_loc,
@@ -670,7 +672,7 @@ class multipanel:
                 self._title_text.set_text(self._title)
                 self._title_text.set_ha(self._title_loc)
                 self._title_text.set_va("center")
-                self._title_text.set_fontsize(cns.settings.title_fontsize)
+                self._title_text.set_fontsize(settings.title_fontsize)
                 self._title_text.set_fontweight(self._title_fontweight)
 
         # Create or update axes for all panels
@@ -716,9 +718,9 @@ class multipanel:
                     1,
                     label,
                     transform=label_transform,
-                    fontsize=cns.settings.title_fontsize,
-                    fontweight=cns.settings.panel_label_fontweight,
-                    fontname=cns.settings.panel_label_fontname,
+                    fontsize=settings.title_fontsize,
+                    fontweight=settings.panel_label_fontweight,
+                    fontname=settings.panel_label_fontname,
                     ha="right",
                     va="bottom",
                 )
@@ -727,9 +729,9 @@ class multipanel:
                 label_text.set_position((0, 1))
                 label_text.set_text(label)
                 label_text.set_transform(label_transform)
-                label_text.set_fontsize(cns.settings.title_fontsize)
-                label_text.set_fontweight(cns.settings.panel_label_fontweight)
-                label_text.set_fontname(cns.settings.panel_label_fontname)
+                label_text.set_fontsize(settings.title_fontsize)
+                label_text.set_fontweight(settings.panel_label_fontweight)
+                label_text.set_fontname(settings.panel_label_fontname)
                 label_text.set_ha("right")
                 label_text.set_va("bottom")
 
@@ -845,26 +847,26 @@ class multipanel:
         multipanel may do one guarded relayout pass before display or save.
         """
         if color_cycle is None:
-            color_cycle = cns.settings.palette_qual
+            color_cycle = settings.palette_qual
         if color_map is None:
-            color_map = cns.settings.palette_seq
+            color_map = settings.palette_seq
         if height is None:
-            height = cns.settings.panel_height
+            height = settings.panel_height
         if width is None:
-            width = cns.settings.panel_width
+            width = settings.panel_width
         if pad_left is None:
-            pad_left = cns.settings.panel_pad_left
+            pad_left = settings.panel_pad_left
         if pad_top is None:
-            pad_top = cns.settings.panel_pad_top
+            pad_top = settings.panel_pad_top
         if margin_left is None:
-            margin_left = cns.settings.panel_margin_left
+            margin_left = settings.panel_margin_left
         if margin_top is None:
-            margin_top = cns.settings.panel_margin_top
+            margin_top = settings.panel_margin_top
         if margin_right is None:
-            margin_right = cns.settings.panel_margin_right
+            margin_right = settings.panel_margin_right
         if margin_bottom is None:
-            margin_bottom = cns.settings.panel_margin_bottom
-        cns.setup_matplotlib(color_cycle, color_map)
+            margin_bottom = settings.panel_margin_bottom
+        setup_matplotlib(color_cycle, color_map)
 
         if label is None:
             label = self._labels[self._panel_index]

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -658,7 +658,8 @@ class CNSSettings:
 
     def __init__(self) -> None:
         """Initialize settings with default values."""
-        self.reset()
+        for name, spec in type(self)._setting_specs.items():
+            object.__setattr__(self, f"_{name}", deepcopy(spec.default))
 
     def reset(self) -> None:
         """Reset all settings to their package defaults.

--- a/src/cnsplots/_setup.py
+++ b/src/cnsplots/_setup.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 import matplotlib as mpl
 from matplotlib import font_manager as fm
 
-import cnsplots as cns
+from cnsplots._settings import settings
 
 _HELVETICA_BOLD_REGISTERED = False
 ColorCycle = Union[str, list[str]]
@@ -81,9 +81,9 @@ def _validate_title_fontweight(value: str | int | None) -> str | int:
 def _font_rcparams() -> dict[str, object]:
     """Return the shared font-related matplotlib rcParams."""
     return {
-        "mathtext.fontset": cns.settings.mathtext_fontset,
-        "font.family": cns.settings.font_family,
-        "font.sans-serif": list(cns.settings.font_sans_serif),
+        "mathtext.fontset": settings.mathtext_fontset,
+        "font.family": settings.font_family,
+        "font.sans-serif": list(settings.font_sans_serif),
     }
 
 
@@ -93,7 +93,7 @@ def _resolve_legend_fontsizes(
 ) -> tuple[int | float, int | float]:
     """Resolve legend font sizes while preserving title-font inheritance."""
     if legend_fontsize is _UNSET:
-        resolved_legend_fontsize = cns.settings.legend_fontsize
+        resolved_legend_fontsize = settings.legend_fontsize
     elif legend_fontsize is None or isinstance(legend_fontsize, (int, float)):
         resolved_legend_fontsize = legend_fontsize
     else:
@@ -101,7 +101,7 @@ def _resolve_legend_fontsizes(
     if resolved_legend_fontsize is None:
         resolved_legend_fontsize = title_fontsize
 
-    legend_title_fontsize = cns.settings.legend_title_fontsize
+    legend_title_fontsize = settings.legend_title_fontsize
     if legend_title_fontsize is None:
         legend_title_fontsize = title_fontsize
 
@@ -212,18 +212,20 @@ def setup_matplotlib(
     ...     legend_fontsize=8,
     ... )
     """
+    from cnsplots._utils import palettes
+
     # Use settings values if parameters are not provided
     if color_cycle is None:
-        color_cycle = cns.settings.palette_qual
+        color_cycle = settings.palette_qual
     if color_map is None:
-        color_map = cns.settings.palette_seq
+        color_map = settings.palette_seq
     if title_fontsize is None:
-        title_fontsize = cns.settings.title_fontsize
+        title_fontsize = settings.title_fontsize
     if title_fontweight is None:
-        title_fontweight = cns.settings.title_fontweight
+        title_fontweight = settings.title_fontweight
     title_fontweight = _validate_title_fontweight(title_fontweight)
     if axes_linewidth is None:
-        axes_linewidth = cns.settings.axes_linewidth
+        axes_linewidth = settings.axes_linewidth
 
     _ensure_helvetica_bold()
     resolved_legend_fontsize, legend_title_fontsize = _resolve_legend_fontsizes(
@@ -242,53 +244,53 @@ def setup_matplotlib(
         return {
             **_font_rcparams(),
             "font.size": title_fontsize,
-            "savefig.bbox": cns.settings.savefig_bbox,
-            "savefig.pad_inches": cns.settings.savefig_pad_inches,
-            "savefig.dpi": cns.settings.savefig_dpi,
-            "savefig.transparent": cns.settings.savefig_transparent,
-            "svg.fonttype": cns.settings.svg_fonttype,
+            "savefig.bbox": settings.savefig_bbox,
+            "savefig.pad_inches": settings.savefig_pad_inches,
+            "savefig.dpi": settings.savefig_dpi,
+            "savefig.transparent": settings.savefig_transparent,
+            "svg.fonttype": settings.svg_fonttype,
             # Embed fonts as TrueType (Type 42) in the intermediate PDF so that
             # mutool can resolve every glyph back to a Unicode codepoint.  The
             # default Type 3 encoding has no Unicode map, causing math/symbol
             # glyphs (e.g. the minus sign in 10⁻⁹) to be converted to paths.
-            "pdf.fonttype": cns.settings.pdf_fonttype,
+            "pdf.fonttype": settings.pdf_fonttype,
             "axes.titlesize": title_fontsize,
             "axes.titleweight": title_fontweight,
-            "axes.titlelocation": cns.settings.axes_titlelocation,
+            "axes.titlelocation": settings.axes_titlelocation,
             "axes.labelsize": title_fontsize,
-            "axes.grid": cns.settings.axes_grid,
-            "axes.spines.top": cns.settings.axes_spines_top,
-            "axes.spines.right": cns.settings.axes_spines_right,
+            "axes.grid": settings.axes_grid,
+            "axes.spines.top": settings.axes_spines_top,
+            "axes.spines.right": settings.axes_spines_right,
             "axes.linewidth": axes_linewidth,
-            "axes.edgecolor": cns.settings.axes_edgecolor,
-            "axes.labelcolor": cns.settings.axes_labelcolor,
-            "axes.labelpad": cns.settings.axes_labelpad,
-            "axes.titlepad": cns.settings.axes_titlepad,
-            "axes.xmargin": cns.settings.axes_xmargin,
-            "axes.ymargin": cns.settings.axes_ymargin,
-            "axes.prop_cycle": mpl.cycler(color=cns.palettes(color_cycle)),
+            "axes.edgecolor": settings.axes_edgecolor,
+            "axes.labelcolor": settings.axes_labelcolor,
+            "axes.labelpad": settings.axes_labelpad,
+            "axes.titlepad": settings.axes_titlepad,
+            "axes.xmargin": settings.axes_xmargin,
+            "axes.ymargin": settings.axes_ymargin,
+            "axes.prop_cycle": mpl.cycler(color=palettes(color_cycle)),
             "image.cmap": color_map,
             "legend.fontsize": resolved_legend_fontsize,
             "legend.title_fontsize": legend_title_fontsize,
-            "legend.frameon": cns.settings.legend_frameon,
-            "legend.markerscale": cns.settings.legend_markerscale,
-            "legend.handlelength": cns.settings.legend_handlelength,
-            "legend.handleheight": cns.settings.legend_handleheight,
-            "legend.handletextpad": cns.settings.legend_handletextpad,
+            "legend.frameon": settings.legend_frameon,
+            "legend.markerscale": settings.legend_markerscale,
+            "legend.handlelength": settings.legend_handlelength,
+            "legend.handleheight": settings.legend_handleheight,
+            "legend.handletextpad": settings.legend_handletextpad,
             "xtick.labelsize": resolved_legend_fontsize,
-            "xtick.bottom": cns.settings.xtick_bottom,
-            "xtick.color": cns.settings.xtick_color,
-            "xtick.major.size": cns.settings.xtick_major_size,
-            "xtick.major.width": cns.settings.xtick_major_width,
-            "xtick.major.pad": cns.settings.xtick_major_pad,
-            "xtick.alignment": cns.settings.xtick_alignment,
+            "xtick.bottom": settings.xtick_bottom,
+            "xtick.color": settings.xtick_color,
+            "xtick.major.size": settings.xtick_major_size,
+            "xtick.major.width": settings.xtick_major_width,
+            "xtick.major.pad": settings.xtick_major_pad,
+            "xtick.alignment": settings.xtick_alignment,
             "ytick.labelsize": resolved_legend_fontsize,
-            "ytick.left": cns.settings.ytick_left,
-            "ytick.color": cns.settings.ytick_color,
-            "ytick.major.size": cns.settings.ytick_major_size,
-            "ytick.major.width": cns.settings.ytick_major_width,
-            "ytick.major.pad": cns.settings.ytick_major_pad,
-            "ytick.alignment": cns.settings.ytick_alignment,
+            "ytick.left": settings.ytick_left,
+            "ytick.color": settings.ytick_color,
+            "ytick.major.size": settings.ytick_major_size,
+            "ytick.major.width": settings.ytick_major_width,
+            "ytick.major.pad": settings.ytick_major_pad,
+            "ytick.alignment": settings.ytick_alignment,
         }
 
     for categorical in [
@@ -323,7 +325,7 @@ def setup_matplotlib(
     ]:
         if categorical not in mpl.colormaps:
             mpl.colormaps.register(
-                mpl.colors.ListedColormap(cns.palettes(categorical)), name=categorical
+                mpl.colors.ListedColormap(palettes(categorical)), name=categorical
             )
     for continues in [
         "parula",
@@ -335,7 +337,7 @@ def setup_matplotlib(
         "YlGnBu_custom",
     ]:
         if continues not in mpl.colormaps:
-            mpl.colormaps.register(cns.palettes(continues), name=continues)
+            mpl.colormaps.register(palettes(continues), name=continues)
 
     mpl.rcParams.update(config())
 
@@ -385,9 +387,9 @@ def setup_scanpy() -> None:
 
     setup_matplotlib()
     cast(Any, scanpy).set_figure_params(
-        scanpy=cns.settings.scanpy_use_default_style,
-        figsize=cns.settings.scanpy_figsize,
-        facecolor=cns.settings.scanpy_facecolor,
+        scanpy=settings.scanpy_use_default_style,
+        figsize=settings.scanpy_figsize,
+        facecolor=settings.scanpy_facecolor,
     )
 
 
@@ -485,14 +487,14 @@ def setup_ax(
     """
     # Use settings values if parameters are not provided
     if title_fontsize is None:
-        title_fontsize = cns.settings.title_fontsize
+        title_fontsize = settings.title_fontsize
     if title_fontweight is None:
-        title_fontweight = cns.settings.title_fontweight
+        title_fontweight = settings.title_fontweight
     title_fontweight = _validate_title_fontweight(title_fontweight)
     if axes_linewidth is None:
-        axes_linewidth = cns.settings.axes_linewidth
+        axes_linewidth = settings.axes_linewidth
     if colorbar_label is None:
-        colorbar_label = cns.settings.setup_ax_colorbar_label
+        colorbar_label = settings.setup_ax_colorbar_label
 
     _ensure_helvetica_bold()
     resolved_legend_fontsize, _ = _resolve_legend_fontsizes(
@@ -506,63 +508,63 @@ def setup_ax(
     ax.set_title(
         ax.get_title(),
         fontproperties=title_props,
-        loc=cns.settings.axes_titlelocation,
-        pad=cns.settings.axes_titlepad,
+        loc=settings.axes_titlelocation,
+        pad=settings.axes_titlepad,
     )
     ax.set_xlabel(
         ax.get_xlabel(),
         fontsize=title_fontsize,
-        color=cns.settings.axes_labelcolor,
-        labelpad=cns.settings.axes_labelpad,
+        color=settings.axes_labelcolor,
+        labelpad=settings.axes_labelpad,
     )
     ax.set_ylabel(
         ax.get_ylabel(),
         fontsize=title_fontsize,
-        color=cns.settings.axes_labelcolor,
-        labelpad=cns.settings.axes_labelpad,
+        color=settings.axes_labelcolor,
+        labelpad=settings.axes_labelpad,
     )
-    ax.spines["top"].set_visible(cns.settings.axes_spines_top)
-    ax.spines["right"].set_visible(cns.settings.axes_spines_right)
+    ax.spines["top"].set_visible(settings.axes_spines_top)
+    ax.spines["right"].set_visible(settings.axes_spines_right)
     for spine_name in ("top", "right", "bottom", "left"):
         ax.spines[spine_name].set_linewidth(axes_linewidth)
-        ax.spines[spine_name].set_color(cns.settings.axes_edgecolor)
+        ax.spines[spine_name].set_color(settings.axes_edgecolor)
     ax.tick_params(
         axis="x",
         labelsize=resolved_legend_fontsize,
-        colors=cns.settings.xtick_color,
-        length=cns.settings.xtick_major_size,
-        width=cns.settings.xtick_major_width,
-        pad=cns.settings.xtick_major_pad,
-        labelrotation=cns.settings.xtick_labelrotation,
-        bottom=cns.settings.xtick_bottom,
+        colors=settings.xtick_color,
+        length=settings.xtick_major_size,
+        width=settings.xtick_major_width,
+        pad=settings.xtick_major_pad,
+        labelrotation=settings.xtick_labelrotation,
+        bottom=settings.xtick_bottom,
     )
     ax.tick_params(
         axis="y",
         labelsize=resolved_legend_fontsize,
-        colors=cns.settings.ytick_color,
-        length=cns.settings.ytick_major_size,
-        width=cns.settings.ytick_major_width,
-        pad=cns.settings.ytick_major_pad,
-        labelrotation=cns.settings.ytick_labelrotation,
-        left=cns.settings.ytick_left,
+        colors=settings.ytick_color,
+        length=settings.ytick_major_size,
+        width=settings.ytick_major_width,
+        pad=settings.ytick_major_pad,
+        labelrotation=settings.ytick_labelrotation,
+        left=settings.ytick_left,
     )
     for tick_label in ax.get_xticklabels():
-        tick_label.set_horizontalalignment(cns.settings.xtick_alignment)
+        tick_label.set_horizontalalignment(settings.xtick_alignment)
     for tick_label in ax.get_yticklabels():
-        tick_label.set_verticalalignment(cns.settings.ytick_alignment)
-    ax.grid(cns.settings.axes_grid)
-    ax.margins(x=cns.settings.axes_xmargin, y=cns.settings.axes_ymargin)
+        tick_label.set_verticalalignment(settings.ytick_alignment)
+    ax.grid(settings.axes_grid)
+    ax.margins(x=settings.axes_xmargin, y=settings.axes_ymargin)
     cbar = ax.collections[0].colorbar if ax.collections else None
     if cbar is not None:
         cbar.ax.tick_params(
             labelsize=resolved_legend_fontsize,
-            colors=cns.settings.ytick_color,
+            colors=settings.ytick_color,
         )
         if colorbar_label:
             cbar.set_label(
                 colorbar_label,
                 fontsize=title_fontsize,
-                color=cns.settings.axes_labelcolor,
+                color=settings.axes_labelcolor,
             )
 
 
@@ -628,10 +630,10 @@ def setup_ggplot() -> str:
     >>> p < -ggplot(data, aes(x=x, y=y)) + geom_point()
     >>> p + theme_custom
     """
-    fontsize = cns.settings.ggplot_fontsize
-    font_family = json.dumps(cns.settings.ggplot_font_family)
-    font_face = json.dumps(cns.settings.ggplot_font_face)
-    text_color = json.dumps(cns.settings.ggplot_text_color)
+    fontsize = settings.ggplot_fontsize
+    font_family = json.dumps(settings.ggplot_font_family)
+    font_face = json.dumps(settings.ggplot_font_face)
+    text_color = json.dumps(settings.ggplot_text_color)
 
     return f"""
     fontsize <- {fontsize}

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -29,7 +29,8 @@ from statannotations.Annotator import Annotator
 from statannotations.PValueFormat import PValueFormat
 from statannotations.utils import DEFAULT
 
-import cnsplots as cns
+from cnsplots._settings import settings
+from cnsplots._setup import setup_matplotlib
 from cnsplots._svg import _save_svg
 
 logger = logging.getLogger(__name__)
@@ -49,9 +50,9 @@ CHOCOLATE = "#662506"
 
 def _legend_fontsize() -> int | float:
     """Return the configured legend font size, falling back to title size."""
-    legend_fontsize = cns.settings.legend_fontsize
+    legend_fontsize = settings.legend_fontsize
     if legend_fontsize is None:
-        return cns.settings.title_fontsize
+        return settings.title_fontsize
     return legend_fontsize
 
 
@@ -78,7 +79,7 @@ def _resize_legend_markers(
 
 def _annotation_text_color(color: Any) -> str:
     """Return a readable annotation color for a background fill."""
-    if not cns.settings.annotation_auto_contrast:
+    if not settings.annotation_auto_contrast:
         return "white"
 
     r, g, b, _ = mcolors.to_rgba(color)
@@ -224,15 +225,15 @@ def figure(height=None, width=None, color_cycle=None, color_map=None):
     >>> cns.heatmapplot(adata)
     """
     if height is None:
-        height = cns.settings.figure_height
+        height = settings.figure_height
     if width is None:
-        width = cns.settings.figure_width
+        width = settings.figure_width
     if color_cycle is None:
-        color_cycle = cns.settings.palette_qual
+        color_cycle = settings.palette_qual
     if color_map is None:
-        color_map = cns.settings.palette_seq
-    cns.setup_matplotlib(color_cycle, color_map)
-    plt.figure(figsize=(width / 72, height / 72), dpi=cns.settings.figure_dpi)
+        color_map = settings.palette_seq
+    setup_matplotlib(color_cycle, color_map)
+    plt.figure(figsize=(width / 72, height / 72), dpi=settings.figure_dpi)
 
 
 def savefig(filepath):
@@ -288,7 +289,7 @@ def savefig(filepath):
     fig = plt.gcf()
     for ax in fig.get_axes():
         apply_unicode_font(ax)
-    target_dpi = float(cns.settings.savefig_dpi)
+    target_dpi = float(settings.savefig_dpi)
     original_dpi = fig.dpi
     root, ext = os.path.splitext(filepath)
     try:
@@ -312,7 +313,7 @@ def savefig(filepath):
 
 def _get_export_bbox_inches(fig) -> mtransforms.Bbox | None:
     """Return a shared export bbox so raster and vector outputs align."""
-    if cns.settings.savefig_bbox != "tight":
+    if settings.savefig_bbox != "tight":
         return None
 
     original_canvas = fig.canvas
@@ -322,8 +323,8 @@ def _get_export_bbox_inches(fig) -> mtransforms.Bbox | None:
         bbox_inches = fig.get_tightbbox(agg_canvas.get_renderer())
         if bbox_inches is None:
             return None
-        if cns.settings.savefig_pad_inches:
-            bbox_inches = bbox_inches.padded(float(cns.settings.savefig_pad_inches))
+        if settings.savefig_pad_inches:
+            bbox_inches = bbox_inches.padded(float(settings.savefig_pad_inches))
         return mtransforms.Bbox.from_extents(*bbox_inches.extents)
     finally:
         fig.set_canvas(original_canvas)
@@ -386,10 +387,10 @@ def take_legend_out(title=None):
     plt.legend(
         handles=handles,
         labels=labels,
-        bbox_to_anchor=cns.settings.legend_out_bbox_to_anchor,
-        loc=cns.settings.legend_out_loc,
+        bbox_to_anchor=settings.legend_out_bbox_to_anchor,
+        loc=settings.legend_out_loc,
         title=title,
-        markerscale=cns.settings.legend_out_markerscale,
+        markerscale=settings.legend_out_markerscale,
     )
 
 
@@ -448,9 +449,9 @@ def add_panel_label(name="A", pad_left=None, pad_top=None):
     >>> cns.add_panel_label("B", pad_left=24, pad_top=6)
     """
     if pad_left is None:
-        pad_left = cns.settings.panel_pad_left
+        pad_left = settings.panel_pad_left
     if pad_top is None:
-        pad_top = cns.settings.panel_pad_top
+        pad_top = settings.panel_pad_top
 
     ax = plt.gca()
     fig = ax.figure
@@ -465,9 +466,9 @@ def add_panel_label(name="A", pad_left=None, pad_top=None):
         1,
         name,
         transform=transform,
-        fontsize=cns.settings.title_fontsize,
-        fontname=cns.settings.panel_label_fontname,
-        fontweight=cns.settings.panel_label_fontweight,
+        fontsize=settings.title_fontsize,
+        fontname=settings.panel_label_fontname,
+        fontweight=settings.panel_label_fontweight,
         ha="right",
         va="bottom",
     )
@@ -616,11 +617,11 @@ def _addcount_helper(data, attr, ax, axis="x"):
 
 
 def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=None):
-    resolved_format = cns.settings.pvalue_format if format is None else format
+    resolved_format = settings.pvalue_format if format is None else format
     if resolved_format not in {"star", "threshold", "full"}:
         raise ValueError("format must be one of: 'star', 'threshold', 'full'")
 
-    pvalue_fontsize = cns.settings.pvalue_fontsize
+    pvalue_fontsize = settings.pvalue_fontsize
 
     class PValueFormatNew(PValueFormat):
         def __init__(self):
@@ -703,7 +704,7 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=No
     annotator.configure(
         test=test if contingency is None else None,
         text_format="full" if resolved_format == "full" else "star",
-        loc=cns.settings.pvalue_loc,
+        loc=settings.pvalue_loc,
         line_width=0.5,
         line_offset=0,
         line_offset_to_group=0,

--- a/src/cnsplots/helpers/_heatmap.py
+++ b/src/cnsplots/helpers/_heatmap.py
@@ -11,7 +11,7 @@ import pandas as pd
 from PyComplexHeatmap import ClusterMapPlotter, DotClustermapPlotter
 from PyComplexHeatmap.clustermap import mm2inch
 
-import cnsplots as cns
+import cnsplots._utils as utils
 
 
 def _get_canvas_renderer(canvas: Any) -> Any | None:
@@ -461,7 +461,7 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
                 if annotation.label_max_width > self.label_max_width:
                     self.label_max_width = annotation.label_max_width
         if self.legend:
-            if cns._utils._is_qualitative_cmap(self.cmap):
+            if utils._is_qualitative_cmap(self.cmap):
                 if isinstance(self.data, pd.DataFrame):
                     unique_values = sorted(np.unique(self.data.values.astype(str)))
                 else:
@@ -472,7 +472,7 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
                 elif isinstance(self.cmap, dict):
                     cmap = {k: v for k, v in self.cmap.items() if k in unique_values}
                 else:
-                    cmap = cns._utils._get_hex_colors_from_colorbar(
+                    cmap = utils._get_hex_colors_from_colorbar(
                         self.cmap, len(unique_values)
                     )
                     cmap = {k: v for k, v in zip(unique_values, cmap)}

--- a/src/cnsplots/plots/__init__.py
+++ b/src/cnsplots/plots/__init__.py
@@ -1,65 +1,59 @@
 """Plot functions for cnsplots."""
 
-from cnsplots.plots._categorical import (
-    barplot,
-    donutplot,
-    lollipopplot,
-    pieplot,
-    stackplot,
-    stripplot,
-)
-from cnsplots.plots._distribution import (
-    boxplot,
-    distplot,
-    histplot,
-    kdeplot,
-    qqplot,
-    ridgeplot,
-    violinplot,
-)
-from cnsplots.plots._genomics import gseaplot, volcanoplot
-from cnsplots.plots._heatmap import confusionplot, dotplot, heatmapplot
-from cnsplots.plots._regression import lineplot, regplot, scatterplot, slopeplot
-from cnsplots.plots._sets import upsetplot, vennplot
-from cnsplots.plots._specialized import (
-    forestplot,
-    phyloplot,
-    placeholderplot,
-    rocplot,
-    sankeyplot,
-)
-from cnsplots.plots._survival import cumulativeincidenceplot, survivalplot
+from importlib import import_module
 
-__all__ = [
-    "barplot",
-    "boxplot",
-    "confusionplot",
-    "cumulativeincidenceplot",
-    "distplot",
-    "donutplot",
-    "dotplot",
-    "forestplot",
-    "gseaplot",
-    "heatmapplot",
-    "histplot",
-    "kdeplot",
-    "lineplot",
-    "lollipopplot",
-    "phyloplot",
-    "placeholderplot",
-    "pieplot",
-    "qqplot",
-    "regplot",
-    "ridgeplot",
-    "rocplot",
-    "sankeyplot",
-    "scatterplot",
-    "slopeplot",
-    "stackplot",
-    "stripplot",
-    "survivalplot",
-    "upsetplot",
-    "vennplot",
-    "violinplot",
-    "volcanoplot",
-]
+_LAZY_IMPORTS = {
+    "barplot": ("cnsplots.plots._categorical", "barplot"),
+    "boxplot": ("cnsplots.plots._distribution", "boxplot"),
+    "confusionplot": ("cnsplots.plots._heatmap", "confusionplot"),
+    "cumulativeincidenceplot": (
+        "cnsplots.plots._survival",
+        "cumulativeincidenceplot",
+    ),
+    "distplot": ("cnsplots.plots._distribution", "distplot"),
+    "donutplot": ("cnsplots.plots._categorical", "donutplot"),
+    "dotplot": ("cnsplots.plots._heatmap", "dotplot"),
+    "forestplot": ("cnsplots.plots._specialized", "forestplot"),
+    "gseaplot": ("cnsplots.plots._genomics", "gseaplot"),
+    "heatmapplot": ("cnsplots.plots._heatmap", "heatmapplot"),
+    "histplot": ("cnsplots.plots._distribution", "histplot"),
+    "kdeplot": ("cnsplots.plots._distribution", "kdeplot"),
+    "lineplot": ("cnsplots.plots._regression", "lineplot"),
+    "lollipopplot": ("cnsplots.plots._categorical", "lollipopplot"),
+    "phyloplot": ("cnsplots.plots._specialized", "phyloplot"),
+    "placeholderplot": ("cnsplots.plots._specialized", "placeholderplot"),
+    "pieplot": ("cnsplots.plots._categorical", "pieplot"),
+    "qqplot": ("cnsplots.plots._distribution", "qqplot"),
+    "regplot": ("cnsplots.plots._regression", "regplot"),
+    "ridgeplot": ("cnsplots.plots._distribution", "ridgeplot"),
+    "rocplot": ("cnsplots.plots._specialized", "rocplot"),
+    "sankeyplot": ("cnsplots.plots._specialized", "sankeyplot"),
+    "scatterplot": ("cnsplots.plots._regression", "scatterplot"),
+    "slopeplot": ("cnsplots.plots._regression", "slopeplot"),
+    "stackplot": ("cnsplots.plots._categorical", "stackplot"),
+    "stripplot": ("cnsplots.plots._categorical", "stripplot"),
+    "survivalplot": ("cnsplots.plots._survival", "survivalplot"),
+    "upsetplot": ("cnsplots.plots._sets", "upsetplot"),
+    "vennplot": ("cnsplots.plots._sets", "vennplot"),
+    "violinplot": ("cnsplots.plots._distribution", "violinplot"),
+    "volcanoplot": ("cnsplots.plots._genomics", "volcanoplot"),
+}
+
+__all__ = list(_LAZY_IMPORTS)
+
+
+def __getattr__(name: str):
+    """Load a plot function on first access."""
+    try:
+        module_name, attribute_name = _LAZY_IMPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+    value = getattr(import_module(module_name), attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Return eager and lazy module attributes."""
+    return sorted(set(globals()) | set(__all__))

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -12,7 +12,7 @@ import pandas as pd
 import seaborn as sns
 from matplotlib.patches import Patch
 
-import cnsplots as cns
+import cnsplots._utils as utils
 from cnsplots._utils import _legend_fontsize, _resize_legend_markers
 from cnsplots._validation import (
     validate_column_exists,
@@ -256,7 +256,7 @@ def barplot(
                 size=_legend_fontsize(),
             )
     if pairs is not None:
-        cns.utils._p_value_helper("t-test_welch", data, ax, plotting, pairs)
+        utils._p_value_helper("t-test_welch", data, ax, plotting, pairs)
     if show_legend:
         ax.legend(
             handles=legend_handles,
@@ -498,7 +498,7 @@ def lollipopplot(
             plotting["hue"] = hue
         if hue_order is not None:
             plotting["hue_order"] = hue_order
-        cns.utils._p_value_helper("t-test_welch", data, ax, plotting, pairs)
+        utils._p_value_helper("t-test_welch", data, ax, plotting, pairs)
 
     # Legend
     if show_legend:
@@ -621,22 +621,22 @@ def stackplot(
         ax = df.plot.bar(stacked=True, width=width, ax=ax, rot=0)
         ax.set_ylabel(value_label)
         ax.set_xlabel("")
-    cns.take_legend_out()
+    utils.take_legend_out()
     if addcount:
         count_attr = y if horizontal else x
         count_axis = "y" if horizontal else "x"
-        cns.utils._addcount_helper(data, count_attr, ax, axis=count_axis)
+        utils._addcount_helper(data, count_attr, ax, axis=count_axis)
     if pairs is not None:
         if horizontal:
             plotting = {"data": data2, "x": "count", "y": y, "order": bar_order}
         else:
             plotting = {"data": data2, "x": x, "y": "count", "order": bar_order}
         if contingency.shape[1] == 2:
-            cns.utils._p_value_helper(
+            utils._p_value_helper(
                 "fisher-exact", data2, ax, plotting, pairs, contingency
             )
         else:
-            cns.utils._p_value_helper(
+            utils._p_value_helper(
                 "chi-squared", data2, ax, plotting, pairs, contingency
             )
 
@@ -730,7 +730,7 @@ def stripplot(
         showmeans=showmeans,
     )
     if addcount:
-        cns.utils._addcount_helper(data, x, ax)
+        utils._addcount_helper(data, x, ax)
 
     _resize_legend_markers(ax.get_legend(), size**2, marker_size=size * 2)
 
@@ -799,7 +799,7 @@ def pieplot(
     )
     percent_texts = [text for text in ax.texts if text.get_text().endswith("%")]
     for wedge, text in zip(ax.patches, percent_texts):
-        text.set_color(cns.utils._annotation_text_color(wedge.get_facecolor()))
+        text.set_color(utils._annotation_text_color(wedge.get_facecolor()))
     legend_positions = {
         "right": {"loc": "upper left", "bbox_to_anchor": (1, 1.02)},
         "left": {"loc": "upper right", "bbox_to_anchor": (-0.02, 1.02)},
@@ -868,7 +868,7 @@ def donutplot(
         wedgeprops={"edgecolor": "black", "linewidth": 0.3, "width": 0.4},
     )
     plt.annotate(x, (0, 0), size=_legend_fontsize(), ha="center", va="center")
-    cns.utils._remove_edge_from_legend_items(ax)
+    utils._remove_edge_from_legend_items(ax)
     legend_positions = {
         "right": {"loc": "upper left", "bbox_to_anchor": (1, 1.02)},
         "left": {"loc": "upper right", "bbox_to_anchor": (-0.02, 1.02)},

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -16,7 +16,7 @@ import pandas as pd
 import scipy as sp
 import seaborn as sns
 
-import cnsplots as cns
+import cnsplots._utils as utils
 from cnsplots._utils import _legend_fontsize
 from cnsplots._validation import (
     validate_column_exists,
@@ -141,7 +141,7 @@ def boxplot(
                 line.set_mfc("white")
                 line.set_mec("white")
 
-    cns.utils._remove_edge_from_legend_items(ax)
+    utils._remove_edge_from_legend_items(ax)
     whis_str = (
         "minimum and maximum values"
         if whis == (0, 100)
@@ -156,10 +156,10 @@ def boxplot(
         f" correspond to the {whis_str}."
     )
     if pairs is not None:
-        cns.utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
+        utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
 
     if addcount:
-        cns.utils._addcount_helper(data, x, ax)
+        utils._addcount_helper(data, x, ax)
 
     return ax
 
@@ -257,10 +257,10 @@ def violinplot(
     if add_box:
         sns.boxplot(**boxplot_kwargs)
     if pairs is not None:
-        cns.utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
+        utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
 
     if addcount:
-        cns.utils._addcount_helper(data, x, ax)
+        utils._addcount_helper(data, x, ax)
 
     return ax
 
@@ -475,7 +475,7 @@ def histplot(**kwargs: Any) -> Axes:
     kwargs.setdefault("edgecolor", None)
     ax = sns.histplot(**kwargs)
     if track_detached_axes:
-        cns.utils._capture_detached_axes_layout(ax, existing_axes)
+        utils._capture_detached_axes_layout(ax, existing_axes)
     return ax
 
 
@@ -525,7 +525,7 @@ def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes
 
     categories = data[y].unique()
     n = len(categories)
-    colors = cns.utils._get_hex_colors_from_colorbar(cmap, n)
+    colors = utils._get_hex_colors_from_colorbar(cmap, n)
     ax = plt.gca()
 
     from scipy.stats import gaussian_kde

--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -11,7 +11,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 
-import cnsplots as cns
+import cnsplots._utils as utils
+from cnsplots._setup import setup_ax
 from cnsplots._utils import _legend_fontsize, _resize_legend_markers
 from cnsplots._validation import (
     validate_columns_exist,
@@ -115,8 +116,8 @@ def volcanoplot(
         de.loc[de[symbol].isin(show_list) & down, hue] = "Down"
     de = de.sort_values(hue)
 
-    blue = cns.get_hexcolors_from_apalette([0], "BlueRed")
-    red = cns.get_hexcolors_from_apalette([1], "BlueRed")
+    blue = utils.get_hexcolors_from_apalette([0], "BlueRed")
+    red = utils.get_hexcolors_from_apalette([1], "BlueRed")
     ax = sns.scatterplot(
         data=de,
         x=x,
@@ -157,7 +158,7 @@ def volcanoplot(
         linewidth=0.8,
         dashes=(8, 5),
     )
-    cns.take_legend_out()
+    utils.take_legend_out()
     _resize_legend_markers(ax.get_legend(), 20)
 
     return ax
@@ -262,6 +263,6 @@ def gseaplot(
         labelspacing=0.2,
         markerscale=1.5,
     )
-    cns.setup_ax(ax, colorbar_label="")
+    setup_ax(ax, colorbar_label="")
     plt.xlabel("Normalized Enrichment Score (NES)")
     return ax

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -22,7 +22,8 @@ import seaborn as sns
 from natsort import natsort_keygen
 from scipy.stats import fisher_exact
 
-import cnsplots as cns
+import cnsplots._utils as utils
+from cnsplots._settings import settings
 import cnsplots.helpers._heatmap as helper_heatmap
 from cnsplots._utils import _legend_fontsize
 from cnsplots._validation import (
@@ -46,8 +47,8 @@ def _style_plotter_colorbars(cbars: list[Any]) -> None:
         cbar.ax.tick_params(
             size=0,
             labelsize=legend_fontsize,
-            colors=cns.settings.ytick_color,
-            pad=cns.settings.ytick_major_pad,
+            colors=settings.ytick_color,
+            pad=settings.ytick_major_pad,
         )
         if font_family:
             for tick_label in cbar.ax.get_yticklabels():
@@ -186,7 +187,7 @@ def heatmapplot(
         validate_adata_var_columns(adata, col_split, "heatmapplot")
 
     if cmap is None:
-        cmap = cns.settings.palette_seq
+        cmap = settings.palette_seq
     cat_palettes = ["Set1", "Set2", "Ecotyper1", "Dark2", "Ecotyper2", "Set3"]
     cont_palettes = ["parula", "gnuplot", "bwr", "hot"]
     cbar_titles = [label]
@@ -316,7 +317,7 @@ def heatmapplot(
     cmp.ax_heatmap.set_axis_on()
     sns.despine(ax=cmp.ax_heatmap, bottom=False, left=False, top=False, right=False)
     for s in ["top", "bottom", "left", "right"]:
-        cmp.ax_heatmap.spines[s].set_linewidth(cns.settings.axes_linewidth)
+        cmp.ax_heatmap.spines[s].set_linewidth(settings.axes_linewidth)
 
     _style_plotter_colorbars(cmp.cbars)
     helper_heatmap._capture_detached_colorbar_layout(cmp)
@@ -466,7 +467,7 @@ def dotplot(
             which="major",
             direction="out",
             length=1.5,
-            width=cns.settings.axes_linewidth,
+            width=settings.axes_linewidth,
             bottom=True,
             left=True,
             top=False,
@@ -480,7 +481,7 @@ def dotplot(
     cmp.ax_heatmap.grid(False)
     sns.despine(ax=cmp.ax_heatmap, top=True, right=True, bottom=False, left=False)
     for s in ["bottom", "left"]:
-        cmp.ax_heatmap.spines[s].set_linewidth(cns.settings.axes_linewidth)
+        cmp.ax_heatmap.spines[s].set_linewidth(settings.axes_linewidth)
 
     _style_plotter_colorbars(cmp.cbars)
     return cmp
@@ -616,7 +617,7 @@ def confusionplot(
                     str(int(cell_value)),
                     ha="center",
                     va="center",
-                    color=cns.utils._annotation_text_color((r, g, b, 1.0)),
+                    color=utils._annotation_text_color((r, g, b, 1.0)),
                 )
 
     # Remove colorbar to match your original style

--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -15,7 +15,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
 
-import cnsplots as cns
+import cnsplots._utils as utils
+from cnsplots._setup import setup_ax
 from cnsplots._utils import _legend_fontsize
 
 
@@ -146,17 +147,17 @@ def upsetplot(
         plot_fig.patch.set_facecolor("none")
         plot_fig.patch.set_alpha(0)
     ax_tot = axes.get("totals")
-    cns.setup_ax(axes["matrix"])
-    cns.setup_ax(axes["shading"])
+    setup_ax(axes["matrix"])
+    setup_ax(axes["shading"])
     axes["shading"].tick_params(axis="y", which="both", length=0, left=False)
-    cns.setup_ax(axes["intersections"])
+    setup_ax(axes["intersections"])
     axes["matrix"].tick_params(axis="both", which="both", length=0)
     legend_fontsize = _legend_fontsize()
     for txt in axes["intersections"].texts:
         _normalize_text_position(txt)
         txt.set_size(legend_fontsize)
     if ax_tot is not None:
-        cns.setup_ax(ax_tot)
+        setup_ax(ax_tot)
         for txt in ax_tot.texts:
             _normalize_text_position(txt)
             txt.set_size(legend_fontsize)
@@ -245,7 +246,7 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
             patch.set_linewidth(0.5)
             get_facecolor = getattr(patch, "get_facecolor", None)
             if callable(get_facecolor):
-                label.set_color(cns.utils._annotation_text_color(get_facecolor()))
+                label.set_color(utils._annotation_text_color(get_facecolor()))
         except AttributeError:
             pass
     for area in names:

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -14,7 +14,6 @@ import seaborn as sns
 from matplotlib.patches import Circle, FancyBboxPatch, Polygon
 from sklearn.metrics import auc, roc_curve
 
-import cnsplots.helpers._phylo as helper_phylo
 import cnsplots.helpers._sankey as helper_sankey
 from cnsplots._utils import _legend_fontsize
 from cnsplots._validation import (
@@ -231,6 +230,8 @@ def phyloplot(adata: AnnData) -> None:
     """
     # Validate inputs
     validate_anndata(adata, "adata", "phyloplot")
+
+    import cnsplots.helpers._phylo as helper_phylo
 
     helper_phylo.phyloplot(adata)
 

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -14,7 +14,6 @@ import num2tex
 import numpy as np
 import pandas as pd
 
-import cnsplots.helpers._cmprsk as helper_cmprsk
 from cnsplots._validation import (
     validate_binary_column,
     validate_column_type,
@@ -377,6 +376,7 @@ def cumulativeincidenceplot(
             f"non-negative, got {censor_mark_length!r}"
         )
 
+    import cnsplots.helpers._cmprsk as helper_cmprsk
     import lifelines as ll
     from lifelines.plotting import add_at_risk_counts
 

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import anndata as ad
+import lifelines as ll
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -46,7 +47,7 @@ def test_methods_internal_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
         ) -> None:
             return None
 
-    monkeypatch.setattr(_methods.ll, "CoxPHFitter", FakeCoxPHFitter)
+    monkeypatch.setattr(ll, "CoxPHFitter", FakeCoxPHFitter)
     model = cns.CoxModel(
         pd.DataFrame({"time": [1, 2], "event": [1, 0], "x": [0, 1]}),
         duration="time",
@@ -378,7 +379,7 @@ def test_upsetplot_clears_white_figure_patch(monkeypatch: pytest.MonkeyPatch) ->
         UpSet=FakeUpSet,
     )
     monkeypatch.setattr(sets_mod, "_import_upsetplot_module", lambda: fake_module)
-    monkeypatch.setattr(cns, "setup_ax", lambda ax: None)
+    monkeypatch.setattr(sets_mod, "setup_ax", lambda ax: None)
 
     axes = cns.upsetplot({"A": {"x"}, "B": {"x", "y"}})
 
@@ -1262,7 +1263,7 @@ def test_remaining_visual_internal_coverage(
         lambda self: volcano_legend,
         raising=False,
     )
-    monkeypatch.setattr(genomics_mod.cns, "take_legend_out", lambda: None)
+    monkeypatch.setattr(genomics_mod.utils, "take_legend_out", lambda: None)
     cns.figure(120, 120)
     cns.volcanoplot(volcano_df)
     assert volcano_legend.legend_handles[0].sizes == [20]

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import lifelines as ll
 import numpy as np
 import pandas as pd
 import pytest
@@ -109,7 +110,7 @@ def test_cox_model_warns_for_failed_unstratified_fit(
         def fit(self, *args: Any, **kwargs: Any) -> None:
             raise ValueError("invalid formula")
 
-    monkeypatch.setattr(_methods.ll, "CoxPHFitter", FailingCoxPHFitter)
+    monkeypatch.setattr(ll, "CoxPHFitter", FailingCoxPHFitter)
     model = cns.CoxModel(
         pd.DataFrame({"time": [1.0, 2.0], "event": [0, 1]}),
         duration="time",

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import ast
 import builtins
 import inspect
 import re
+import subprocess
 import sys
 import types
 from collections.abc import Mapping, Sequence
@@ -38,6 +40,101 @@ def _svg_view_box_size(path: Path) -> tuple[float, float]:
         raise AssertionError(f"viewBox not found in {path}")
     width, height = (float(value) for value in match.groups())
     return width, height
+
+
+def test_root_import_is_lazy_and_side_effect_free() -> None:
+    script = """
+import logging
+import sys
+import warnings
+
+logger_levels = {
+    "cnsplots": 11,
+    "fontTools": 12,
+    "matplotlib": 13,
+}
+for logger_name, level in logger_levels.items():
+    logging.getLogger(logger_name).setLevel(level)
+warning_filters = list(warnings.filters)
+modules_before = set(sys.modules)
+
+import cnsplots
+
+assert list(warnings.filters) == warning_filters
+assert all(
+    logging.getLogger(name).level == level for name, level in logger_levels.items()
+)
+new_modules = set(sys.modules) - modules_before
+assert not any(name.startswith("cnsplots.") for name in new_modules)
+heavy_modules = {
+    "Bio",
+    "PyComplexHeatmap",
+    "gseapy",
+    "lifelines",
+    "matplotlib",
+    "numpy",
+    "pandas",
+    "scanpy",
+    "scipy",
+    "seaborn",
+    "sklearn",
+    "statsmodels",
+}
+assert not ({name.split(".")[0] for name in new_modules} & heavy_modules)
+
+_ = cnsplots.settings
+assert list(warnings.filters) == warning_filters
+assert all(
+    logging.getLogger(name).level == level for name, level in logger_levels.items()
+)
+
+_ = cnsplots.barplot
+assert "cnsplots.plots._categorical" in sys.modules
+assert not {
+    "cnsplots.plots._genomics",
+    "cnsplots.plots._heatmap",
+    "cnsplots.plots._sets",
+    "cnsplots.plots._survival",
+} & set(sys.modules)
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+    src_path = Path(__file__).parents[1] / "src"
+    no_site_script = (
+        f"import sys; sys.path.insert(0, {str(src_path)!r}); "
+        "import cnsplots; assert len(cnsplots.__all__) == 63"
+    )
+    subprocess.run([sys.executable, "-S", "-c", no_site_script], check=True)
+
+
+def test_lazy_facade_introspection() -> None:
+    import cnsplots.plots as plots
+
+    assert set(cns.__all__) <= set(dir(cns))
+    assert set(plots.__all__) <= set(dir(plots))
+    assert plots.barplot is cns.barplot
+    assert plots.__dict__["barplot"] is plots.barplot
+
+    with pytest.raises(AttributeError, match="missing_public_name"):
+        getattr(cns, "missing_public_name")
+    with pytest.raises(AttributeError, match="missing_plot_name"):
+        getattr(plots, "missing_plot_name")
+
+
+def test_internal_modules_do_not_import_root_facade() -> None:
+    source_root = Path(__file__).parents[1] / "src" / "cnsplots"
+    offenders: list[str] = []
+    for path in source_root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import) and any(
+                alias.name == "cnsplots" for alias in node.names
+            ):
+                offenders.append(f"{path.relative_to(source_root)}:{node.lineno}")
+            if isinstance(node, ast.ImportFrom) and node.module == "cnsplots":
+                offenders.append(f"{path.relative_to(source_root)}:{node.lineno}")
+
+    assert offenders == []
 
 
 def test_public_namespace_contract() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/d4/6585f3b6fdb75648bca294664af4becc8aa2fb3fb08f4e4e9fd27e10d773/adjusttext-1.3.0.tar.gz", hash = "sha256:4ab75cd4453af4828876ac3e964f2c49be642ea834f0c1f7449558d5f12cbca1", size = 15724, upload-time = "2024-10-31T16:45:36.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/1c/8feedd607cc14c5df9aef74fe3af9a99bf660743b842a9b5b1865326b4aa/adjustText-1.3.0-py3-none-any.whl", hash = "sha256:da23d7b24b6db5ffa039bb136bfa556207365e32f48ac74b07ad26dd485bc691", size = 13154, upload-time = "2024-10-31T16:45:35.227Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/80/7ad35ee5321a86b842f9e8516c8ae4c86f58db7b40e82ce9759f94517a50/adjusttext-1.3.0-py3-none-any.whl", hash = "sha256:bc6c118cd9d7caf6ae37f9355e51d840a2d7f64b4fb2956b8401de27c5af803b", size = 13264, upload-time = "2026-06-08T16:40:05.041Z" },
 ]
 
 [[package]]
@@ -53,14 +54,14 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "array-api-compat", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "h5py", marker = "python_full_version < '3.11'" },
-    { name = "natsort", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pandas", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "array-api-compat" },
+    { name = "exceptiongroup" },
+    { name = "h5py" },
+    { name = "natsort" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/bb/895fa2e9f8cd6d1c058aa90759da715037d0f11e23713e692537555549d7/anndata-0.11.4.tar.gz", hash = "sha256:4ce08d09d2ccb5f37d32790363bbcc7fc1b79863842296ae4badfaf48c736e24", size = 541143, upload-time = "2025-03-26T11:38:54.566Z" }
 wheels = [
@@ -77,15 +78,15 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "array-api-compat", marker = "python_full_version >= '3.11'" },
-    { name = "h5py", marker = "python_full_version >= '3.11'" },
-    { name = "legacy-api-wrap", marker = "python_full_version >= '3.11'" },
-    { name = "natsort", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pandas", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "zarr", marker = "python_full_version >= '3.11'" },
+    { name = "array-api-compat" },
+    { name = "h5py" },
+    { name = "legacy-api-wrap" },
+    { name = "natsort" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "zarr" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/81/29809c5710123bb37ea9d9de9da0e83dda5be9d8419cce256e4406b37c44/anndata-0.12.10.tar.gz", hash = "sha256:73a73c99ca50400eb9dc7f2fdd400cf677ea4bb9ef1f7c04691c0fc557e43d7f", size = 2254675, upload-time = "2026-02-06T14:02:24.716Z" }
 wheels = [
@@ -289,7 +290,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -482,8 +483,9 @@ version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "adjusttext" },
+    { name = "anndata", version = "0.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "anndata", version = "0.12.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "biopython" },
-    { name = "glasbey" },
     { name = "gseapy" },
     { name = "lifelines", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "lifelines", version = "0.30.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -492,7 +494,6 @@ dependencies = [
     { name = "matplotlib-venn" },
     { name = "natsort" },
     { name = "num2tex" },
-    { name = "numba" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "palettable" },
@@ -516,6 +517,7 @@ dev = [
     { name = "bump-my-version" },
     { name = "fastcluster" },
     { name = "furo" },
+    { name = "glasbey" },
     { name = "ipykernel" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -537,11 +539,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "adjusttext" },
+    { name = "anndata" },
     { name = "biopython" },
     { name = "bump-my-version", marker = "extra == 'dev'" },
     { name = "fastcluster", marker = "extra == 'dev'" },
     { name = "furo", marker = "extra == 'dev'" },
-    { name = "glasbey" },
+    { name = "glasbey", marker = "extra == 'dev'" },
     { name = "gseapy" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "lifelines", specifier = ">=0.30,<0.31" },
@@ -551,7 +554,6 @@ requires-dist = [
     { name = "myst-parser", marker = "extra == 'dev'" },
     { name = "natsort" },
     { name = "num2tex" },
-    { name = "numba", specifier = ">=0.58.1" },
     { name = "numpy" },
     { name = "palettable" },
     { name = "pandas" },
@@ -617,7 +619,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -689,7 +691,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -971,7 +973,7 @@ name = "donfig"
 version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
@@ -983,7 +985,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1004,7 +1006,7 @@ name = "fast-array-utils"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1e/ff/93edc904b05a3260d5a690ac6dcdcd3cce10065b6fb56cdc683f80969456/fast_array_utils-1.3.1.tar.gz", hash = "sha256:34d175a63e9208c6fcbcb3cc18f75480ecdeaeed248759da0e74ab8fbcf55808", size = 330367, upload-time = "2025-11-18T10:20:32.016Z" }
 wheels = [
@@ -1013,10 +1015,10 @@ wheels = [
 
 [package.optional-dependencies]
 accel = [
-    { name = "numba", marker = "python_full_version >= '3.12'" },
+    { name = "numba" },
 ]
 sparse = [
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -1433,17 +1435,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/61/1810830e8b93c72dcd3c0f150c80a00c3deb229562d9423807ec92c3a539/ipython-8.38.0.tar.gz", hash = "sha256:9cfea8c903ce0867cc2f23199ed8545eb741f3a69420bfcf3743ad1cec856d39", size = 5513996, upload-time = "2026-01-05T10:59:06.901Z" }
 wheels = [
@@ -1458,17 +1460,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version == '3.11.*'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version == '3.11.*'" },
-    { name = "jedi", marker = "python_full_version == '3.11.*'" },
-    { name = "matplotlib-inline", marker = "python_full_version == '3.11.*'" },
-    { name = "pexpect", marker = "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "stack-data", marker = "python_full_version == '3.11.*'" },
-    { name = "traitlets", marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -1484,16 +1486,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -1505,7 +1507,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1715,13 +1717,13 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "autograd", marker = "python_full_version < '3.11'" },
-    { name = "autograd-gamma", marker = "python_full_version < '3.11'" },
-    { name = "formulaic", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "autograd" },
+    { name = "autograd-gamma" },
+    { name = "formulaic" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "pandas" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ea/4f/f0b363278d40baf7d7a03217bee839cb880946c62109f243391c8754bb09/lifelines-0.30.0.tar.gz", hash = "sha256:f7f6f6275fcb167fe0f5b1ef98f868993f9c074cb74b1dd6e92736efa854be18", size = 383221, upload-time = "2024-10-29T12:00:43.513Z" }
 wheels = [
@@ -1738,13 +1740,13 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "autograd", marker = "python_full_version >= '3.11'" },
-    { name = "autograd-gamma", marker = "python_full_version >= '3.11'" },
-    { name = "formulaic", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "autograd" },
+    { name = "autograd-gamma" },
+    { name = "formulaic" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pandas" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/4b/f92ca958b11284f9e80075d6b80b8150a3a231edb55e73a42878f786a54a/lifelines-0.30.3.tar.gz", hash = "sha256:acd1e0ecada4280c7bb2948f39c760a0f9158a57d752c8ca29f984a86c698b7f", size = 690663, upload-time = "2026-03-05T16:54:44.365Z" }
 wheels = [
@@ -1905,7 +1907,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version < '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -1922,7 +1924,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -2144,12 +2146,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -2166,12 +2168,12 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "jinja2" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
 wheels = [
@@ -2287,8 +2289,8 @@ name = "numcodecs"
 version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
 wheels = [
@@ -3263,32 +3265,32 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "anndata", version = "0.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "anndata", version = "0.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
     { name = "anndata", version = "0.12.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "h5py", marker = "python_full_version < '3.12'" },
-    { name = "joblib", marker = "python_full_version < '3.12'" },
-    { name = "legacy-api-wrap", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib", marker = "python_full_version < '3.12'" },
-    { name = "natsort", marker = "python_full_version < '3.12'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "h5py" },
+    { name = "joblib" },
+    { name = "legacy-api-wrap" },
+    { name = "matplotlib" },
+    { name = "natsort" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numba", marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numba" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pandas", marker = "python_full_version < '3.12'" },
-    { name = "patsy", marker = "python_full_version < '3.12'" },
-    { name = "pynndescent", marker = "python_full_version < '3.12'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "seaborn", marker = "python_full_version < '3.12'" },
-    { name = "session-info2", marker = "python_full_version < '3.12'" },
-    { name = "statsmodels", marker = "python_full_version < '3.12'" },
-    { name = "tqdm", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-    { name = "umap-learn", marker = "python_full_version < '3.12'" },
+    { name = "seaborn" },
+    { name = "session-info2" },
+    { name = "statsmodels" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "umap-learn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/a8/285f1a9c995906b7e0ae3c399208fe67cfba8126dd31359dfef0908f6edc/scanpy-1.11.5.tar.gz", hash = "sha256:b2ef5476dfb1144b7dd0fae90b0198699c7988e6b27f083904150642c7ba6b89", size = 14088122, upload-time = "2025-10-21T08:24:43.999Z" }
 wheels = [
@@ -3304,28 +3306,28 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "anndata", version = "0.12.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "fast-array-utils", extra = ["accel", "sparse"], marker = "python_full_version >= '3.12'" },
-    { name = "h5py", marker = "python_full_version >= '3.12'" },
-    { name = "joblib", marker = "python_full_version >= '3.12'" },
-    { name = "legacy-api-wrap", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib", marker = "python_full_version >= '3.12'" },
-    { name = "natsort", marker = "python_full_version >= '3.12'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "numba", marker = "python_full_version >= '3.12'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pandas", marker = "python_full_version >= '3.12'" },
-    { name = "patsy", marker = "python_full_version >= '3.12'" },
-    { name = "pynndescent", marker = "python_full_version >= '3.12'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "seaborn", marker = "python_full_version >= '3.12'" },
-    { name = "session-info2", marker = "python_full_version >= '3.12'" },
-    { name = "statsmodels", marker = "python_full_version >= '3.12'" },
-    { name = "tqdm", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
-    { name = "umap-learn", marker = "python_full_version >= '3.12'" },
+    { name = "anndata", version = "0.12.10", source = { registry = "https://pypi.org/simple" } },
+    { name = "fast-array-utils", extra = ["accel", "sparse"] },
+    { name = "h5py" },
+    { name = "joblib" },
+    { name = "legacy-api-wrap" },
+    { name = "matplotlib" },
+    { name = "natsort" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "seaborn" },
+    { name = "session-info2" },
+    { name = "statsmodels" },
+    { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "umap-learn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/3e/180968c66be48f9dab747330beb2056df5bb7a115a56d3700da149c48916/scanpy-1.12.tar.gz", hash = "sha256:8139840bb948ce0aa0798c9b8b88c1df4f06c27641a792f0995d39cd4dcf858a", size = 14418589, upload-time = "2026-01-23T13:25:23.414Z" }
 wheels = [
@@ -3340,10 +3342,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -3389,10 +3391,10 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -3442,7 +3444,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3503,7 +3505,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -3628,23 +3630,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -3661,23 +3663,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.11'" },
-    { name = "babel", marker = "python_full_version >= '3.11'" },
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "imagesize", marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -3692,7 +3694,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/f0/43c6a5ff3e7b08a8c3b32f81b859f1b518ccc31e45f22e2b41ced38be7b9/sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55", size = 36282, upload-time = "2025-01-16T18:25:30.958Z" }
 wheels = [
@@ -3709,7 +3711,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
 wheels = [
@@ -3750,7 +3752,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -3767,7 +3769,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
 wheels = [
@@ -4267,12 +4269,12 @@ name = "zarr"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "donfig", marker = "python_full_version >= '3.11'" },
-    { name = "google-crc32c", marker = "python_full_version >= '3.11'" },
-    { name = "numcodecs", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "donfig" },
+    { name = "google-crc32c" },
+    { name = "numcodecs" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
 wheels = [


### PR DESCRIPTION
## What changed

- Replace eager root and plotting exports with cached lazy lookups while preserving the public API.
- Remove import-time warning and logger mutations and reverse internal imports away from the root facade.
- Audit dependency metadata: declare AnnData directly, keep Glasbey development-only, and remove Numba as a direct requirement while retaining all feature backends in the default installation.
- Document the batteries-included installation and lazy runtime behavior.

## Testing

- make test — 163 passed with 100% coverage
- make lint — all hooks passed
- uv lock --check
- Built and inspected wheel metadata

## Risks and follow-ups

- Star imports intentionally resolve every public lazy export; normal package imports remain lightweight.
- No follow-up work is required.