### PR TITLE
🐛 Fix gseaplot default semantics

### DIFF
--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -20,6 +20,14 @@ from cnsplots._validation import (
     validate_dataframe_not_empty,
 )
 
+_CNS_CONTINUOUS_CMAPS = {
+    "BuRd_custom",
+    "OrBu_custom",
+    "WhYlOrRd_custom",
+    "YlGnBu_custom",
+    "parula",
+}
+
 
 def volcanoplot(
     data: pd.DataFrame,
@@ -172,6 +180,7 @@ def gseaplot(
     cmap: str = "BuRd_custom",
     top_term: int = 20,
     size: float = 1.8,
+    significance_column: str = "FDR q-val",
 ) -> Axes:
     """
     Create a Gene Set Enrichment Analysis (GSEA) dot plot.
@@ -189,13 +198,17 @@ def gseaplot(
     color : str, default: 'NES'
         Column name for the variable to use for dot color encoding.
     cutoff : float, default: 0.05
-        Significance cutoff for filtering gene sets.
+        Significance cutoff applied to ``significance_column`` when filtering
+        gene sets.
     cmap : str, default: 'BuRd_custom'
         Colormap for encoding the color variable.
     top_term : int, default: 20
         Maximum number of top gene sets to display.
     size : float, default: 1.8
         Scaling factor for dot sizes.
+    significance_column : str, default: 'FDR q-val'
+        Column containing significance values used to filter gene sets by
+        ``cutoff``. This is independent of the ``color`` encoding.
 
     Returns
     -------
@@ -227,18 +240,21 @@ def gseaplot(
     """
     # Validate inputs
     validate_dataframe(data, "data", "gseaplot")
-    validate_columns_exist(data, [y, "NES", color], "gseaplot")
+    validate_columns_exist(data, [y, "NES", color, significance_column], "gseaplot")
     validate_dataframe_not_empty(data, "gseaplot")
 
     import gseapy as gp
 
+    plot_data = data.loc[data[significance_column] <= cutoff].copy()
+    resolved_cmap = utils.palettes(cmap) if cmap in _CNS_CONTINUOUS_CMAPS else cmap
+
     ax = plt.gca()
     gp.dotplot(
-        data,
-        cmap=cmap,
+        plot_data,
+        cmap=resolved_cmap,
         y=y,
         x="NES",
-        cutoff=cutoff,
+        cutoff=np.inf,
         column=color,
         ax=ax,
         top_term=top_term,

--- a/tests/test_plot_behavior_regressions.py
+++ b/tests/test_plot_behavior_regressions.py
@@ -162,3 +162,59 @@ def test_gseaplot_raises_when_backend_does_not_create_legend(
     cns.figure(120, 120)
     with pytest.raises(RuntimeError, match="did not produce a legend"):
         cns.gseaplot(gsea_plot_df, y="Clean_Term")
+
+
+def test_gseaplot_filters_significance_independently_from_color(
+    monkeypatch: pytest.MonkeyPatch,
+    gsea_plot_df: pd.DataFrame,
+) -> None:
+    captured_data: list[pd.DataFrame] = []
+    captured_options: dict[str, object] = {}
+
+    def fake_dotplot(
+        data: pd.DataFrame,
+        cmap: object,
+        y: str,
+        x: str,
+        cutoff: float,
+        column: str,
+        ax: plt.Axes,
+        top_term: int,
+        size: float,
+    ) -> None:
+        captured_data.append(data.copy())
+        captured_options.update(cmap=cmap, cutoff=cutoff, column=column)
+        scatter = ax.scatter(data[x], np.arange(len(data)), c=data[column])
+        plt.gcf().colorbar(scatter, ax=ax)
+        handle = plt.Line2D([], [], marker="o", linestyle="none", color="black")
+        ax.legend([handle], ["20"], title="size")
+
+    monkeypatch.setitem(
+        sys.modules, "gseapy", types.SimpleNamespace(dotplot=fake_dotplot)
+    )
+    data = gsea_plot_df.assign(score=[10.0, 20.0, 30.0])
+    data.loc[data["Clean_Term"] == "Pathway B", "FDR q-val"] = 0.2
+
+    cns.gseaplot(
+        data,
+        y="Clean_Term",
+        color="score",
+        cutoff=0.05,
+        cmap="viridis",
+        significance_column="FDR q-val",
+    )
+
+    assert captured_data[0]["Clean_Term"].tolist() == ["Pathway A", "Pathway C"]
+    assert captured_data[0]["score"].tolist() == [10.0, 30.0]
+    assert captured_options == {
+        "cmap": "viridis",
+        "cutoff": np.inf,
+        "column": "score",
+    }
+
+
+def test_gseaplot_validates_significance_column(
+    gsea_plot_df: pd.DataFrame,
+) -> None:
+    with pytest.raises(ValueError, match="FDR q-val"):
+        cns.gseaplot(gsea_plot_df.drop(columns="FDR q-val"), y="Clean_Term")

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -455,6 +455,33 @@ def test_public_prerank_and_gseaplot_use_real_gseapy_backend() -> None:
     assert rendered_nes == pytest.approx(expected_nes)
 
 
+def test_gseaplot_direct_call_resolves_default_colormap_locally() -> None:
+    src_path = Path(__file__).parents[1] / "src"
+    script = f"""
+import sys
+sys.path.insert(0, {str(src_path)!r})
+
+import matplotlib
+matplotlib.use("Agg", force=True)
+import pandas as pd
+
+import cnsplots as cns
+
+assert "BuRd_custom" not in matplotlib.colormaps
+data = pd.DataFrame(
+    {{
+        "Term": ["Significant", "Not significant"],
+        "NES": [2.0, -1.5],
+        "FDR q-val": [0.01, 0.2],
+    }}
+)
+ax = cns.gseaplot(data, y="Term")
+assert [label.get_text() for label in ax.get_yticklabels()] == ["Significant"]
+assert "BuRd_custom" not in matplotlib.colormaps
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
 def test_public_prerank_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
     real_import = builtins.__import__
 


### PR DESCRIPTION
## What changed

- Resolve cnsplots continuous colormaps locally so direct `gseaplot()` calls do not require global Matplotlib setup.
- Add `significance_column`, defaulting to `FDR q-val`, and filter significance independently from color encoding.
- Add regression coverage for clean-process defaults, independent filtering, and significance-column validation.

## Testing

- `make test` — 166 passed with 100% coverage.
- `make lint` — all hooks passed.

## Risks and follow-ups

- Calls using result tables without `FDR q-val` must select their significance column explicitly.
- No follow-up work is currently required.