### PR TITLE
🐛 Fix plotting and layout defects

### DIFF
--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, cast
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from matplotlib.backend_bases import DrawEvent, Event, RendererBase
 
@@ -20,6 +22,200 @@ from cnsplots._setup import setup_matplotlib
 
 _LEFT_DECORATION_TOLERANCE_PX = 0.5
 _RELAYOUT_MAX_PASSES = 3
+
+
+def _validate_positive_finite_dimension(
+    name: str,
+    value: int | float,
+) -> int | float:
+    """Validate a dimension used to construct a matplotlib figure or axes."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a number")
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be a positive finite number")
+    return value
+
+
+@dataclass
+class _Panel:
+    """Typed panel state with compatibility for legacy mapping-style access."""
+
+    label: str
+    width: int | float
+    height: int | float
+    pad_left: int | float
+    pad_top: int | float
+    margin_left: int | float
+    margin_top: int | float
+    margin_right: int | float
+    margin_bottom: int | float
+    left_decoration_width_px: float = 0.0
+    label_width_px: float = 0.0
+    label_height_px: float = 0.0
+    top_decoration_height_px: float = 0.0
+    _below: str | None = None
+    _is_spacer: bool = False
+    known_figure_axes_ids: set[int] | None = None
+
+    def __getitem__(self, key: str) -> Any:
+        """Support existing private consumers that index panel state as a dict."""
+        return getattr(self, key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Support existing private consumers that update panel measurements."""
+        setattr(self, key, value)
+
+    def __contains__(self, key: object) -> bool:
+        """Report whether a legacy mapping key currently has a value."""
+        return isinstance(key, str) and getattr(self, key, None) is not None
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return a legacy mapping value without exposing storage details."""
+        if key == "known_figure_axes_ids" and self.known_figure_axes_ids is None:
+            return default
+        return getattr(self, key, default)
+
+    def pop(self, key: str, default: Any = None) -> Any:
+        """Clear the optional axes snapshot used by legacy private consumers."""
+        if key != "known_figure_axes_ids":
+            return default
+        value = self.known_figure_axes_ids
+        self.known_figure_axes_ids = None
+        if value is None:
+            return default
+        return value
+
+
+@dataclass(frozen=True)
+class _PanelGeometry:
+    """Immutable inputs needed by the pure layout phase."""
+
+    label: str
+    width: float
+    height: float
+    margin_left: float
+    margin_top: float
+    left_reserve: float
+    top_reserve: float
+    total_width: float
+    total_height: float
+    below: str | None
+    is_spacer: bool
+
+
+@dataclass(frozen=True)
+class _PanelLayout:
+    """Calculated rows, heights, and axes positions for a panel collection."""
+
+    rows: tuple[tuple[int, ...], ...]
+    row_heights: tuple[float, ...]
+    positions: tuple[tuple[float, float], ...]
+
+
+def _layout_panels(
+    panels: tuple[_PanelGeometry, ...],
+    max_width: float,
+    title_height: float,
+) -> _PanelLayout:
+    """Calculate panel layout without mutating panel or multipanel state."""
+    label_to_index: dict[str, int] = {}
+    for idx, panel in enumerate(panels):
+        if panel.label in label_to_index:
+            raise ValueError(f"Panel label {panel.label!r} already exists")
+        label_to_index[panel.label] = idx
+
+    children: list[list[int]] = [[] for _ in panels]
+    for idx, panel in enumerate(panels):
+        if panel.below is None:
+            continue
+        parent_idx = label_to_index.get(panel.below)
+        if parent_idx is None:
+            raise ValueError(
+                f"below must reference an existing panel label: {panel.below!r}"
+            )
+        children[parent_idx].append(idx)
+
+    states = [0] * len(panels)
+
+    def validate_acyclic(panel_idx: int) -> None:
+        if states[panel_idx] == 1:
+            raise ValueError("Panel below relationships must not contain cycles")
+        if states[panel_idx] == 2:
+            return
+        states[panel_idx] = 1
+        for child_idx in children[panel_idx]:
+            validate_acyclic(child_idx)
+        states[panel_idx] = 2
+
+    for idx in range(len(panels)):
+        validate_acyclic(idx)
+
+    subtree_sizes: list[tuple[float, float] | None] = [None] * len(panels)
+
+    def get_subtree_size(panel_idx: int) -> tuple[float, float]:
+        cached_size = subtree_sizes[panel_idx]
+        if cached_size is not None:
+            return cached_size
+        panel = panels[panel_idx]
+        subtree_width = panel.total_width
+        subtree_height = panel.total_height
+        for child_idx in children[panel_idx]:
+            child_width, child_height = get_subtree_size(child_idx)
+            subtree_width = max(subtree_width, child_width)
+            subtree_height += child_height
+        subtree_sizes[panel_idx] = (subtree_width, subtree_height)
+        return subtree_width, subtree_height
+
+    rows: list[list[int]] = []
+    row_heights: list[float] = []
+    current_row: list[int] = []
+    current_row_width = 0.0
+    current_row_height = 0.0
+
+    root_indices = [idx for idx, panel in enumerate(panels) if panel.below is None]
+    for panel_idx in root_indices:
+        subtree_width, subtree_height = get_subtree_size(panel_idx)
+        if current_row and current_row_width + subtree_width > max_width:
+            rows.append(current_row)
+            row_heights.append(current_row_height)
+            current_row = [panel_idx]
+            current_row_width = subtree_width
+            current_row_height = subtree_height
+        else:
+            current_row.append(panel_idx)
+            current_row_width += subtree_width
+            current_row_height = max(current_row_height, subtree_height)
+
+    if current_row:
+        rows.append(current_row)
+        row_heights.append(current_row_height)
+
+    positions = [(0.0, 0.0)] * len(panels)
+
+    def place_subtree(panel_idx: int, column_x: float, outer_y: float) -> float:
+        panel = panels[panel_idx]
+        positions[panel_idx] = (
+            column_x + panel.margin_left + panel.left_reserve,
+            outer_y + panel.margin_top + panel.top_reserve,
+        )
+        next_y = outer_y + panel.total_height
+        for child_idx in children[panel_idx]:
+            next_y = place_subtree(child_idx, column_x, next_y)
+        return next_y
+
+    row_y = title_height
+    for row_idx, row in enumerate(rows):
+        column_x = 0.0
+        for panel_idx in row:
+            place_subtree(panel_idx, column_x, row_y)
+            column_x += get_subtree_size(panel_idx)[0]
+        row_y += row_heights[row_idx]
+
+    return _PanelLayout(
+        rows=tuple(tuple(row) for row in rows),
+        row_heights=tuple(row_heights),
+        positions=tuple(positions),
+    )
 
 
 def _validate_title_loc(loc: str) -> str:
@@ -129,11 +325,14 @@ class multipanel:
             max_width = settings.multipanel_max_width
         if loc is None:
             loc = settings.multipanel_title_loc
-        self._max_width = max_width
+        self._max_width = _validate_positive_finite_dimension(
+            "max_width",
+            max_width,
+        )
         self._title = title
         self._title_loc = _validate_title_loc(loc)
         self._title_fontweight = _validate_title_fontweight(title_fontweight)
-        self._panels = []  # List of panel info dicts
+        self._panels: list[_Panel] = []
         self.fig = None
         self.axes = []
         self._created_axes = {}
@@ -146,6 +345,7 @@ class multipanel:
         # Each row is a list of panel indices
         self._rows = []
         self._row_heights = []  # Max total height in each row
+        self._panel_positions: list[tuple[float, float]] = []
         self._draw_event_cid: int | None = None
         self._is_relayout_in_draw = False
 
@@ -158,19 +358,25 @@ class multipanel:
             settings.title_fontsize + settings.multipanel_title_height_pad,
         )
 
-    def _get_left_decoration_width_px(self, panel: dict) -> float:
+    def _get_left_decoration_width_px(
+        self,
+        panel: _Panel | dict[str, Any],
+    ) -> float:
         """Get the cached rendered width of left-side axis decorations."""
         return float(panel.get("left_decoration_width_px", 0.0))
 
-    def _get_label_width_px(self, panel: dict) -> float:
+    def _get_label_width_px(self, panel: _Panel | dict[str, Any]) -> float:
         """Get the cached rendered width of the panel label."""
         return float(panel.get("label_width_px", 0.0))
 
-    def _get_label_height_px(self, panel: dict) -> float:
+    def _get_label_height_px(self, panel: _Panel | dict[str, Any]) -> float:
         """Get the cached rendered height of the panel label."""
         return float(panel.get("label_height_px", 0.0))
 
-    def _get_top_decoration_height_px(self, panel: dict) -> float:
+    def _get_top_decoration_height_px(
+        self,
+        panel: _Panel | dict[str, Any],
+    ) -> float:
         """Get the cached rendered height of top-side axis decorations."""
         return float(panel.get("top_decoration_height_px", 0.0))
 
@@ -183,23 +389,23 @@ class multipanel:
         """Convert rendered pixels into multipanel layout pixels."""
         return value / self._get_layout_scale()
 
-    def _get_label_gap_px(self, panel: dict) -> float:
+    def _get_label_gap_px(self, panel: _Panel | dict[str, Any]) -> float:
         """Get the rendered-pixel gap between the label and left decorations."""
         return self._get_left_decoration_width_px(panel) + panel.get("pad_left", 0)
 
-    def _get_left_reserve_px(self, panel: dict) -> float:
+    def _get_left_reserve_px(self, panel: _Panel | dict[str, Any]) -> float:
         """Get total left reserve in layout pixels for panel geometry."""
         return self._display_px_to_layout_px(
             self._get_label_width_px(panel) + self._get_label_gap_px(panel)
         )
 
-    def _get_top_label_offset_px(self, panel: dict) -> float:
+    def _get_top_label_offset_px(self, panel: _Panel | dict[str, Any]) -> float:
         """Get the rendered-pixel offset from axes top to label bottom."""
         return self._get_top_decoration_height_px(panel) + float(
             panel.get("pad_top", 0)
         )
 
-    def _get_top_reserve_px(self, panel: dict) -> float:
+    def _get_top_reserve_px(self, panel: _Panel | dict[str, Any]) -> float:
         """Get total top reserve in layout pixels for panel geometry."""
         return self._display_px_to_layout_px(
             self._get_label_height_px(panel) + self._get_top_label_offset_px(panel)
@@ -227,7 +433,10 @@ class multipanel:
             return 0.0, float(self._max_width)
         return left_bound, right_bound
 
-    def _get_panel_total_size(self, panel: dict) -> tuple[float, float]:
+    def _get_panel_total_size(
+        self,
+        panel: _Panel | dict[str, Any],
+    ) -> tuple[float, float]:
         """Get the total width and height of a panel including margins."""
         total_width = (
             panel["margin_left"]
@@ -411,7 +620,11 @@ class multipanel:
                 continue
             panel["known_figure_axes_ids"] = set(figure_axes_ids)
 
-    def _iter_linked_helper_axes(self, ax: Axes, panel: dict):
+    def _iter_linked_helper_axes(
+        self,
+        ax: Axes,
+        panel: _Panel | dict[str, Any],
+    ):
         """Yield new helper axes that are directly linked to a host axes."""
         known_axes_ids = set(panel.get("known_figure_axes_ids", {id(ax)}))
         seen_ids = set()
@@ -498,126 +711,49 @@ class multipanel:
         finally:
             self._is_relayout_in_draw = False
 
-    def _get_stacked_height(self, panel_idx: int) -> float:
-        """Get total height of a panel plus any panels stacked below it."""
-        panel = self._panels[panel_idx]
-        _, total_height = self._get_panel_total_size(panel)
-        # Add heights of children stacked below
-        for p in self._panels:
-            if p.get("_below") == panel["label"]:
-                _, child_height = self._get_panel_total_size(p)
-                total_height += child_height
-        return total_height
+    def _get_panel_geometry(
+        self,
+        panel: _Panel | dict[str, Any],
+    ) -> _PanelGeometry:
+        """Create immutable layout input from mutable rendered panel state."""
+        total_width, total_height = self._get_panel_total_size(panel)
+        return _PanelGeometry(
+            label=panel["label"],
+            width=float(panel["width"]),
+            height=float(panel["height"]),
+            margin_left=float(panel.get("margin_left", 0)),
+            margin_top=float(panel.get("margin_top", 0)),
+            left_reserve=self._get_left_reserve_px(panel),
+            top_reserve=self._get_top_reserve_px(panel),
+            total_width=float(total_width),
+            total_height=float(total_height),
+            below=panel.get("_below"),
+            is_spacer=bool(panel.get("_is_spacer")),
+        )
 
     def _calculate_layout(self) -> None:
         """Calculate row assignments and positions for all panels."""
-        self._rows = []
-        self._row_heights = []
-
-        current_row = []
-        current_row_x = 0
-        current_row_max_height = 0
-
-        for idx, panel in enumerate(self._panels):
-            # Skip panels that are stacked below another panel
-            if panel.get("_below"):
+        for panel in self._panels:
+            if panel.get("_is_spacer"):
                 continue
+            _validate_positive_finite_dimension("width", panel["width"])
+            _validate_positive_finite_dimension("height", panel["height"])
 
-            total_width, _ = self._get_panel_total_size(panel)
-            # Use stacked height (parent + children) for row height
-            stacked_height = self._get_stacked_height(idx)
-
-            # Check if panel fits in current row
-            if current_row and current_row_x + total_width > self._max_width:
-                # Start new row
-                self._rows.append(current_row)
-                self._row_heights.append(current_row_max_height)
-                current_row = [idx]
-                current_row_x = total_width
-                current_row_max_height = stacked_height
-            else:
-                # Add to current row
-                current_row.append(idx)
-                current_row_x += total_width
-                current_row_max_height = max(current_row_max_height, stacked_height)
-
-        # Don't forget the last row
-        if current_row:
-            self._rows.append(current_row)
-            self._row_heights.append(current_row_max_height)
+        geometry = tuple(self._get_panel_geometry(panel) for panel in self._panels)
+        layout = _layout_panels(
+            geometry,
+            float(self._max_width),
+            float(self._get_title_height_px()),
+        )
+        self._rows = [list(row) for row in layout.rows]
+        self._row_heights = list(layout.row_heights)
+        self._panel_positions = list(layout.positions)
 
     def _get_panel_position(self, panel_idx: int) -> tuple[float, float]:
         """Get the x, y position (top-left of axes content area) for a panel."""
-        panel = self._panels[panel_idx]
-
-        # Handle panels stacked below another panel
-        if panel.get("_below"):
-            # Find the parent panel index
-            parent_idx = None
-            for i, p in enumerate(self._panels):
-                if p["label"] == panel["_below"]:
-                    parent_idx = i
-                    break
-            if parent_idx is None:
-                return 0, 0
-
-            parent = self._panels[parent_idx]
-            parent_x, parent_y = self._get_panel_position(parent_idx)
-
-            # x: align to the parent's column origin, then apply this panel's
-            # own left spacing. This keeps stacked panels in the same column
-            # instead of reapplying the parent's left margin as an offset.
-            x = (
-                parent_x
-                - parent["margin_left"]
-                - self._get_left_reserve_px(parent)
-                + panel["margin_left"]
-                + self._get_left_reserve_px(panel)
-            )
-
-            # y: below parent's total height
-            y = (
-                parent_y
-                + parent["height"]
-                + parent["margin_bottom"]
-                + panel["margin_top"]
-                + self._get_top_reserve_px(panel)
-            )
-
-            return x, y
-
-        # Find which row this panel is in
-        row_idx = None
-        col_in_row = None
-        for r_idx, row in enumerate(self._rows):
-            if panel_idx in row:
-                row_idx = r_idx
-                col_in_row = row.index(panel_idx)
-                break
-
-        if row_idx is None or col_in_row is None:
-            return 0, 0
-
-        # Calculate y position (from top of figure)
-        y = self._get_title_height_px() + sum(self._row_heights[:row_idx])
-
-        # Calculate x position
-        x = 0
-        for i in range(col_in_row):
-            prev_idx = self._rows[row_idx][i]
-            prev_panel = self._panels[prev_idx]
-            x += (
-                prev_panel["margin_left"]
-                + self._get_left_reserve_px(prev_panel)
-                + prev_panel["width"]
-                + prev_panel["margin_right"]
-            )
-
-        # Add this panel's left margin and padding
-        x += panel["margin_left"] + self._get_left_reserve_px(panel)
-        y += panel["margin_top"] + self._get_top_reserve_px(panel)
-
-        return x, y
+        if len(self._panel_positions) == len(self._panels):
+            return self._panel_positions[panel_idx]
+        return 0, 0
 
     def _create_or_update_figure(self) -> None:
         """Create or update the figure and all axes based on current layout."""
@@ -866,30 +1002,46 @@ class multipanel:
             margin_right = settings.panel_margin_right
         if margin_bottom is None:
             margin_bottom = settings.panel_margin_bottom
-        setup_matplotlib(color_cycle, color_map)
+
+        width = _validate_positive_finite_dimension("width", width)
+        height = _validate_positive_finite_dimension("height", height)
 
         if label is None:
+            if self._panel_index >= len(self._labels):
+                raise ValueError(
+                    "Automatic panel labels are limited to 26; "
+                    "provide an explicit unique label"
+                )
             label = self._labels[self._panel_index]
+        if not isinstance(label, str):
+            raise TypeError("label must be a string or None")
+        if any(panel.get("label") == label for panel in self._panels):
+            raise ValueError(f"Panel label {label!r} already exists")
+
+        if below is not None:
+            if not isinstance(below, str):
+                raise TypeError("below must be a string or None")
+            if not any(panel.get("label") == below for panel in self._panels):
+                raise ValueError(
+                    f"below must reference an existing panel label: {below!r}"
+                )
+
+        setup_matplotlib(color_cycle, color_map)
 
         self._capture_linked_helper_axes()
 
-        # Store panel info
-        panel_info = {
-            "label": label,
-            "width": width,
-            "height": height,
-            "pad_left": pad_left,
-            "left_decoration_width_px": 0.0,
-            "label_width_px": 0.0,
-            "label_height_px": 0.0,
-            "top_decoration_height_px": 0.0,
-            "pad_top": pad_top,
-            "margin_left": margin_left,
-            "margin_top": margin_top,
-            "margin_right": margin_right,
-            "margin_bottom": margin_bottom,
-            "_below": below,
-        }
+        panel_info = _Panel(
+            label=label,
+            width=width,
+            height=height,
+            pad_left=pad_left,
+            pad_top=pad_top,
+            margin_left=margin_left,
+            margin_top=margin_top,
+            margin_right=margin_right,
+            margin_bottom=margin_bottom,
+            _below=below,
+        )
         self._panels.append(panel_info)
 
         # Create or update figure
@@ -955,16 +1107,16 @@ class multipanel:
                 if remaining > 0:
                     # Add invisible spacer
                     self._panels.append(
-                        {
-                            "label": f"_spacer_{len(self._panels)}",
-                            "width": 0,
-                            "height": 0,
-                            "pad_left": 0,
-                            "pad_top": 0,
-                            "margin_left": 0,
-                            "margin_top": 0,
-                            "margin_right": 0,
-                            "margin_bottom": 0,
-                            "_is_spacer": True,
-                        }
+                        _Panel(
+                            label=f"_spacer_{len(self._panels)}",
+                            width=0,
+                            height=0,
+                            pad_left=0,
+                            pad_top=0,
+                            margin_left=0,
+                            margin_top=0,
+                            margin_right=0,
+                            margin_bottom=0,
+                            _is_spacer=True,
+                        )
                     )

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
 
 import itertools
 import math
-import operator
 import os
 import re
 from pathlib import Path
@@ -20,6 +19,7 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 import num2tex
+import numpy as np
 import palettable
 import pandas as pd
 import scipy.stats as stats
@@ -516,19 +516,16 @@ def get_hexcolors_from_apalette(
     >>> # Extract first two colors from Set1
     >>> colors = cns.get_hexcolors_from_apalette([0, 1], "Set1")
     >>> colors
-    ['#E41A1C', '#377EB8']
+    ['#e41a1c', '#377eb8']
 
     >>> # Extract specific colors from custom palette
     >>> custom = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00"]
     >>> selected = cns.get_hexcolors_from_apalette([0, 2], custom)
     >>> selected
-    ['#FF0000', '#0000FF']
+    ['#ff0000', '#0000ff']
     """
-    if isinstance(palette, str):
-        colors = palettes(palette)
-        return list(operator.itemgetter(*alist)(colors))
-    else:
-        return list(operator.itemgetter(*alist)(palette))
+    colors = palettes(palette) if isinstance(palette, str) else palette
+    return [mcolors.to_hex(colors[index]) for index in alist]
 
 
 def _is_qualitative_cmap(cmap_name):
@@ -541,11 +538,7 @@ def _is_qualitative_cmap(cmap_name):
 
 def _get_hex_colors_from_colorbar(cmap_name, n_colors):
     cmap = mpl.colormaps[cmap_name]
-    if _is_qualitative_cmap(cmap_name):
-        colors = [mcolors.to_hex(cmap(i)) for i in range(0, n_colors)]
-    else:
-        colors = [mcolors.to_hex(cmap(i)) for i in range(0, cmap.N, cmap.N // n_colors)]
-    return colors
+    return [mcolors.to_hex(cmap(value)) for value in np.linspace(0, 1, n_colors)]
 
 
 def _remove_edge_from_legend_items(ax):

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -23,6 +23,7 @@ from cnsplots._validation import (
     validate_columns_exist,
     validate_dataframe,
     validate_dataframe_not_empty,
+    validate_no_nulls,
 )
 
 logger = logging.getLogger(__name__)
@@ -522,8 +523,24 @@ def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes
     validate_dataframe(data, "data", "ridgeplot")
     validate_columns_exist(data, [x, y], "ridgeplot")
     validate_dataframe_not_empty(data, "ridgeplot")
+    validate_no_nulls(data, [x, y], "ridgeplot")
 
     categories = data[y].unique()
+    grouped_values: list[tuple[Any, np.ndarray]] = []
+    for category in categories:
+        values = data.loc[data[y] == category, x].to_numpy()
+        if values.size < 2:
+            raise ValueError(
+                f"[ridgeplot] Group {category!r} must contain at least two "
+                "observations."
+            )
+        if pd.Series(values).nunique() < 2:
+            raise ValueError(
+                f"[ridgeplot] Group {category!r} is constant; kernel density "
+                "estimation requires varying values."
+            )
+        grouped_values.append((category, values))
+
     n = len(categories)
     colors = utils._get_hex_colors_from_colorbar(cmap, n)
     ax = plt.gca()
@@ -534,8 +551,7 @@ def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes
     x_min, x_max = data[x].min(), data[x].max()
     x_grid = np.linspace(x_min, x_max, 200)
 
-    for i, cat in enumerate(categories):
-        x_v = np.array(data[data[y] == cat][x])
+    for i, (cat, x_v) in enumerate(grouped_values):
         kde = gaussian_kde(x_v)
         y_vals = kde(x_grid)
         y_vals = y_vals / y_vals.max()

--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -124,8 +124,8 @@ def volcanoplot(
         de.loc[de[symbol].isin(show_list) & down, hue] = "Down"
     de = de.sort_values(hue)
 
-    blue = utils.get_hexcolors_from_apalette([0], "BlueRed")
-    red = utils.get_hexcolors_from_apalette([1], "BlueRed")
+    blue = utils.get_hexcolors_from_apalette([0], "BlueRed")[0]
+    red = utils.get_hexcolors_from_apalette([1], "BlueRed")[0]
     ax = sns.scatterplot(
         data=de,
         x=x,

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -19,7 +19,9 @@ import numpy as np
 import pandas as pd
 import PyComplexHeatmap as pch
 import seaborn as sns
+from anndata.abc import CSCDataset, CSRDataset
 from natsort import natsort_keygen
+from scipy import sparse
 from scipy.stats import fisher_exact
 
 import cnsplots._utils as utils
@@ -35,6 +37,34 @@ from cnsplots._validation import (
     validate_dataframe,
     validate_dataframe_not_empty,
 )
+
+
+_MAX_DENSE_HEATMAP_BYTES = 512 * 1024**2
+
+
+def _anndata_to_heatmap_dataframe(adata: AnnData, layer: str | None) -> pd.DataFrame:
+    if layer is None and adata.X is None:
+        raise ValueError("X is None, cannot convert to dataframe.")
+
+    matrix = adata.X if layer is None else adata.layers[layer]
+    is_backed_sparse = isinstance(matrix, (CSRDataset, CSCDataset))
+    if sparse.issparse(matrix) or is_backed_sparse:
+        dense_nbytes = (
+            int(matrix.shape[0])
+            * int(matrix.shape[1])
+            * np.dtype(matrix.dtype).itemsize
+        )
+        if dense_nbytes > _MAX_DENSE_HEATMAP_BYTES:
+            dense_mib = dense_nbytes / 1024**2
+            raise ValueError(
+                "Sparse heatmap data would require approximately "
+                f"{dense_mib:.1f} MiB when densified; subset AnnData before plotting."
+            )
+        if is_backed_sparse:
+            matrix = matrix.to_memory()
+        matrix = matrix.toarray()
+
+    return pd.DataFrame(matrix, index=adata.obs_names, columns=adata.var_names)
 
 
 def _style_plotter_colorbars(cbars: list[Any]) -> None:
@@ -242,7 +272,7 @@ def heatmapplot(
             else:
                 rc_dict[annot] = pch.anno_simple(
                     series,
-                    cmap=cont_palettes[cont_counter],
+                    cmap=cont_palettes[cont_counter % len(cont_palettes)],
                     height=3,
                     rasterized=True,
                     linewidth=0,
@@ -277,7 +307,7 @@ def heatmapplot(
     if col_split is not None and not isinstance(col_split, int):
         col_split_val = adata.var[col_split]
 
-    df = adata.to_df() if layer is None else adata.to_df(layer=layer)
+    df = _anndata_to_heatmap_dataframe(adata, layer)
     cmp = helper_heatmap.ClusterMapPlotterNew(
         data=df,
         left_annotation=left_annotation,

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -191,9 +191,9 @@ def sankeyplot(data: pd.DataFrame, x: str, y: str, label_rotation: float = 0) ->
     validate_dataframe_not_empty(data, "sankeyplot")
 
     ax = plt.gca()
-    current_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
     keys = np.union1d(data[x].unique(), data[y].unique())
-    color_dict = dict(zip(keys, current_colors))
+    colors = sns.color_palette(n_colors=len(keys))
+    color_dict = dict(zip(keys, colors))
     helper_sankey.sankeyplot(
         data[x],
         data[y],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1066,7 +1066,7 @@ def test_utils_helpers_and_showcase_data(
     ]
     assert _utils._is_qualitative_cmap("Set1") is True
     assert _utils._is_qualitative_cmap("viridis") is False
-    assert len(_utils._get_hex_colors_from_colorbar("viridis", 3)) == 4
+    assert len(_utils._get_hex_colors_from_colorbar("viridis", 3)) == 3
 
     fig2, ax2 = plt.subplots()
     ax2.scatter([0, 1], [0, 1], label="Group", edgecolors="black")

--- a/tests/test_heatmap_defects.py
+++ b/tests/test_heatmap_defects.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import anndata as ad
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import sparse
+
+import cnsplots as cns
+from cnsplots.plots import _heatmap as heatmap_mod
+
+
+def _stub_plotter(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_plotter(**kwargs: object) -> types.SimpleNamespace:
+        ax = plt.gca()
+        return types.SimpleNamespace(
+            data2d=kwargs["data"],
+            heatmap_axes=np.array([[ax]], dtype=object),
+            ax_heatmap=ax,
+            cbars=[],
+        )
+
+    monkeypatch.setattr(
+        heatmap_mod.helper_heatmap, "ClusterMapPlotterNew", fake_plotter
+    )
+
+
+def test_heatmapplot_cycles_continuous_annotation_palettes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adata = ad.AnnData(np.ones((3, 2)))
+    annotations = [f"score_{index}" for index in range(4)]
+    for index, annotation in enumerate(annotations):
+        adata.obs[annotation] = np.arange(3) + index
+
+    seen_cmaps: list[str] = []
+
+    def fake_anno_simple(series: pd.Series, **kwargs: object) -> object:
+        seen_cmaps.append(str(kwargs["cmap"]))
+        return object()
+
+    monkeypatch.setattr(heatmap_mod.pch, "anno_simple", fake_anno_simple)
+    monkeypatch.setattr(heatmap_mod.pch, "HeatmapAnnotation", lambda **kwargs: kwargs)
+    _stub_plotter(monkeypatch)
+
+    with cns.settings.context(palette_seq="parula"):
+        cns.heatmapplot(adata, row_annotation=annotations)
+
+    assert seen_cmaps == ["gnuplot", "bwr", "hot", "gnuplot"]
+
+
+@pytest.mark.parametrize("layer", [None, "counts"])
+def test_heatmapplot_converts_sparse_data_without_anndata_to_df(
+    monkeypatch: pytest.MonkeyPatch, layer: str | None
+) -> None:
+    matrix = sparse.csr_matrix([[1.0, 0.0], [0.0, 2.0]])
+    adata = ad.AnnData(matrix)
+    adata.obs_names = ["cell_1", "cell_2"]
+    adata.var_names = ["gene_1", "gene_2"]
+    adata.layers["counts"] = matrix * 2
+    expected_matrix = matrix if layer is None else matrix * 2
+
+    monkeypatch.setattr(
+        ad.AnnData,
+        "to_df",
+        lambda *args, **kwargs: pytest.fail("heatmapplot called AnnData.to_df()"),
+    )
+    _stub_plotter(monkeypatch)
+
+    plotter = cns.heatmapplot(adata, layer=layer)
+
+    expected = pd.DataFrame(
+        expected_matrix.toarray(), index=adata.obs_names, columns=adata.var_names
+    )
+    pd.testing.assert_frame_equal(plotter.data2d, expected)
+
+
+def test_heatmapplot_rejects_unsafe_sparse_densification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adata = ad.AnnData(sparse.csr_matrix((2, 2), dtype=np.float64))
+    monkeypatch.setattr(heatmap_mod, "_MAX_DENSE_HEATMAP_BYTES", 1)
+    monkeypatch.setattr(
+        ad.AnnData,
+        "to_df",
+        lambda *args, **kwargs: pytest.fail("heatmapplot called AnnData.to_df()"),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"approximately 0\.0 MiB.*subset AnnData before plotting",
+    ):
+        cns.heatmapplot(adata)
+
+
+def test_heatmapplot_converts_backed_sparse_data(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    matrix = sparse.csr_matrix([[1.0, 0.0], [0.0, 2.0]])
+    source = ad.AnnData(matrix)
+    source.obs_names = ["cell_1", "cell_2"]
+    source.var_names = ["gene_1", "gene_2"]
+    path = tmp_path / "sparse.h5ad"
+    ad.AnnData.write_h5ad(source, path)
+    backed = ad.read_h5ad(path, backed="r")
+
+    monkeypatch.setattr(
+        ad.AnnData,
+        "to_df",
+        lambda *args, **kwargs: pytest.fail("heatmapplot called AnnData.to_df()"),
+    )
+    _stub_plotter(monkeypatch)
+
+    try:
+        plotter = cns.heatmapplot(backed)
+    finally:
+        backed.file.close()
+
+    expected = pd.DataFrame(
+        matrix.toarray(), index=source.obs_names, columns=source.var_names
+    )
+    pd.testing.assert_frame_equal(plotter.data2d, expected)
+
+
+def test_heatmapplot_preserves_missing_x_error() -> None:
+    adata = ad.AnnData(X=None, shape=(2, 2))
+
+    with pytest.raises(ValueError, match="X is None, cannot convert to dataframe"):
+        cns.heatmapplot(adata)

--- a/tests/test_multipanel_defects.py
+++ b/tests/test_multipanel_defects.py
@@ -1,0 +1,269 @@
+"""Regression tests for multipanel validation and stacked layout."""
+
+from __future__ import annotations
+
+import string
+from dataclasses import FrozenInstanceError, replace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import cnsplots as cns
+from cnsplots import _multipanels as multipanel_mod
+
+
+@pytest.mark.parametrize("max_width", [0, -1, np.nan, np.inf, -np.inf])
+def test_multipanel_rejects_non_positive_or_non_finite_max_width(
+    max_width: float,
+) -> None:
+    with pytest.raises(ValueError, match="max_width must be a positive finite number"):
+        cns.multipanel(max_width=max_width)
+
+
+@pytest.mark.parametrize("max_width", [True, "100"])
+def test_multipanel_rejects_non_numeric_max_width(max_width: Any) -> None:
+    with pytest.raises(TypeError, match="max_width must be a number"):
+        cns.multipanel(max_width=max_width)
+
+
+@pytest.mark.parametrize("dimension", ["width", "height"])
+@pytest.mark.parametrize("value", [0, -1, np.nan, np.inf, -np.inf])
+def test_multipanel_rejects_non_positive_or_non_finite_panel_dimensions(
+    dimension: str,
+    value: float,
+) -> None:
+    mp = cns.multipanel()
+
+    with pytest.raises(
+        ValueError,
+        match=rf"{dimension} must be a positive finite number",
+    ):
+        cast(Any, mp.panel)(**{dimension: value})
+
+    assert mp._panels == []
+    assert mp.fig is None
+
+
+@pytest.mark.parametrize("dimension", ["width", "height"])
+@pytest.mark.parametrize("value", [True, "100"])
+def test_multipanel_rejects_non_numeric_panel_dimensions(
+    dimension: str,
+    value: Any,
+) -> None:
+    mp = cns.multipanel()
+
+    with pytest.raises(TypeError, match=rf"{dimension} must be a number"):
+        cast(Any, mp.panel)(**{dimension: value})
+
+    assert mp._panels == []
+    assert mp.fig is None
+
+
+def test_multipanel_rejects_duplicate_labels_without_mutating_layout() -> None:
+    mp = cns.multipanel(max_width=100)
+    original_ax = mp.panel("A", width=20, height=20)
+
+    with pytest.raises(ValueError, match="Panel label 'A' already exists"):
+        mp.panel("A", width=20, height=20)
+
+    assert len(mp._panels) == 1
+    assert mp.axes == [original_ax]
+    assert mp.get_axes("A") is original_ax
+
+
+def test_multipanel_rejects_automatic_label_collision() -> None:
+    mp = cns.multipanel(max_width=100)
+    mp.panel("B", width=20, height=20)
+
+    with pytest.raises(ValueError, match="Panel label 'B' already exists"):
+        mp.panel(width=20, height=20)
+
+
+def test_multipanel_rejects_missing_below_parent_without_mutating_layout() -> None:
+    mp = cns.multipanel(max_width=100)
+
+    with pytest.raises(
+        ValueError,
+        match="below must reference an existing panel label: 'missing'",
+    ):
+        mp.panel("A", width=20, height=20, below="missing")
+
+    assert mp._panels == []
+    assert mp.fig is None
+
+
+def test_multipanel_rejects_non_string_labels_and_parents() -> None:
+    mp = cns.multipanel(max_width=100)
+    legacy_panel = cast(Any, mp.panel)
+
+    with pytest.raises(TypeError, match="label must be a string or None"):
+        legacy_panel(1, width=20, height=20)
+
+    mp.panel("A", width=20, height=20)
+    with pytest.raises(TypeError, match="below must be a string or None"):
+        legacy_panel("B", width=20, height=20, below=1)
+
+
+def test_multipanel_layout_rejects_below_cycles() -> None:
+    mp = cns.multipanel(max_width=100)
+    mp.panel("A", width=20, height=20)
+    mp.panel("B", width=20, height=20, below="A")
+    mp._panels[0]["_below"] = "B"
+
+    with pytest.raises(ValueError, match="below relationships must not contain cycles"):
+        mp._calculate_layout()
+
+
+def test_pure_multipanel_layout_validates_duplicate_and_missing_labels() -> None:
+    mp = cns.multipanel(max_width=100)
+    mp.panel("A", width=20, height=20)
+    mp.panel("B", width=20, height=20)
+    geometry = tuple(mp._get_panel_geometry(panel) for panel in mp._panels)
+
+    duplicate_geometry = (geometry[0], replace(geometry[1], label="A"))
+    with pytest.raises(ValueError, match="Panel label 'A' already exists"):
+        multipanel_mod._layout_panels(duplicate_geometry, 100, 0)
+
+    missing_parent_geometry = (
+        geometry[0],
+        replace(geometry[1], below="missing"),
+    )
+    with pytest.raises(
+        ValueError,
+        match="below must reference an existing panel label: 'missing'",
+    ):
+        multipanel_mod._layout_panels(missing_parent_geometry, 100, 0)
+
+
+def test_multipanel_reports_exhausted_automatic_labels() -> None:
+    mp = cns.multipanel(max_width=100)
+
+    for expected_label in string.ascii_uppercase:
+        mp.panel(
+            width=1,
+            height=1,
+            pad_left=0,
+            pad_top=0,
+            margin_left=0,
+            margin_top=0,
+            margin_right=0,
+            margin_bottom=0,
+        )
+        assert mp._panels[-1]["label"] == expected_label
+
+    with pytest.raises(ValueError, match="Automatic panel labels are limited to 26"):
+        mp.panel(width=1, height=1)
+
+
+def test_multipanel_stacks_multiple_children_without_overlap() -> None:
+    mp = cns.multipanel(max_width=100)
+    panel_kwargs = {
+        "width": 20,
+        "pad_left": 0,
+        "pad_top": 0,
+        "margin_left": 0,
+        "margin_top": 0,
+        "margin_right": 0,
+        "margin_bottom": 0,
+    }
+
+    mp.panel("A", height=20, **panel_kwargs)
+    mp.panel("B", height=10, below="A", **panel_kwargs)
+    mp.panel("C", height=15, below="A", **panel_kwargs)
+
+    assert mp._get_panel_position(0) == pytest.approx((0, 0))
+    assert mp._get_panel_position(1) == pytest.approx((0, 20))
+    assert mp._get_panel_position(2) == pytest.approx((0, 30))
+    assert mp._row_heights == pytest.approx([45])
+
+
+def test_multipanel_stacks_nested_children_before_later_siblings() -> None:
+    mp = cns.multipanel(max_width=100)
+    panel_kwargs = {
+        "width": 20,
+        "pad_left": 0,
+        "pad_top": 0,
+        "margin_left": 0,
+        "margin_top": 0,
+        "margin_right": 0,
+        "margin_bottom": 0,
+    }
+
+    mp.panel("A", height=20, **panel_kwargs)
+    mp.panel("B", height=10, below="A", **panel_kwargs)
+    mp.panel("C", height=15, below="A", **panel_kwargs)
+    mp.panel("D", height=5, below="B", **panel_kwargs)
+
+    assert mp._get_panel_position(0) == pytest.approx((0, 0))
+    assert mp._get_panel_position(1) == pytest.approx((0, 20))
+    assert mp._get_panel_position(3) == pytest.approx((0, 30))
+    assert mp._get_panel_position(2) == pytest.approx((0, 35))
+    assert mp._row_heights == pytest.approx([50])
+
+
+def test_multipanel_uses_descendant_width_for_row_wrapping() -> None:
+    mp = cns.multipanel(max_width=70)
+    panel_kwargs = {
+        "height": 10,
+        "pad_left": 0,
+        "pad_top": 0,
+        "margin_left": 0,
+        "margin_top": 0,
+        "margin_right": 0,
+        "margin_bottom": 0,
+    }
+
+    mp.panel("A", width=20, **panel_kwargs)
+    mp.panel("B", width=60, below="A", **panel_kwargs)
+    mp.panel("C", width=20, **panel_kwargs)
+
+    assert mp._rows == [[0], [2]]
+    assert mp._get_panel_position(2)[1] == pytest.approx(20)
+
+
+def test_multipanel_uses_typed_panels_and_pure_immutable_layout() -> None:
+    mp = cns.multipanel(max_width=100)
+    panel_kwargs = {
+        "width": 20,
+        "pad_left": 0,
+        "pad_top": 0,
+        "margin_left": 0,
+        "margin_top": 0,
+        "margin_right": 0,
+        "margin_bottom": 0,
+    }
+    mp.panel("A", height=20, **panel_kwargs)
+    mp.panel("B", height=10, below="A", **panel_kwargs)
+
+    panel = mp._panels[0]
+    assert isinstance(panel, multipanel_mod._Panel)
+    assert panel.width == panel["width"] == 20
+
+    panel.pop("known_figure_axes_ids", None)
+    fallback_axes_ids = {123}
+    assert panel.get("known_figure_axes_ids", fallback_axes_ids) is fallback_axes_ids
+    assert "known_figure_axes_ids" not in panel
+    assert panel.pop("known_figure_axes_ids", fallback_axes_ids) is fallback_axes_ids
+    assert panel.pop("width", "not removable") == "not removable"
+    assert panel.width == 20
+
+    geometry = tuple(mp._get_panel_geometry(item) for item in mp._panels)
+    panel_state = tuple(vars(item).copy() for item in mp._panels)
+    figure = mp.fig
+    axes = tuple(mp.axes)
+
+    first_layout = multipanel_mod._layout_panels(geometry, 100, 0)
+    second_layout = multipanel_mod._layout_panels(geometry, 100, 0)
+
+    assert first_layout == second_layout
+    assert first_layout.rows == ((0,),)
+    assert first_layout.row_heights == pytest.approx((30,))
+    assert np.asarray(first_layout.positions) == pytest.approx(
+        np.asarray(((0, 0), (0, 20)))
+    )
+    assert tuple(vars(item).copy() for item in mp._panels) == panel_state
+    assert mp.fig is figure
+    assert tuple(mp.axes) == axes
+    with pytest.raises(FrozenInstanceError):
+        setattr(first_layout, "rows", ())

--- a/tests/test_palette_sankey_defects.py
+++ b/tests/test_palette_sankey_defects.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import matplotlib as mpl
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+from cycler import cycler
+
+from cnsplots import _utils
+from cnsplots.plots import _specialized
+
+
+def test_get_hexcolors_from_apalette_preserves_singleton_color() -> None:
+    assert _utils.get_hexcolors_from_apalette([0], "Set1") == ["#e41a1c"]
+
+
+def test_get_hexcolors_from_apalette_normalizes_custom_colors() -> None:
+    assert _utils.get_hexcolors_from_apalette([0, 1], ["red", (0, 1, 0)]) == [
+        "#ff0000",
+        "#00ff00",
+    ]
+
+
+@pytest.mark.parametrize("n_colors", [3, 300])
+def test_get_hex_colors_from_colorbar_returns_requested_count(n_colors: int) -> None:
+    colors = _utils._get_hex_colors_from_colorbar("viridis", n_colors)
+
+    assert len(colors) == n_colors
+    assert colors[0] == mcolors.to_hex(mpl.colormaps["viridis"](0))
+    assert colors[-1] == mcolors.to_hex(mpl.colormaps["viridis"](1.0))
+
+
+def test_sankeyplot_assigns_color_to_every_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "source": ["source_a", "source_b", "source_c"],
+            "target": ["target", "target", "target"],
+        }
+    )
+    captured_colors: dict[str, object] = {}
+
+    def capture_colors(
+        *args: object, colorDict: dict[str, object], **kwargs: object
+    ) -> None:
+        captured_colors.update(colorDict)
+
+    monkeypatch.setattr(_specialized.helper_sankey, "sankeyplot", capture_colors)
+
+    with plt.rc_context({"axes.prop_cycle": cycler(color=["#111111", "#eeeeee"])}):
+        _specialized.sankeyplot(data, x="source", y="target")
+
+    assert set(captured_colors) == {
+        "source_a",
+        "source_b",
+        "source_c",
+        "target",
+    }
+    assert len(captured_colors) == 4

--- a/tests/test_ridgeplot_defects.py
+++ b/tests/test_ridgeplot_defects.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+import scipy.stats
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (
+            pd.DataFrame(
+                {"value": [1.0, None, 2.0, 3.0], "group": ["A", "A", "B", "B"]}
+            ),
+            "Null values",
+        ),
+        (
+            pd.DataFrame({"value": [2.0, 3.0, 1.0], "group": ["B", "B", "A"]}),
+            "at least two observations",
+        ),
+        (
+            pd.DataFrame(
+                {"value": [2.0, 3.0, 1.0, 1.0], "group": ["B", "B", "A", "A"]}
+            ),
+            "constant",
+        ),
+    ],
+)
+def test_ridgeplot_rejects_invalid_groups_before_kde(
+    monkeypatch: pytest.MonkeyPatch,
+    data: pd.DataFrame,
+    message: str,
+) -> None:
+    def unexpected_kde(*args: object, **kwargs: object) -> None:
+        raise AssertionError("gaussian_kde should not be called")
+
+    monkeypatch.setattr(scipy.stats, "gaussian_kde", unexpected_kde)
+
+    with pytest.raises(ValueError, match=message):
+        cns.ridgeplot(data, x="value", y="group")
+
+
+def test_ridgeplot_rejects_null_group_labels() -> None:
+    data = pd.DataFrame({"value": [1.0, 2.0, 3.0, 4.0], "group": ["A", "A", None, "B"]})
+
+    with pytest.raises(ValueError, match="Null values"):
+        cns.ridgeplot(data, x="value", y="group")


### PR DESCRIPTION
## What changed

- Normalize palette selections and generate exact color counts for colormaps and Sankey labels.
- Cycle continuous heatmap annotation palettes and guard in-memory and backed sparse densification.
- Validate ridge plot groups before kernel density estimation.
- Add typed multipanel state, a pure recursive layout phase, and validation for labels, dimensions, parent relationships, cycles, and automatic-label limits.
- Add focused regressions for each corrected behavior.

## Testing

- make test: 213 passed with 100% coverage.
- make lint: all hooks passed, including Ruff, type checking, codespell, and documentation checks.

## Risks and follow-ups

- Sparse heatmaps estimated above 512 MiB now fail fast and ask callers to subset AnnData before plotting.
- The pre-existing multipanel newline spacer behavior remains unchanged and should be addressed separately.