### PR TITLE
💥 Harden statistical plot correctness

### DIFF
--- a/examples/showcase.py
+++ b/examples/showcase.py
@@ -211,7 +211,7 @@ ax.set_title("Ridgeplot")
 
 # Panel P: slopeplot
 mp.panel("P", 65, 80, below="O", margin_top=10, pad_top=-5, margin_right=0)
-ax = cns.slopeplot(data=slope_df, x="site", y="value", hue="label")
+ax = cns.slopeplot(data=slope_df, x="site", y="value", hue="label", pair="pair")
 ax.set_title("Slopeplot")
 
 # Panel Q: scatterplot

--- a/examples/slopeplot.py
+++ b/examples/slopeplot.py
@@ -5,7 +5,7 @@ Slope Plot
 Create slope plots for visualizing changes between conditions.
 
 Slope plots (also called slopegraphs) show how values change between
-two or more conditions, making them ideal for paired data comparisons
+two conditions, making them ideal for paired data comparisons
 and before/after analyses.
 """
 
@@ -39,6 +39,12 @@ data = np.concatenate(
 )
 data = pd.DataFrame(columns=["value", "site", "label"], data=data.T)
 data["value"] = data["value"].astype(float)
+data["subject"] = [
+    f"{site}_{subject}"
+    for _condition in ("healthy", "disease")
+    for site in ("site1", "site2", "site3")
+    for subject in range(15)
+]
 
 
 # %%
@@ -46,7 +52,7 @@ data["value"] = data["value"].astype(float)
 # ~~~~~~~~~~~~~~~
 # Visualize changes between healthy and disease states.
 cns.figure(150, 150)
-ax = cns.slopeplot(data=data, x="site", y="value", hue="label")
+ax = cns.slopeplot(data=data, x="site", y="value", hue="label", pair="subject")
 ax.set_title("Basic Slope Plot", pad=15)
 
 
@@ -55,21 +61,21 @@ ax.set_title("Basic Slope Plot", pad=15)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Apply different color schemes.
 cns.figure(150, 150, "Set1")
-cns.slopeplot(data=data, x="site", y="value", hue="label")
+cns.slopeplot(data=data, x="site", y="value", hue="label", pair="subject")
 
 
 # %%
 # Tableau palette
 # ~~~~~~~~~~~~~~~
 cns.figure(150, 150, "Tableau")
-cns.slopeplot(data=data, x="site", y="value", hue="label")
+cns.slopeplot(data=data, x="site", y="value", hue="label", pair="subject")
 
 
 # %%
 # Bold palette
 # ~~~~~~~~~~~~
 cns.figure(150, 150, "Bold")
-cns.slopeplot(data=data, x="site", y="value", hue="label")
+cns.slopeplot(data=data, x="site", y="value", hue="label", pair="subject")
 
 
 # %%
@@ -78,7 +84,7 @@ cns.slopeplot(data=data, x="site", y="value", hue="label")
 # Compare only two sites for cleaner visualization.
 data_2sites = data[data["site"].isin(["site1", "site2"])]
 cns.figure(120, 150)
-cns.slopeplot(data=data_2sites, x="site", y="value", hue="label")
+cns.slopeplot(data=data_2sites, x="site", y="value", hue="label", pair="subject")
 
 
 # %%
@@ -102,7 +108,13 @@ treatment_data = pd.DataFrame(
 )
 
 cns.figure(120, 150)
-ax = cns.slopeplot(data=treatment_data, x="patient", y="value", hue="timepoint")
+ax = cns.slopeplot(
+    data=treatment_data,
+    x="patient",
+    y="value",
+    hue="timepoint",
+    pair="patient",
+)
 ax.set_title("Treatment Response", pad=12)
 
 
@@ -118,17 +130,35 @@ for gene in genes:
     treated = baseline + np.random.normal(1.5, 0.5, 10)
     for i, (b, t) in enumerate(zip(baseline, treated)):
         gene_data.append(
-            {"sample": i, "condition": "Control", "expression": b, "gene": gene}
+            {
+                "sample": i,
+                "pair": f"{gene}_{i}",
+                "condition": "Control",
+                "expression": b,
+                "gene": gene,
+            }
         )
         gene_data.append(
-            {"sample": i, "condition": "Treatment", "expression": t, "gene": gene}
+            {
+                "sample": i,
+                "pair": f"{gene}_{i}",
+                "condition": "Treatment",
+                "expression": t,
+                "gene": gene,
+            }
         )
 
 gene_df = pd.DataFrame(gene_data)
 gene_df_tp53 = gene_df[gene_df["gene"] == "TP53"]
 
 cns.figure(120, 150)
-ax = cns.slopeplot(data=gene_df_tp53, x="sample", y="expression", hue="condition")
+ax = cns.slopeplot(
+    data=gene_df_tp53,
+    x="sample",
+    y="expression",
+    hue="condition",
+    pair="pair",
+)
 ax.set_title("TP53 Expression", pad=12)
 
 
@@ -137,7 +167,13 @@ ax.set_title("TP53 Expression", pad=12)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare expression changes for multiple genes.
 cns.figure(150, 150)
-ax = cns.slopeplot(data=gene_df, x="condition", y="expression", hue="gene")
+ax = cns.slopeplot(
+    data=gene_df,
+    x="gene",
+    y="expression",
+    hue="condition",
+    pair="pair",
+)
 ax.set_title("Gene Expression Changes")
 cns.take_legend_out()
 
@@ -165,15 +201,28 @@ for subj in subjects:
 time_df = pd.DataFrame(time_data)
 
 cns.figure(180, 150)
-ax = cns.slopeplot(data=time_df, x="timepoint", y="value", hue="group")
+two_timepoints = time_df[time_df["timepoint"].isin(["Day 0", "Day 14"])]
+ax = cns.slopeplot(
+    data=two_timepoints,
+    x="group",
+    y="value",
+    hue="timepoint",
+    pair="subject",
+)
 ax.set_title("Time Course", pad=20)
 
 
 # %%
-# Wider figure for more timepoints
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Wider figure for grouped comparisons
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 cns.figure(220, 150)
-ax = cns.slopeplot(data=time_df, x="timepoint", y="value", hue="group")
+ax = cns.slopeplot(
+    data=two_timepoints,
+    x="group",
+    y="value",
+    hue="timepoint",
+    pair="subject",
+)
 ax.set_title("Time Course (Wide)", pad=20)
 
 
@@ -198,7 +247,13 @@ paired_data = pd.DataFrame(
 )
 
 cns.figure(120, 150)
-ax = cns.slopeplot(data=paired_data, x="patient", y="expression", hue="tissue")
+ax = cns.slopeplot(
+    data=paired_data,
+    x="patient",
+    y="expression",
+    hue="tissue",
+    pair="patient",
+)
 ax.set_title("Tumor vs Normal", pad=12)
 
 
@@ -211,14 +266,14 @@ mp = cns.multipanel(max_width=260)
 # Early stage
 early = paired_data[paired_data["stage"] == "Early"]
 mp.panel("A", 120, 100)
-cns.slopeplot(data=early, x="patient", y="expression", hue="tissue")
+cns.slopeplot(data=early, x="patient", y="expression", hue="tissue", pair="patient")
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Early Stage")
 
 # Late stage
 late = paired_data[paired_data["stage"] == "Late"]
 mp.panel("B", 120, 100, margin_right=0)
-cns.slopeplot(data=late, x="patient", y="expression", hue="tissue")
+cns.slopeplot(data=late, x="patient", y="expression", hue="tissue", pair="patient")
 mp.get_axes("B").legend().remove()
 mp.get_axes("B").set_title("Late Stage")
 
@@ -254,7 +309,13 @@ for site in sites:
 drug_df = pd.DataFrame(drug_data)
 
 cns.figure(150, 150)
-ax = cns.slopeplot(data=drug_df, x="condition", y="value", hue="site")
+ax = cns.slopeplot(
+    data=drug_df,
+    x="site",
+    y="value",
+    hue="condition",
+    pair="sample",
+)
 ax.set_title("Drug Response by Site")
 cns.take_legend_out()
 
@@ -265,16 +326,16 @@ cns.take_legend_out()
 mp = cns.multipanel(max_width=410)
 
 mp.panel("A", 120, 100, color_cycle="Set1")
-cns.slopeplot(data=data_2sites, x="site", y="value", hue="label")
+cns.slopeplot(data=data_2sites, x="site", y="value", hue="label", pair="subject")
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Set1")
 
 mp.panel("B", 120, 100, color_cycle="Tableau")
-cns.slopeplot(data=data_2sites, x="site", y="value", hue="label")
+cns.slopeplot(data=data_2sites, x="site", y="value", hue="label", pair="subject")
 mp.get_axes("B").legend().remove()
 mp.get_axes("B").set_title("Tableau")
 
 mp.panel("C", 120, 100, color_cycle="Bold", margin_right=0)
-cns.slopeplot(data=data_2sites, x="site", y="value", hue="label")
+cns.slopeplot(data=data_2sites, x="site", y="value", hue="label", pair="subject")
 mp.get_axes("C").legend().remove()
 mp.get_axes("C").set_title("Bold")

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -353,8 +353,12 @@ class LogisticModel:
         Returns
         -------
         tuple of float
-            (auc_median, lower_bound, upper_bound)
+            (auc, lower_bound, upper_bound), where ``auc`` is computed from all
+            predictions and bootstrap samples are used only for the bounds.
         """
+        y_true = np.asarray(y_true)
+        y_pred_proba = np.asarray(y_pred_proba)
+        auc = skl.metrics.roc_auc_score(y_true, y_pred_proba)
         aucs = []
         rng = np.random.default_rng(42)
         n = len(y_true)
@@ -362,13 +366,14 @@ class LogisticModel:
             indices = rng.choice(n, n, replace=True)
             if len(np.unique(y_true[indices])) < 2:
                 continue
-            auc = skl.metrics.roc_auc_score(y_true[indices], y_pred_proba[indices])
-            aucs.append(auc)
+            bootstrap_auc = skl.metrics.roc_auc_score(
+                y_true[indices], y_pred_proba[indices]
+            )
+            aucs.append(bootstrap_auc)
         aucs = np.array(aucs)
-        auc_median = np.median(aucs)
         lower = np.percentile(aucs, 100 * alpha / 2)
         upper = np.percentile(aucs, 100 * (1 - alpha / 2))
-        return float(auc_median), float(lower), float(upper)
+        return float(auc), float(lower), float(upper)
 
     def fit(self) -> None:
         """
@@ -396,7 +401,7 @@ class LogisticModel:
         1. Design matrix is created using Patsy (supports formulas)
         2. Predictors are standardized within each cross-validation fold
         3. LogisticRegressionCV fits with L1 penalty and 5-fold CV
-        4. AUC and 95% CI are computed from out-of-fold predictions via bootstrap
+        4. AUC is computed from all out-of-fold predictions, with a bootstrap 95% CI
 
         Runtime warnings are emitted for hue groups with no outcome variance.
         Errors during fitting are caught and surfaced as warnings.
@@ -428,23 +433,46 @@ class LogisticModel:
             ]
 
         for hue_group, hue_data in hue_groups:
+            hue_data = hue_data.reset_index(drop=True)
             for var in self.variates:
                 try:
                     X = patsy.dmatrix(var, hue_data, return_type="dataframe").drop(
                         "Intercept", axis=1
                     )
-                    y = hue_data[self.event].values
-                    if len(np.unique(y)) < 2:
+                    y = hue_data.loc[X.index, self.event].to_numpy()
+                    class_counts = pd.Series(y).value_counts()
+                    if len(class_counts) < 2:
                         warnings.warn(
                             f"No variance in outcome for {var} in hue group {hue_group}",
                             RuntimeWarning,
                             stacklevel=2,
                         )
                         continue
+                    if len(class_counts) > 2:
+                        raise ValueError(
+                            "Logistic regression requires exactly two outcome classes"
+                        )
+
+                    n_splits = 5
+                    if (class_counts < n_splits).any():
+                        raise ValueError(
+                            "Outer 5-fold cross-validation requires at least 5 "
+                            "observations in each outcome class after removing rows "
+                            f"with missing predictor values; got {class_counts.to_dict()}"
+                        )
+                    outer_training_counts = class_counts - np.ceil(
+                        class_counts / n_splits
+                    ).astype(int)
+                    if (outer_training_counts < n_splits).any():
+                        raise ValueError(
+                            "Inner 5-fold cross-validation requires at least 5 "
+                            "observations in each outcome class in every outer training "
+                            "fold; at least 7 observations per class are required"
+                        )
                     model = make_pipeline(
                         StandardScaler(),
                         LogisticRegressionCV(
-                            cv=5,
+                            cv=n_splits,
                             penalty="l1",
                             solver="liblinear",
                             random_state=42,
@@ -452,7 +480,7 @@ class LogisticModel:
                         ),
                     )
                     y_pred_proba = cross_val_predict(
-                        model, X, y, cv=5, method="predict_proba"
+                        model, X, y, cv=n_splits, method="predict_proba"
                     )[:, 1]
                     auc, auc_lower, auc_upper = self._compute_auc_ci(y, y_pred_proba)
                     model_result = {

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -847,11 +847,18 @@ def get_showcase_data(
         (1, "site2", "disease"),
         (3, "site3", "disease"),
     ]:
-        for value in np.random.normal(loc=mean, size=15):
-            slope_rows.append({"value": float(value), "site": site, "label": label})
+        for subject, value in enumerate(np.random.normal(loc=mean, size=15)):
+            slope_rows.append(
+                {
+                    "value": float(value),
+                    "site": site,
+                    "label": label,
+                    "pair": f"{site}_{subject}",
+                }
+            )
     slope_df = pd.DataFrame(
         slope_rows,
-        columns=pd.Index(["value", "site", "label"]),
+        columns=pd.Index(["value", "site", "label", "pair"]),
     )
 
     # ROC data

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -692,6 +692,39 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=No
             )
         pairs = hue_pairs
 
+    contingency_tables = None
+    if contingency is not None:
+        contingency = contingency.fillna(0)
+        contingency_tables = []
+        for pair in pairs:
+            if len(pair) != 2 or pair[0] == pair[1]:
+                raise ValueError(
+                    "Contingency-table comparisons require exactly two distinct "
+                    "levels per pair."
+                )
+            missing_levels = [level for level in pair if level not in contingency.index]
+            if missing_levels:
+                raise ValueError(
+                    "Contingency-table pair contains levels absent from the data: "
+                    f"{missing_levels}."
+                )
+            table = contingency.loc[list(pair)].to_numpy(dtype=float)
+            if table.shape[0] < 2 or table.shape[1] < 2:
+                raise ValueError(
+                    "Contingency-table comparisons require at least two rows and "
+                    "two columns."
+                )
+            if not np.isfinite(table).all() or (table < 0).any():
+                raise ValueError(
+                    "Contingency-table cells must contain finite, nonnegative counts."
+                )
+            if (table.sum(axis=0) == 0).any() or (table.sum(axis=1) == 0).any():
+                raise ValueError(
+                    "Contingency-table comparisons require nonzero row and column "
+                    "margins."
+                )
+            contingency_tables.append(table)
+
     annotator = Annotator(ax, pairs, **plotting)
     annotator._pvalue_format = PValueFormatNew()
     annotator.configure(
@@ -711,15 +744,13 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=No
 
     pvalues = []
     if test == "fisher-exact":
-        assert contingency is not None
-        for pair in pairs:
-            pvalues.append(stats.fisher_exact(contingency.loc[list(pair)].values)[1])
+        assert contingency_tables is not None
+        for table in contingency_tables:
+            pvalues.append(stats.fisher_exact(table)[1])
     if test == "chi-squared":
-        assert contingency is not None
-        for pair in pairs:
-            pvalues.append(
-                stats.chi2_contingency(contingency.loc[list(pair)].values)[1]
-            )
+        assert contingency_tables is not None
+        for table in contingency_tables:
+            pvalues.append(stats.chi2_contingency(table)[1])
 
     if contingency is None:
         annotator.apply_and_annotate()

--- a/src/cnsplots/_validation.py
+++ b/src/cnsplots/_validation.py
@@ -423,7 +423,7 @@ def validate_sufficient_data(
 
 def validate_binary_column(data: pd.DataFrame, column: str, function_name: str) -> None:
     """
-    Validate that a column contains only two unique values.
+    Validate that a column contains exactly the binary values 0 and 1.
 
     Parameters
     ----------
@@ -437,13 +437,98 @@ def validate_binary_column(data: pd.DataFrame, column: str, function_name: str) 
     Raises
     ------
     ValueError
-        If the column does not have exactly 2 unique values.
+        If the column does not contain exactly 0 and 1.
     """
     unique_values = data[column].dropna().unique()
-    if len(unique_values) != 2:
+    if np.iscomplexobj(unique_values) or set(unique_values) != {0, 1}:
         raise ValueError(
-            f"[{function_name}] Column '{column}' must have exactly 2 unique values for binary operations, "
-            f"found {len(unique_values)}: {list(unique_values)}"
+            f"[{function_name}] Column '{column}' must have exactly 2 unique values, "
+            f"specifically 0 and 1, found {list(unique_values)}"
+        )
+
+
+def validate_time_to_event_data(
+    data: pd.DataFrame,
+    duration: str,
+    event: str,
+    group: str,
+    function_name: str,
+    *,
+    competing_risks: bool = False,
+    min_groups: int = 1,
+) -> None:
+    """Validate durations, event codes, and per-group sample adequacy."""
+    validate_column_type(data, duration, ["numeric"], function_name)
+    validate_no_nulls(data, [duration, event, group], function_name)
+
+    duration_values = data[duration].to_numpy()
+    if np.iscomplexobj(duration_values) or pd.api.types.is_bool_dtype(
+        data[duration].dtype
+    ):
+        raise ValueError(
+            f"[{function_name}] Column '{duration}' must contain real-valued numeric "
+            "durations."
+        )
+    durations = duration_values.astype(float)
+    if not np.isfinite(durations).all():
+        raise ValueError(
+            f"[{function_name}] Column '{duration}' must contain only finite durations."
+        )
+    if (durations < 0).any():
+        raise ValueError(
+            f"[{function_name}] Column '{duration}' must contain only non-negative "
+            "durations."
+        )
+
+    if competing_risks:
+        validate_column_type(data, event, ["numeric"], function_name)
+        raw_event_values = data[event].to_numpy()
+        if np.iscomplexobj(raw_event_values):
+            raise ValueError(
+                f"[{function_name}] Column '{event}' must contain non-negative integer "
+                "event codes (0 = censored, 1 = event of interest, 2+ = competing "
+                "events)."
+            )
+        event_values = raw_event_values.astype(float)
+        if (
+            not np.isfinite(event_values).all()
+            or (event_values < 0).any()
+            or (event_values != np.floor(event_values)).any()
+        ):
+            raise ValueError(
+                f"[{function_name}] Column '{event}' must contain non-negative integer "
+                "event codes (0 = censored, 1 = event of interest, 2+ = competing "
+                "events)."
+            )
+    else:
+        validate_binary_column(data, event, function_name)
+
+    group_sizes = data.groupby(group, observed=True).size()
+    if len(group_sizes) < min_groups:
+        raise ValueError(
+            f"[{function_name}] Column '{group}' must contain at least {min_groups} "
+            f"groups, found {len(group_sizes)}."
+        )
+
+    small_groups = group_sizes[group_sizes < 2]
+    if not small_groups.empty:
+        raise ValueError(
+            f"[{function_name}] Each group in column '{group}' must contain at least 2 "
+            f"observations; insufficient groups: {list(small_groups.index)}."
+        )
+
+    event_counts = (
+        data.loc[data[event] == 1]
+        .groupby(group, observed=True)
+        .size()
+        .reindex(group_sizes.index, fill_value=0)
+    )
+    groups_without_events = event_counts[event_counts < 1]
+    if not groups_without_events.empty:
+        raise ValueError(
+            f"[{function_name}] Each group in column '{group}' must contain at least one "
+            f"event of interest (event code 1); groups without events: "
+            f"{list(groups_without_events.index)}."
         )
 
 

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib.patches import Patch
+from scipy import stats
 
 import cnsplots._utils as utils
 from cnsplots._utils import _legend_fontsize, _resize_legend_markers
@@ -22,6 +23,10 @@ from cnsplots._validation import (
 )
 
 LollipopPair = Union[tuple[str, str], tuple[tuple[str, str], tuple[str, str]]]
+LollipopError = float | tuple[float, float]
+
+_LOLLIPOP_BOOTSTRAP_SAMPLES = 1000
+_LOLLIPOP_BOOTSTRAP_SEED = 0
 
 
 def _resolve_palette_column(
@@ -54,22 +59,51 @@ def _resolve_palette_column(
     return category_to_color, legend_handles
 
 
-def _compute_lollipop_error(group_values: pd.Series, errorbar: str) -> float:
+def _compute_lollipop_error(
+    group_values: pd.Series,
+    errorbar: str,
+    estimator: str = "mean",
+) -> LollipopError:
     """Compute the requested lollipop error magnitude for one group."""
-    sem = group_values.std() / np.sqrt(len(group_values))
+    if estimator not in {"mean", "median"}:
+        raise ValueError("estimator must be one of: 'mean', 'median'")
+    if errorbar not in {"se", "sd", "ci"}:
+        raise ValueError("errorbar must be one of: 'se', 'sd', 'ci', or None")
+
+    values = group_values.dropna()
+    sample_size = len(values)
+    standard_deviation = values.std()
+    if errorbar == "sd":
+        return standard_deviation
+    if sample_size < 2:
+        return np.nan
+
+    if estimator == "median":
+        samples = values.to_numpy(dtype=float)
+        rng = np.random.default_rng(_LOLLIPOP_BOOTSTRAP_SEED)
+        indices = rng.integers(
+            0,
+            sample_size,
+            size=(_LOLLIPOP_BOOTSTRAP_SAMPLES, sample_size),
+        )
+        bootstrap_medians = np.median(samples[indices], axis=1)
+        if errorbar == "se":
+            return float(bootstrap_medians.std(ddof=1))
+        lower, upper = np.percentile(bootstrap_medians, [2.5, 97.5])
+        estimate = float(np.median(samples))
+        return estimate - float(lower), float(upper) - estimate
+
+    sem = standard_deviation / np.sqrt(sample_size)
     if errorbar == "se":
         return sem
-    if errorbar == "sd":
-        return group_values.std()
-    if errorbar == "ci":
-        return 1.96 * sem
-    return 0
+    return stats.t.ppf(0.975, sample_size - 1) * sem
 
 
 def _lollipop_errors(
     grouped: Any,
     categories: list[str],
     errorbar: str | None,
+    estimator: str,
     *,
     require_multiple: bool,
 ) -> pd.Series | None:
@@ -77,7 +111,7 @@ def _lollipop_errors(
     if errorbar is None:
         return None
     errors = grouped.apply(
-        lambda values: _compute_lollipop_error(values, errorbar)
+        lambda values: _compute_lollipop_error(values, errorbar, estimator)
     ).reindex(categories)
     if require_multiple:
         counts = grouped.count().reindex(categories)
@@ -125,11 +159,17 @@ def _draw_lollipop_series(
 
     if errors is not None:
         for position, value, error in zip(positions, values, errors):
-            if pd.isna(error):
+            error_values = np.asarray(error, dtype=float)
+            if np.isnan(error_values).any():
                 continue
-            error_kwargs = {"yerr" if orient == "v" else "xerr": error}
+            resolved_error: float | np.ndarray
+            if error_values.ndim == 0:
+                resolved_error = float(error_values)
+            else:
+                resolved_error = error_values.reshape(2, 1)
+            error_kwargs = {"yerr" if orient == "v" else "xerr": resolved_error}
             point = (position, value) if orient == "v" else (value, position)
-            ax.errorbar(
+            cast(Any, ax.errorbar)(
                 *point,
                 **error_kwargs,
                 fmt="none",
@@ -317,7 +357,9 @@ def lollipopplot(
         The aggregation function to compute for each category.
     errorbar : {'se', 'sd', 'ci'}, optional
         Type of error bar to draw. ``'se'`` for standard error, ``'sd'`` for
-        standard deviation, ``'ci'`` for 95% confidence interval.
+        standard deviation, ``'ci'`` for a 95% confidence interval. Mean intervals
+        use Student's t distribution; median intervals use deterministic bootstrap
+        percentiles.
     markersize : float, default: 20
         Size of the dot markers (in points squared, passed to scatter ``s``).
     linewidth : float, default: 1.5
@@ -364,6 +406,10 @@ def lollipopplot(
     validate_dataframe_not_empty(data, "lollipopplot")
     if hue is not None:
         validate_column_exists(data, hue, "hue", "lollipopplot")
+    if estimator not in {"mean", "median"}:
+        raise ValueError("estimator must be one of: 'mean', 'median'")
+    if errorbar not in {None, "se", "sd", "ci"}:
+        raise ValueError("errorbar must be one of: 'se', 'sd', 'ci', or None")
 
     palette_is_column = isinstance(palette, str) and palette in data.columns
     if hue is not None and palette_is_column and palette != hue:
@@ -414,7 +460,13 @@ def lollipopplot(
     if hue is None:
         grouped = data.groupby(cat_col, sort=False)[val_col]
         means = grouped.agg(agg_func).reindex(categories)
-        errors = _lollipop_errors(grouped, categories, errorbar, require_multiple=False)
+        errors = _lollipop_errors(
+            grouped,
+            categories,
+            errorbar,
+            estimator,
+            require_multiple=False,
+        )
         _draw_lollipop_series(
             ax,
             orient=orient,
@@ -448,7 +500,11 @@ def lollipopplot(
             means = grouped.agg(agg_func).reindex(categories)
             positions = cat_positions + offsets[i]
             errors = _lollipop_errors(
-                grouped, categories, errorbar, require_multiple=True
+                grouped,
+                categories,
+                errorbar,
+                estimator,
+                require_multiple=True,
             )
             _draw_lollipop_series(
                 ax,
@@ -553,7 +609,8 @@ def stackplot(
     normalize : bool, default: True
         Whether to normalize counts to frequencies (proportions summing to 1).
     pairs : list of tuple of str, optional
-        List of pairs of category names from x for pairwise statistical comparisons.
+        List of pairs of bar-category names for pairwise statistical comparisons
+        (levels of ``x`` vertically and levels of ``y`` horizontally).
     addcount : bool, default: False
         Whether to append total counts to the category tick labels in the
         format ``n=...``.
@@ -599,6 +656,7 @@ def stackplot(
         df = data2.pivot(index=y, columns=x, values="count")
     else:
         df = data2.pivot(index=x, columns=y, values="count")
+    df = df.fillna(0)
     contingency = df.copy()
     if stack_order is not None:
         df.columns = pd.CategoricalIndex(

--- a/src/cnsplots/plots/_regression.py
+++ b/src/cnsplots/plots/_regression.py
@@ -19,7 +19,28 @@ from cnsplots._validation import (
     validate_columns_exist,
     validate_dataframe,
     validate_dataframe_not_empty,
+    validate_no_nulls,
 )
+
+
+def _finite_xy_data(data: pd.DataFrame, x: str, y: str) -> pd.DataFrame:
+    """Return rows whose x and y values are both finite."""
+    xy_values = data[[x, y]].to_numpy(dtype=float, na_value=np.nan)
+    return data.loc[np.isfinite(xy_values).all(axis=1)]
+
+
+def _validate_pearson_sample_size(
+    data: pd.DataFrame,
+    *,
+    group: Any = None,
+) -> None:
+    """Require enough plotted pairs for Pearson correlation."""
+    if len(data) < 2:
+        group_suffix = "" if group is None else f" in hue group {group!r}"
+        raise ValueError(
+            "[regplot] Pearson correlation requires at least 2 finite paired "
+            f"observations{group_suffix}."
+        )
 
 
 def regplot(
@@ -103,9 +124,17 @@ def regplot(
     args.update(kwargs)
     palette = plt.rcParams["axes.prop_cycle"].by_key()["color"]
     color_is_column = isinstance(color, str) and color in data.columns
-    if hue:
-        for idx, hue_val in enumerate(data[hue].unique()):
-            subset = data[data[hue] == hue_val]
+    finite_data = _finite_xy_data(data, x, y)
+    if hue is not None:
+        plot_data = finite_data.loc[finite_data[hue].notna()]
+        _validate_pearson_sample_size(plot_data)
+        hue_subsets = [
+            (hue_val, plot_data[plot_data[hue] == hue_val])
+            for hue_val in plot_data[hue].unique()
+        ]
+        for hue_val, subset in hue_subsets:
+            _validate_pearson_sample_size(subset, group=hue_val)
+        for idx, (hue_val, subset) in enumerate(hue_subsets):
             ax = sns.regplot(
                 data=subset,
                 x=x,
@@ -115,11 +144,11 @@ def regplot(
                 label=hue_val,
                 **args,
             )
-            rho, p_value = sp.stats.pearsonr(subset[x], subset[y])
+            r, p_value = sp.stats.pearsonr(subset[x], subset[y])
             ax.text(
                 0.05,
                 0.95 - 0.08 * idx,
-                rf"{hue_val}: $\rho$={rho:.2f},"
+                rf"{hue_val}: $r$={r:.2f},"
                 rf" P=${num2tex.num2tex(p_value, precision=2):.2g}$",
                 color=palette[idx % len(palette)],
                 transform=ax.transAxes,
@@ -128,9 +157,11 @@ def regplot(
             )
         ax.legend(title=hue)
     elif color_is_column:
+        plot_data = finite_data.loc[finite_data[color].notna()]
+        _validate_pearson_sample_size(plot_data)
         line_args = {k: v for k, v in args.items() if k != "scatter_kws"}
         ax = sns.regplot(
-            data=data,
+            data=plot_data,
             x=x,
             y=y,
             ax=ax,
@@ -138,9 +169,9 @@ def regplot(
             scatter=False,
             **line_args,
         )
-        unique_vals = data[color].unique()
+        unique_vals = plot_data[color].unique()
         for idx, val in enumerate(unique_vals):
-            subset = data[data[color] == val]
+            subset = plot_data[plot_data[color] == val]
             ax.scatter(
                 subset[x],
                 subset[y],
@@ -150,11 +181,11 @@ def regplot(
                 alpha=1,
                 edgecolors="none",
             )
-        rho, p_value = sp.stats.pearsonr(data[x], data[y])
+        r, p_value = sp.stats.pearsonr(plot_data[x], plot_data[y])
         ax.text(
             0.05,
             0.95,
-            rf"$\rho$={rho:.2f}, $P={num2tex.num2tex(p_value, precision=2):.2g}$",
+            rf"$r$={r:.2f}, $P={num2tex.num2tex(p_value, precision=2):.2g}$",
             color="black",
             transform=ax.transAxes,
             ha="left",
@@ -165,19 +196,20 @@ def regplot(
             ax.get_legend(), 2 * s, marker_size=2 * np.sqrt(s / np.pi)
         )
     else:
+        _validate_pearson_sample_size(finite_data)
         ax = sns.regplot(
-            data=data,
+            data=finite_data,
             x=x,
             y=y,
             ax=ax,
             color=color,
             **args,
         )
-        rho, p_value = sp.stats.pearsonr(data[x], data[y])
+        r, p_value = sp.stats.pearsonr(finite_data[x], finite_data[y])
         ax.text(
             0.05,
             0.95,
-            rf"$\rho$={rho:.2f}, $P={num2tex.num2tex(p_value, precision=2):.2g}$",
+            rf"$r$={r:.2f}, $P={num2tex.num2tex(p_value, precision=2):.2g}$",
             color=color,
             transform=ax.transAxes,
             ha="left",
@@ -289,7 +321,7 @@ def lineplot(**kwargs: Any) -> Axes:
     return ax
 
 
-def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str) -> Axes:
+def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str, pair: str) -> Axes:
     """
     Create a slope plot showing paired changes between two conditions.
 
@@ -298,11 +330,15 @@ def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str) -> Axes:
     data : pd.DataFrame
         The input DataFrame containing paired observations.
     x : str
-        Column name for the categorical variable defining the two conditions.
+        Column name for the categorical variable defining groups along the x-axis.
     y : str
         Column name for the continuous variable to plot.
     hue : str
-        Column name for the grouping variable. Must have exactly two unique values.
+        Column name defining the two conditions. Must have exactly two unique values.
+    pair : str
+        Column containing the subject or observation identifier used to pair values
+        across the two conditions. Each pair must belong to one ``x`` group and have
+        exactly one value per condition.
 
     Returns
     -------
@@ -324,21 +360,52 @@ def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str) -> Axes:
     ...     x="patient_id",
     ...     y="tumor_size",
     ...     hue="timepoint",
+    ...     pair="patient_id",
     ... )
     >>> ax.set_ylabel("Tumor Size (mm)")
 
     >>> # Compare two treatments across sites
-    >>> ax = cns.slopeplot(data=df, x="site", y="response_rate", hue="treatment")
+    >>> ax = cns.slopeplot(
+    ...     data=df,
+    ...     x="site",
+    ...     y="response_rate",
+    ...     hue="treatment",
+    ...     pair="subject_id",
+    ... )
     """
     # Validate inputs
     validate_dataframe(data, "data", "slopeplot")
-    validate_columns_exist(data, [x, y, hue], "slopeplot")
+    validate_columns_exist(data, [x, y, hue, pair], "slopeplot")
     validate_dataframe_not_empty(data, "slopeplot")
+    validate_no_nulls(data, [x, y, hue, pair], "slopeplot")
+
+    hues = data[hue].unique()
+    if len(hues) != 2:
+        raise ValueError(
+            f"[slopeplot] Column '{hue}' must have exactly 2 unique values, "
+            f"found {len(hues)}: {list(hues)}"
+        )
+
+    pair_count = len(data[[pair]].drop_duplicates())
+    pair_x_keys = list(dict.fromkeys((pair, x)))
+    if len(data[pair_x_keys].drop_duplicates()) != pair_count:
+        raise ValueError(
+            f"[slopeplot] Each '{pair}' pair must belong to exactly one '{x}' group."
+        )
+
+    observation_keys = list(dict.fromkeys((pair, hue)))
+    has_duplicates = data.duplicated(observation_keys).any()
+    observed_count = len(data[observation_keys].drop_duplicates())
+    expected_count = 2 * pair_count
+    if has_duplicates or observed_count != expected_count:
+        raise ValueError(
+            f"[slopeplot] Each '{pair}' pair must have exactly one '{y}' value "
+            f"for each '{hue}' level."
+        )
 
     # https://cduvallet.github.io/posts/2018/03/slopegraphs-in-python
     red = palettable.colorbrewer.qualitative.Set1_9.hex_colors[0]
     blue = palettable.colorbrewer.qualitative.Set1_9.hex_colors[1]
-    hues = data[hue].unique()
 
     ax = plt.gca()
 
@@ -346,8 +413,8 @@ def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str) -> Axes:
     i = 1.0
     for site, subdf in data.groupby(x):
         sites.append(str(site))
-        h = subdf[subdf[hue] == hues[0]][y].values
-        d = subdf[subdf[hue] == hues[1]][y].values
+        h = subdf[subdf[hue] == hues[0]].set_index(pair)[y]
+        d = subdf[subdf[hue] == hues[1]].set_index(pair)[y].reindex(h.index)
 
         x1 = i - 0.2
         x2 = i + 0.2

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -15,13 +15,10 @@ import numpy as np
 import pandas as pd
 
 from cnsplots._validation import (
-    validate_binary_column,
-    validate_column_type,
     validate_columns_exist,
     validate_dataframe,
     validate_dataframe_not_empty,
-    validate_no_nulls,
-    validate_sufficient_data,
+    validate_time_to_event_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -114,6 +111,7 @@ def survivalplot(
     event: str,
     hue: str,
     hue_order: list[str] | None = None,
+    time_label: str = "Time",
 ) -> Axes:
     """
     Create a Kaplan-Meier survival plot with statistical comparisons.
@@ -134,6 +132,8 @@ def survivalplot(
         Column name for the grouping variable to compare survival curves.
     hue_order : list, optional
         Order of groups from hue to display and compare.
+    time_label : str, default: "Time"
+        Label for the time axis, including units when applicable.
 
     Returns
     -------
@@ -154,6 +154,7 @@ def survivalplot(
     ...     event="death",
     ...     hue="treatment",
     ...     hue_order=["control", "drug_a", "drug_b"],
+    ...     time_label="Time (months)",
     ... )
     >>> ax.set_title("Overall Survival by Treatment")
     """
@@ -162,15 +163,14 @@ def survivalplot(
     validate_columns_exist(data, [duration, event, hue], "survivalplot")
     validate_dataframe_not_empty(data, "survivalplot")
 
-    # Validate data types
-    validate_column_type(data, duration, ["numeric"], "survivalplot")
-    validate_binary_column(data, event, "survivalplot")
-
-    # Validate no nulls in critical columns
-    validate_no_nulls(data, [duration, event, hue], "survivalplot")
-
-    # Validate sufficient data
-    validate_sufficient_data(data, duration, 2, "survivalplot")
+    validate_time_to_event_data(
+        data,
+        duration,
+        event,
+        hue,
+        "survivalplot",
+        min_groups=2,
+    )
 
     import lifelines as ll
     from lifelines.statistics import multivariate_logrank_test
@@ -200,16 +200,8 @@ def survivalplot(
             )
     assert ax is not None
     plt.ylim(-0.05, 1.01)
-    if ax.get_xlim()[1] > 120:
-        ax.xaxis.set_major_locator(plt.MultipleLocator(24))
-        plt.xlabel("Time (Months)")
-    elif ax.get_xlim()[1] > 12:
-        ax.xaxis.set_major_locator(plt.MultipleLocator(12))
-        plt.xlabel("Time (Months)")
-    else:
-        ax.xaxis.set_major_locator(plt.MultipleLocator(1))
-        plt.xlabel("Time (Years)")
-    plt.ylabel("Overall survival probability")
+    ax.set_xlabel(time_label)
+    ax.set_ylabel("Survival probability")
 
     df = data[[duration, hue, event]].copy()
     df[hue] = df[hue].cat.codes
@@ -283,6 +275,8 @@ def cumulativeincidenceplot(
     xticks: np.ndarray | Sequence[int | float] | None = None,
     censor_mark_position: CensorMarkPosition | list[CensorMarkPosition] = "line",
     censor_mark_length: float = _DEFAULT_CENSOR_MARK_LENGTH,
+    time_label: str = "Time",
+    seed: int | None = 0,
 ) -> Axes:
     """
     Create a cumulative incidence plot for competing risks analysis.
@@ -324,6 +318,12 @@ def cumulativeincidenceplot(
     censor_mark_length : float, default: 0.02
         Length of each vertical censoring mark in cumulative-incidence probability
         units. The same length is used for all curves.
+    time_label : str, default: "Time"
+        Label for the time axis, including units when applicable.
+    seed : int or None, default: 0
+        Seed used by lifelines when tied event times require jittering. The default
+        makes tied-data plots deterministic. The caller's NumPy random state is
+        restored after fitting.
 
     Returns
     -------
@@ -345,6 +345,7 @@ def cumulativeincidenceplot(
     ...     hue="treatment",
     ...     hue_order=["placebo", "drug"],
     ...     show_risk_table=True,
+    ...     time_label="Time (years)",
     ... )
 
     >>> # With custom tick positions
@@ -354,6 +355,7 @@ def cumulativeincidenceplot(
     ...     event="outcome",
     ...     hue="risk_group",
     ...     xticks=[0, 12, 24, 36, 48, 60],
+    ...     time_label="Time (months)",
     ... )
     """
     # Validate inputs
@@ -361,14 +363,14 @@ def cumulativeincidenceplot(
     validate_columns_exist(data, [duration, event, hue], "cumulativeincidenceplot")
     validate_dataframe_not_empty(data, "cumulativeincidenceplot")
 
-    # Validate data types
-    validate_column_type(data, duration, ["numeric"], "cumulativeincidenceplot")
-
-    # Validate no nulls in critical columns
-    validate_no_nulls(data, [duration, event, hue], "cumulativeincidenceplot")
-
-    # Validate sufficient data
-    validate_sufficient_data(data, duration, 2, "cumulativeincidenceplot")
+    validate_time_to_event_data(
+        data,
+        duration,
+        event,
+        hue,
+        "cumulativeincidenceplot",
+        competing_risks=True,
+    )
 
     if censor_mark_length < 0:
         raise ValueError(
@@ -393,8 +395,12 @@ def cumulativeincidenceplot(
         label = f"{group} (n={df.shape[0]})"
         if show_risk_table:
             label = group
-        fitter = ll.AalenJohansenFitter()
-        fitter.fit(df[duration], df[event], label=label, event_of_interest=1)
+        fitter = ll.AalenJohansenFitter(seed=seed)
+        random_state = np.random.get_state()
+        try:
+            fitter.fit(df[duration], df[event], label=label, event_of_interest=1)
+        finally:
+            np.random.set_state(random_state)
         fitters.append(fitter)
         df = pd.merge(
             fitter.cumulative_density_.reset_index(drop=False),
@@ -431,7 +437,7 @@ def cumulativeincidenceplot(
     assert ax is not None
     ax.set_ylim(_CIF_Y_LIMITS)
     ax.set_ylabel("Cumulative incidence probability")
-    ax.set_xlabel("Time (Years)")
+    ax.set_xlabel(time_label)
     specified_xticks = None
     if xticks is not None:
         specified_xticks = np.asarray(list(xticks), dtype=float)
@@ -444,8 +450,9 @@ def cumulativeincidenceplot(
             )
             ax.set_xlim(new_xlim)
     if data[hue].nunique() > 1:
+        gray_events = data[event].where(data[event] <= 1, 2)
         pvalue = helper_cmprsk.cuminc(
-            data[duration], data[event], group=data[hue].cat.codes
+            data[duration], gray_events, group=data[hue].cat.codes
         )
         p = num2tex.num2tex(pvalue, precision=2)
         logger.info("P-value was determined by two-sided Gray's test.")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1232,6 +1232,19 @@ def test_utils_helpers_and_showcase_data(
     monkeypatch.setitem(sys.modules, "scanpy", fake_sc)
     data = _utils.get_showcase_data()
     assert len(data) == 13
+    slope_data = data[7]
+    assert isinstance(slope_data, pd.DataFrame)
+    with monkeypatch.context() as slope_context:
+        slope_context.setitem(sys.modules, "seaborn", sns)
+        cns.figure(120, 120)
+        slope_ax = cns.slopeplot(
+            slope_data,
+            x="site",
+            y="value",
+            hue="label",
+            pair="pair",
+        )
+    assert len(slope_ax.lines) == 45
     assert isinstance(data[10], pd.DataFrame)
     assert isinstance(data[11], pd.DataFrame)
     assert isinstance(data[12], dict)

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -762,10 +762,13 @@ def test_plot_internal_coverage(
     phylo_adata: ad.AnnData,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    with pytest.raises(ValueError, match="errorbar must be one of"):
+        cns.lollipopplot(
+            categorical_df, x="group", y="value", addtip=True, errorbar="bad"
+        )
+
     cns.figure(120, 120)
-    lollipop_ax = cns.lollipopplot(
-        categorical_df, x="group", y="value", addtip=True, errorbar="bad"
-    )
+    lollipop_ax = cns.lollipopplot(categorical_df, x="group", y="value", addtip=True)
     lollipop_points = [
         collection
         for collection in lollipop_ax.collections
@@ -937,7 +940,7 @@ def test_plot_internal_coverage(
         np.asarray(regression_ax.lines[0].get_ydata(), dtype=float),
         2 * np.asarray(regression_ax.lines[0].get_xdata(), dtype=float),
     )
-    assert [text.get_text() for text in regression_ax.texts] == [r"$\rho$=1.00, $P=0$"]
+    assert [text.get_text() for text in regression_ax.texts] == [r"$r$=1.00, $P=0$"]
     assert fake_legend.legend_handles[0].sizes == [6]
 
     monkeypatch.undo()
@@ -1082,7 +1085,7 @@ def test_plot_internal_coverage(
     bad_survival["time"] = bad_survival["time"] * 20
     cns.figure(120, 120)
     ax = cns.survivalplot(bad_survival, "time", "event", "group")
-    assert ax.get_xlabel() == "Time (Months)"
+    assert ax.get_xlabel() == "Time"
 
     import lifelines
     import lifelines.statistics as lifelines_statistics

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -16,7 +16,7 @@ import cnsplots as cns
 from cnsplots import _methods
 
 
-def test_auc_ci_uses_bootstrap_median_without_changing_global_rng(
+def test_auc_ci_uses_full_predictions_and_bootstrap_only_for_bounds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class FakeGenerator:
@@ -50,7 +50,7 @@ def test_auc_ci_uses_bootstrap_median_without_changing_global_rng(
     )
 
     rng_state_after = repr(np.random.get_state())
-    assert (auc, lower, upper) == (0.0, 0.0, 0.0)
+    assert (auc, lower, upper) == (0.5, 0.0, 0.0)
     assert rng_state_before == rng_state_after
 
 
@@ -60,9 +60,9 @@ def test_logistic_model_uses_scaled_out_of_fold_predictions(
 ) -> None:
     data = pd.DataFrame(
         {
-            "event": [0, 1] * 10,
-            "score": np.arange(20, dtype=float),
-            "group": ["A"] * 10 + ["B"] * 10,
+            "event": [0, 1] * 14,
+            "score": np.arange(28, dtype=float),
+            "group": ["A"] * 14 + ["B"] * 14,
         }
     )
     seen_estimators: list[Pipeline] = []
@@ -101,6 +101,74 @@ def test_logistic_model_uses_scaled_out_of_fold_predictions(
         assert classifier.penalty == "l1"
         assert classifier.solver == "liblinear"
         assert classifier.cv == 5
+
+
+def test_logistic_model_aligns_outcome_after_patsy_drops_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "event": [0, 1] * 8,
+            "score": np.arange(16, dtype=float),
+        },
+        index=np.arange(100, 116),
+    )
+    data.loc[[100, 101], "score"] = np.nan
+
+    def fake_cross_val_predict(
+        estimator: Pipeline,
+        X: pd.DataFrame,
+        y: np.ndarray,
+        *,
+        cv: int,
+        method: str,
+    ) -> np.ndarray:
+        assert X.index.tolist() == list(range(2, 16))
+        np.testing.assert_array_equal(y, data["event"].to_numpy()[2:])
+        probabilities = np.linspace(0.1, 0.9, len(y))
+        return np.column_stack((1 - probabilities, probabilities))
+
+    monkeypatch.setattr(_methods, "cross_val_predict", fake_cross_val_predict)
+    monkeypatch.setattr(
+        cns.LogisticModel,
+        "_compute_auc_ci",
+        lambda self, y, predictions: (0.5, 0.4, 0.6),
+    )
+
+    model = cns.LogisticModel(data, event="event", variates=["score"])
+    model.fit()
+
+    assert model.results is not None
+
+
+@pytest.mark.parametrize(
+    ("minority_count", "message"),
+    [
+        (4, "Outer 5-fold cross-validation requires at least 5 observations"),
+        (6, "Inner 5-fold cross-validation requires at least 5 observations"),
+    ],
+)
+def test_logistic_model_validates_each_nested_cv_layer(
+    minority_count: int, message: str
+) -> None:
+    event = [0] * minority_count + [1] * 10
+    data = pd.DataFrame({"event": event, "score": np.arange(len(event))})
+    model = cns.LogisticModel(data, event="event", variates=["score"])
+
+    with pytest.warns(RuntimeWarning, match=message):
+        model.fit()
+
+    assert model.results is None
+
+
+def test_logistic_model_rejects_more_than_two_outcome_classes() -> None:
+    data = pd.DataFrame({"event": [0, 1, 2] * 7, "score": np.arange(21, dtype=float)})
+    model = cns.LogisticModel(data, event="event", variates=["score"])
+
+    with pytest.warns(RuntimeWarning, match="requires exactly two outcome classes"):
+        model.fit()
+
+    assert model.results is None
 
 
 def test_cox_model_warns_for_failed_unstratified_fit(

--- a/tests/test_plot_behavior_regressions.py
+++ b/tests/test_plot_behavior_regressions.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import sys
 import types
+from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
 from matplotlib.collections import LineCollection, PathCollection
+from scipy import stats
 
 import cnsplots as cns
 
@@ -112,6 +114,180 @@ def test_lollipop_rejects_ambiguous_palette_column_combinations() -> None:
             x="category",
             y="value",
             palette="palette_group",
+        )
+
+
+def test_lollipop_validates_summary_options() -> None:
+    from cnsplots.plots._categorical import _compute_lollipop_error
+
+    data = pd.DataFrame({"category": ["A", "A"], "value": [1.0, 2.0]})
+
+    with pytest.raises(ValueError, match="estimator must be one of"):
+        cns.lollipopplot(data, x="category", y="value", estimator="mode")
+    with pytest.raises(ValueError, match="errorbar must be one of"):
+        cns.lollipopplot(data, x="category", y="value", errorbar="confidence")
+    with pytest.raises(ValueError, match="errorbar must be one of"):
+        _compute_lollipop_error(data["value"], "confidence")
+    with pytest.raises(ValueError, match="estimator must be one of"):
+        _compute_lollipop_error(data["value"], "ci", "mode")
+    assert np.isnan(_compute_lollipop_error(pd.Series([1.0]), "se"))
+
+
+def test_lollipop_ci_uses_non_null_sample_size_and_t_distribution() -> None:
+    from cnsplots.plots._categorical import _compute_lollipop_error
+
+    values = pd.Series([1.0, 2.0, 3.0, np.nan])
+    expected_sem = values.dropna().std() / np.sqrt(3)
+
+    assert _compute_lollipop_error(values, "se") == pytest.approx(expected_sem)
+    assert _compute_lollipop_error(values, "ci") == pytest.approx(
+        stats.t.ppf(0.975, 2) * expected_sem
+    )
+
+
+def test_lollipop_median_errors_use_deterministic_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cnsplots.plots._categorical import _compute_lollipop_error
+
+    values = pd.Series([1.0, 2.0, 100.0, np.nan])
+    expected_error = _compute_lollipop_error(values, "ci", "median")
+    assert isinstance(expected_error, tuple)
+    assert _compute_lollipop_error(values, "ci", "median") == expected_error
+    median_se = _compute_lollipop_error(values, "se", "median")
+    assert isinstance(median_se, float)
+    assert median_se > 0
+
+    cns.figure(120, 120)
+    ax = plt.gca()
+    errorbar_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        ax,
+        "errorbar",
+        lambda *args, **kwargs: errorbar_calls.append(kwargs),
+    )
+    cns.lollipopplot(
+        pd.DataFrame({"category": ["A"] * 4, "value": values}),
+        x="category",
+        y="value",
+        estimator="median",
+        errorbar="ci",
+    )
+
+    actual_error = errorbar_calls[0]["yerr"]
+    assert isinstance(actual_error, np.ndarray)
+    assert actual_error.shape == (2, 1)
+    actual_values = cast(Any, actual_error).tolist()
+    assert [float(actual_values[0][0]), float(actual_values[1][0])] == pytest.approx(
+        expected_error
+    )
+
+
+def test_stackplot_fills_sparse_cells_before_testing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A", "A", "B"],
+            "outcome": ["Yes", "No", "Yes"],
+        }
+    )
+    calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        cns.utils,
+        "_p_value_helper",
+        lambda *args, **kwargs: calls.append(args),
+    )
+
+    cns.figure(120, 120)
+    cns.stackplot(data, x="group", y="outcome", pairs=[("A", "B")])
+
+    contingency = calls[0][5]
+    assert isinstance(contingency, pd.DataFrame)
+    assert not contingency.isna().any().any()
+    assert contingency.loc["B", "No"] == 0
+
+
+def test_stackplot_tests_sparse_table_with_zero_filled_cells() -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A", "A", "B", "B"],
+            "outcome": ["Yes", "No", "Yes", "Yes"],
+        }
+    )
+
+    cns.figure(120, 120)
+    ax = cns.stackplot(data, x="group", y="outcome", pairs=[("A", "B")])
+
+    assert ax.texts
+
+
+def test_stackplot_rejects_degenerate_contingency_margins() -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A", "B", "C"],
+            "outcome": ["Yes", "Yes", "No"],
+        }
+    )
+
+    cns.figure(120, 120)
+    with pytest.raises(ValueError, match="nonzero row and column margins"):
+        cns.stackplot(data, x="group", y="outcome", pairs=[("A", "B")])
+
+
+def test_stackplot_requires_distinct_comparison_levels() -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A", "A", "B", "B"],
+            "outcome": ["Yes", "No", "Yes", "No"],
+        }
+    )
+
+    cns.figure(120, 120)
+    with pytest.raises(ValueError, match="exactly two distinct levels"):
+        cns.stackplot(data, x="group", y="outcome", pairs=[("A", "A")])
+
+
+@pytest.mark.parametrize(
+    ("contingency", "message"),
+    [
+        (
+            pd.DataFrame(
+                [[1, 1]], index=pd.Index(["A"]), columns=pd.Index(["Yes", "No"])
+            ),
+            "levels absent from the data",
+        ),
+        (
+            pd.DataFrame(
+                [[1], [1]], index=pd.Index(["A", "B"]), columns=pd.Index(["Yes"])
+            ),
+            "at least two rows and two columns",
+        ),
+        (
+            pd.DataFrame(
+                [[1, np.inf], [1, 1]],
+                index=pd.Index(["A", "B"]),
+                columns=pd.Index(["Yes", "No"]),
+            ),
+            "finite, nonnegative counts",
+        ),
+    ],
+)
+def test_contingency_testing_validates_tables(
+    contingency: pd.DataFrame,
+    message: str,
+) -> None:
+    data = pd.DataFrame({"group": ["A", "B"], "value": [1, 1]})
+
+    cns.figure(120, 120)
+    with pytest.raises(ValueError, match=message):
+        cns.utils._p_value_helper(
+            "fisher-exact",
+            data,
+            plt.gca(),
+            {"x": "group", "y": "value"},
+            [("A", "B")],
+            contingency,
         )
 
 

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -121,13 +121,21 @@ def test_slopeplot_keeps_requested_figure_size() -> None:
                 2.8,
             ],
             "label": ["healthy", "disease"] * 15,
+            "pair": np.repeat(
+                [
+                    f"{site}_{replicate}"
+                    for replicate in range(5)
+                    for site in ("site1", "site2", "site3")
+                ],
+                2,
+            ),
         }
     )
 
     cns.figure(150, 150)
     fig = plt.gcf()
     initial_size = tuple(fig.get_size_inches())
-    ax = cns.slopeplot(slope_df, x="site", y="value", hue="label")
+    ax = cns.slopeplot(slope_df, x="site", y="value", hue="label", pair="pair")
     ax.set_title("Basic Slope Plot", pad=15)
 
     fig.canvas.draw()
@@ -146,7 +154,7 @@ def test_survival_plots(
         ax = cns.survivalplot(
             survival_df, "time", "event", "group", hue_order=["Treatment", "Control"]
         )
-    assert ax.get_ylabel() == "Overall survival probability"
+    assert ax.get_ylabel() == "Survival probability"
     survival_lines = {
         line.get_label(): line
         for line in ax.lines
@@ -174,7 +182,7 @@ def test_survival_plots(
     caplog.clear()
     with caplog.at_level(logging.INFO, logger="cnsplots"):
         ax2 = cns.survivalplot(survival_three_group_df, "time", "event", "group")
-    assert ax2.get_xlabel() == "Time (Years)"
+    assert ax2.get_xlabel() == "Time"
     assert "trend" in caplog.text
 
     cns.figure(120, 120)

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -390,7 +390,7 @@ def test_line_scatter_reg_and_slope_plots(
 ) -> None:
     cns.figure(120, 120)
     ax = cns.regplot(numeric_df, x="x", y="y")
-    assert "\\rho" in ax.texts[0].get_text()
+    assert "$r$" in ax.texts[0].get_text()
 
     cns.figure(120, 120)
     ax2 = cns.regplot(numeric_df, x="x", y="y", hue="group", s=5)
@@ -416,7 +416,7 @@ def test_line_scatter_reg_and_slope_plots(
         }
     )
     cns.figure(120, 120)
-    ax6 = cns.slopeplot(slope_df, x="site", y="value", hue="label")
+    ax6 = cns.slopeplot(slope_df, x="site", y="value", hue="label", pair="site")
     assert ax6.get_legend() is not None
 
 

--- a/tests/test_regression_plot_defects.py
+++ b/tests/test_regression_plot_defects.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import PathCollection
+
+import cnsplots as cns
+
+
+def test_regplot_uses_only_finite_plotted_pairs_for_pearson() -> None:
+    data = pd.DataFrame(
+        {
+            "x": [0.0, 1.0, 2.0, np.nan, np.inf],
+            "y": [0.0, 2.0, 1.0, 100.0, -100.0],
+        }
+    )
+
+    cns.figure(120, 120)
+    ax = cns.regplot(data, x="x", y="y")
+
+    assert ax.texts[0].get_text().startswith(r"$r$=0.50,")
+    assert r"\rho" not in ax.texts[0].get_text()
+    scatter = next(
+        collection
+        for collection in ax.collections
+        if isinstance(collection, PathCollection)
+    )
+    np.testing.assert_allclose(
+        np.asarray(scatter.get_offsets(), dtype=float),
+        data.loc[:2, ["x", "y"]].to_numpy(),
+    )
+
+
+@pytest.mark.parametrize("hue", [None, "group"])
+def test_regplot_requires_two_finite_pairs_before_drawing(hue: str | None) -> None:
+    data = pd.DataFrame(
+        {
+            "x": [0.0, np.nan, 1.0],
+            "y": [0.0, 1.0, np.inf],
+            "group": ["A", "A", "A"],
+        }
+    )
+
+    cns.figure(120, 120)
+    with pytest.raises(ValueError, match="at least 2 finite paired observations"):
+        cns.regplot(data, x="x", y="y", hue=hue)
+    assert not plt.gca().collections
+    assert not plt.gca().lines
+
+
+def test_slopeplot_aligns_values_by_pair_key() -> None:
+    data = pd.DataFrame(
+        {
+            "site": ["A"] * 4,
+            "subject": ["one", "two", "two", "one"],
+            "condition": ["before", "before", "after", "after"],
+            "value": [1.0, 10.0, 20.0, 2.0],
+        }
+    )
+
+    cns.figure(120, 120)
+    ax = cns.slopeplot(
+        data,
+        x="site",
+        y="value",
+        hue="condition",
+        pair="subject",
+    )
+
+    paired_values = sorted(tuple(line.get_ydata()) for line in ax.lines)
+    assert paired_values == [(1.0, 2.0), (10.0, 20.0)]
+
+
+@pytest.mark.parametrize(
+    "conditions",
+    [
+        ["before", "before"],
+        ["before", "after", "follow-up"],
+    ],
+)
+def test_slopeplot_requires_exactly_two_hue_levels(conditions: list[str]) -> None:
+    data = pd.DataFrame(
+        {
+            "site": ["A"] * len(conditions),
+            "subject": list(range(len(conditions))),
+            "condition": conditions,
+            "value": np.arange(len(conditions), dtype=float),
+        }
+    )
+
+    with pytest.raises(ValueError, match="exactly 2 unique values"):
+        cns.slopeplot(
+            data,
+            x="site",
+            y="value",
+            hue="condition",
+            pair="subject",
+        )
+
+
+@pytest.mark.parametrize("invalid_kind", ["duplicate", "missing"])
+def test_slopeplot_requires_one_value_per_pair_and_condition(
+    invalid_kind: str,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "site": ["A"] * 4,
+            "subject": ["one", "one", "two", "two"],
+            "condition": ["before", "after"] * 2,
+            "value": [1.0, 2.0, 10.0, 20.0],
+        }
+    )
+    if invalid_kind == "duplicate":
+        data = pd.concat([data, data.iloc[[0]]], ignore_index=True)
+    else:
+        data = data.drop(index=0)
+
+    with pytest.raises(ValueError, match="exactly one .* value for each"):
+        cns.slopeplot(
+            data,
+            x="site",
+            y="value",
+            hue="condition",
+            pair="subject",
+        )
+
+
+def test_slopeplot_requires_each_pair_to_belong_to_one_x_group() -> None:
+    data = pd.DataFrame(
+        {
+            "site": ["A", "A", "B", "B"],
+            "subject": ["one"] * 4,
+            "condition": ["before", "after"] * 2,
+            "value": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="belong to exactly one"):
+        cns.slopeplot(
+            data,
+            x="site",
+            y="value",
+            hue="condition",
+            pair="subject",
+        )

--- a/tests/test_survival_hardening.py
+++ b/tests/test_survival_hardening.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+def test_survivalplot_requires_zero_one_event_semantics(
+    survival_df: pd.DataFrame,
+) -> None:
+    invalid = survival_df.copy()
+    invalid["event"] += 1
+
+    with pytest.raises(ValueError, match="specifically 0 and 1"):
+        cns.survivalplot(invalid, "time", "event", "group")
+
+
+@pytest.mark.parametrize(
+    ("invalid_duration", "message"),
+    [(np.inf, "finite durations"), (-1.0, "non-negative durations")],
+)
+def test_survivalplot_requires_valid_durations(
+    survival_df: pd.DataFrame,
+    invalid_duration: float,
+    message: str,
+) -> None:
+    invalid = survival_df.copy()
+    invalid.loc[0, "time"] = invalid_duration
+
+    with pytest.raises(ValueError, match=message):
+        cns.survivalplot(invalid, "time", "event", "group")
+
+
+@pytest.mark.parametrize("duration_kind", ["complex", "boolean"])
+def test_survivalplot_requires_real_numeric_durations(
+    survival_df: pd.DataFrame,
+    duration_kind: str,
+) -> None:
+    invalid = survival_df.copy()
+    if duration_kind == "complex":
+        invalid["time"] = invalid["time"].astype(complex) + 1j
+    else:
+        invalid["time"] = invalid["time"] > invalid["time"].median()
+
+    with pytest.raises(ValueError, match="real-valued numeric durations"):
+        cns.survivalplot(invalid, "time", "event", "group")
+
+
+@pytest.mark.parametrize("invalid_code", [-1.0, 1.5, np.inf])
+def test_cumulativeincidenceplot_requires_valid_event_codes(
+    competing_risk_df: pd.DataFrame,
+    invalid_code: float,
+) -> None:
+    invalid = competing_risk_df.copy()
+    invalid.loc[0, "event"] = invalid_code
+
+    with pytest.raises(ValueError, match="non-negative integer event codes"):
+        cns.cumulativeincidenceplot(invalid, "time", "event", "group")
+
+
+def test_cumulativeincidenceplot_rejects_complex_event_codes(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    invalid = competing_risk_df.copy()
+    invalid["event"] = invalid["event"].astype(complex) + 1j
+
+    with pytest.raises(ValueError, match="non-negative integer event codes"):
+        cns.cumulativeincidenceplot(invalid, "time", "event", "group")
+
+
+def test_cumulativeincidenceplot_requires_numeric_event_codes(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    invalid = competing_risk_df.assign(event=lambda frame: frame["event"].astype(str))
+
+    with pytest.raises(ValueError, match="must be numeric"):
+        cns.cumulativeincidenceplot(invalid, "time", "event", "group")
+
+
+def test_survivalplot_requires_two_groups(survival_df: pd.DataFrame) -> None:
+    invalid = survival_df.assign(group="only")
+
+    with pytest.raises(ValueError, match="at least 2 groups"):
+        cns.survivalplot(invalid, "time", "event", "group")
+
+
+def test_survivalplot_requires_two_observations_per_group(
+    survival_df: pd.DataFrame,
+) -> None:
+    invalid = pd.concat(
+        [
+            survival_df[survival_df["group"] == "Control"],
+            survival_df[survival_df["group"] == "Treatment"].iloc[[0]],
+        ],
+        ignore_index=True,
+    )
+
+    with pytest.raises(ValueError, match="at least 2 observations"):
+        cns.survivalplot(invalid, "time", "event", "group")
+
+
+def test_survivalplot_requires_an_event_per_group(
+    survival_df: pd.DataFrame,
+) -> None:
+    invalid = survival_df.copy()
+    invalid.loc[invalid["group"] == "Treatment", "event"] = 0
+
+    with pytest.raises(ValueError, match="at least one event of interest"):
+        cns.survivalplot(invalid, "time", "event", "group")
+
+
+def test_survival_time_labels_are_explicit_and_endpoint_neutral(
+    survival_df: pd.DataFrame,
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    ax = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        time_label="Follow-up (months)",
+    )
+    assert ax.get_xlabel() == "Follow-up (months)"
+    assert ax.get_ylabel() == "Survival probability"
+
+    plt.figure()
+    cif_ax = cns.cumulativeincidenceplot(
+        competing_risk_df,
+        "time",
+        "event",
+        "group",
+        time_label="Follow-up (years)",
+    )
+    assert cif_ax.get_xlabel() == "Follow-up (years)"
+
+
+def test_cumulativeincidenceplot_accepts_multiple_competing_event_codes(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    data = competing_risk_df.copy()
+    data.loc[data["event"] == 2, "event"] = 3
+
+    ax = cns.cumulativeincidenceplot(data, "time", "event", "group")
+
+    assert ax.get_xlabel() == "Time"
+
+
+def test_cumulativeincidenceplot_ties_are_deterministic_without_rng_side_effects() -> (
+    None
+):
+    tied = pd.DataFrame(
+        {
+            "time": [1, 1, 2, 3, 1, 1, 2, 3],
+            "event": [1, 2, 0, 1, 1, 2, 0, 1],
+            "group": ["A"] * 4 + ["B"] * 4,
+        }
+    )
+
+    np.random.seed(123)
+    expected_random_values = np.random.random(5)
+    np.random.seed(123)
+    with pytest.warns(Warning, match="Tied event times"):
+        first_ax = cns.cumulativeincidenceplot(tied, "time", "event", "group", seed=17)
+    actual_random_values = np.random.random(5)
+    first_coordinates = [
+        (line.get_xdata().copy(), line.get_ydata().copy()) for line in first_ax.lines
+    ]
+
+    plt.figure()
+    with pytest.warns(Warning, match="Tied event times"):
+        second_ax = cns.cumulativeincidenceplot(tied, "time", "event", "group", seed=17)
+
+    np.testing.assert_array_equal(actual_random_values, expected_random_values)
+    assert len(first_coordinates) == len(second_ax.lines)
+    for (first_x, first_y), second_line in zip(
+        first_coordinates, second_ax.lines, strict=True
+    ):
+        np.testing.assert_array_equal(first_x, second_line.get_xdata())
+        np.testing.assert_array_equal(first_y, second_line.get_ydata())


### PR DESCRIPTION
## What changed

- Enforce valid survival events, durations, competing-risk codes, group event counts, neutral time labels, and deterministic Aalen-Johansen tie handling without global RNG side effects.
- Report LogisticModel AUC from all out-of-fold predictions, align Patsy-retained rows, and validate both nested five-fold CV layers.
- Require an explicit `pair` key in `slopeplot`, align observations by subject, and compute Pearson `r` from the exact finite plotted pairs.
- Zero-fill sparse contingency tables, reject degenerate comparisons, validate lollipop options, and use t or deterministic bootstrap intervals with non-null sample sizes.

## Testing

- `make test` — 252 passed with 100% coverage.
- `make lint` — all hooks passed.

## Risks and follow-ups

- Breaking API change: `slopeplot` callers must now provide the `pair` column name.
- Plot labels default to neutral `Time` and `Survival probability`; callers can pass `time_label` for endpoint-specific units.
- No dependency, CI, or configuration changes.