### PR TITLE
🐛 Prevent confusion order data loss

### DIFF
--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -36,6 +36,7 @@ from cnsplots._validation import (
     validate_columns_exist,
     validate_dataframe,
     validate_dataframe_not_empty,
+    validate_no_nulls,
 )
 
 
@@ -517,6 +518,31 @@ def dotplot(
     return cmp
 
 
+def _resolve_confusion_order(
+    values: pd.Series,
+    order: list[str] | None,
+    order_name: str,
+) -> list[Any]:
+    observed = list(pd.unique(values))
+    if order is None:
+        return observed
+
+    resolved = list(order)
+    observed_index = pd.Index(observed)
+    order_index = pd.Index(resolved)
+    missing = observed_index[~observed_index.isin(order_index)].tolist()
+    extra = order_index[~order_index.isin(observed_index)].tolist()
+    duplicates = order_index[order_index.duplicated()].unique().tolist()
+    if missing or extra or duplicates:
+        raise ValueError(
+            f"[confusionplot] {order_name} must contain each observed label exactly "
+            f"once and no other labels. Missing labels: {missing}; Extra labels: "
+            f"{extra}; Duplicate labels: {duplicates}."
+        )
+
+    return resolved
+
+
 def confusionplot(
     data: pd.DataFrame,
     x: str,
@@ -550,9 +576,11 @@ def confusionplot(
         Whether to compute and display classification metrics. Only applicable
         for 2x2 confusion matrices.
     x_order : list, optional
-        Explicit ordering of prediction labels (columns).
+        Display ordering of prediction labels (columns). Must contain each
+        observed label exactly once; it does not filter observations.
     y_order : list, optional
-        Explicit ordering of true labels (rows).
+        Display ordering of true labels (rows). Must contain each observed
+        label exactly once; it does not filter observations.
     positive_x : hashable, optional
         The label to treat as 'positive' class in predictions.
     positive_y : hashable, optional
@@ -602,16 +630,21 @@ def confusionplot(
     validate_dataframe(data, "data", "confusionplot")
     validate_columns_exist(data, [x, y], "confusionplot")
     validate_dataframe_not_empty(data, "confusionplot")
+    validate_no_nulls(data, [x, y], "confusionplot")
 
-    if y_order is None:
-        y_order = pd.unique(data[y])
-    if x_order is None:
-        x_order = pd.unique(data[x])
+    x_order = _resolve_confusion_order(data[x], x_order, "x_order")
+    y_order = _resolve_confusion_order(data[y], y_order, "y_order")
 
     y_cat = pd.Categorical(data[y], categories=y_order, ordered=True)
     x_cat = pd.Categorical(data[x], categories=x_order, ordered=True)
 
     cm_df = pd.crosstab(y_cat, x_cat, dropna=False)
+    counted_rows = cm_df.to_numpy().sum()
+    if pd.isna(counted_rows) or counted_rows != len(data):
+        raise RuntimeError(
+            "[confusionplot] Confusion matrix count mismatch: "
+            f"expected {len(data)} input rows, counted {counted_rows}."
+        )
 
     # Plot
     ax = plt.gca()
@@ -635,11 +668,6 @@ def confusionplot(
         for i in range(cm_df.shape[0]):
             for j in range(cm_df.shape[1]):
                 cell_value = cm_df.iat[i, j]
-                if pd.isna(cell_value):
-                    raise ValueError(
-                        f"[confusionplot] Confusion matrix contains NaN at position [{i},{j}]. "
-                        "All values must be valid numbers."
-                    )
                 r, g, b, _ = im.cmap(im.norm(cell_value))
                 ax.text(
                     j,
@@ -664,22 +692,10 @@ def confusionplot(
 
         # Decide which labels are positive/negative on each axis
         pos_y = y_order[-1] if positive_y is None else positive_y
-        neg_y_list = [lbl for lbl in y_order if lbl != pos_y]
-        if not neg_y_list:
-            raise ValueError(
-                f"[confusionplot] Could not find negative label in y_order. "
-                f"positive_y='{pos_y}', y_order={list(y_order)}"
-            )
-        neg_y = neg_y_list[0]
+        neg_y = next(lbl for lbl in y_order if lbl != pos_y)
 
         pos_x = x_order[-1] if positive_x is None else positive_x
-        neg_x_list = [lbl for lbl in x_order if lbl != pos_x]
-        if not neg_x_list:
-            raise ValueError(
-                f"[confusionplot] Could not find negative label in x_order. "
-                f"positive_x='{pos_x}', x_order={list(x_order)}"
-            )
-        neg_x = neg_x_list[0]
+        neg_x = next(lbl for lbl in x_order if lbl != pos_x)
 
         # Extract counts in tn/fp/fn/tp layout
         try:
@@ -692,19 +708,6 @@ def confusionplot(
                 "[confusionplot] Could not find a required cell for stats. "
                 f"Check x_order/y_order and positive_x/positive_y. Missing: {e}"
             ) from e
-
-        # Validate no NaN values
-        for name, val in [
-            ("TN", tn_val),
-            ("FP", fp_val),
-            ("FN", fn_val),
-            ("TP", tp_val),
-        ]:
-            if pd.isna(val):
-                raise ValueError(
-                    f"[confusionplot] {name} cell contains NaN. All confusion matrix cells "
-                    "must have valid numeric values for statistics computation."
-                )
 
         tn = int(tn_val)
         fp = int(fp_val)

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -1034,7 +1034,7 @@ def test_plot_internal_coverage(
             columns=pd.Index(["neg", "pos"]),
         ),
     )
-    with pytest.raises(ValueError, match="TN cell contains NaN"):
+    with pytest.raises(RuntimeError, match="count mismatch"):
         cns.confusionplot(
             confusion_df,
             x="pred",
@@ -1168,51 +1168,6 @@ def test_remaining_visual_internal_coverage(
         cmap="parula",
     )
     assert cmp.ax_heatmap is not None
-
-    monkeypatch.setattr(
-        heatmap_mod.pd,
-        "crosstab",
-        lambda *args, **kwargs: pd.DataFrame(
-            [[np.nan, 1], [1, 1]],
-            index=pd.Index(["neg", "pos"]),
-            columns=pd.Index(["neg", "pos"]),
-        ),
-    )
-    with pytest.raises(ValueError, match="contains NaN at position \\[0,0\\]"):
-        cns.confusionplot(
-            confusion_df,
-            x="pred",
-            y="truth",
-            x_order=["neg", "pos"],
-            y_order=["neg", "pos"],
-            annot=True,
-        )
-
-    monkeypatch.setattr(
-        heatmap_mod.pd,
-        "Categorical",
-        lambda values, categories, ordered: values,
-    )
-    monkeypatch.setattr(
-        heatmap_mod.pd,
-        "crosstab",
-        lambda *args, **kwargs: pd.DataFrame(
-            [[1, 0], [0, 1]],
-            index=pd.Index(["neg", "pos"]),
-            columns=pd.Index(["pos1", "pos2"]),
-        ),
-    )
-    with pytest.raises(ValueError, match="Could not find negative label in x_order"):
-        cns.confusionplot(
-            confusion_df,
-            x="pred",
-            y="truth",
-            x_order=["pos", "pos"],
-            y_order=["neg", "pos"],
-            positive_x="pos",
-            add_pvalue=True,
-            annot=False,
-        )
 
     class MarkerHandle:
         def __init__(self) -> None:

--- a/tests/test_plot_behavior_regressions.py
+++ b/tests/test_plot_behavior_regressions.py
@@ -14,6 +14,62 @@ from scipy import stats
 import cnsplots as cns
 
 
+@pytest.mark.parametrize(
+    ("order_name", "order", "expected_detail"),
+    [
+        ("x_order", ["a", "b"], "Missing labels: ['c']"),
+        ("x_order", ["a", "b", "c", "extra"], "Extra labels: ['extra']"),
+        ("y_order", ["a", "b"], "Missing labels: ['c']"),
+        ("y_order", ["a", "b", "c", "extra"], "Extra labels: ['extra']"),
+        ("x_order", ["a", "b", "c", "c"], "Duplicate labels: ['c']"),
+    ],
+)
+def test_confusionplot_rejects_non_exact_orders(
+    order_name: str,
+    order: list[str],
+    expected_detail: str,
+) -> None:
+    data = pd.DataFrame({"pred": ["a", "b", "c"], "truth": ["a", "b", "c"]})
+
+    with pytest.raises(ValueError, match=order_name) as exc_info:
+        cns.confusionplot(data, x="pred", y="truth", **{order_name: order})
+
+    assert expected_detail in str(exc_info.value)
+
+
+def test_confusionplot_ordering_preserves_all_rows() -> None:
+    data = pd.DataFrame({"pred": ["a", "b", "c"], "truth": ["a", "b", "c"]})
+
+    cns.figure(120, 120)
+    ax = cns.confusionplot(
+        data,
+        x="pred",
+        y="truth",
+        x_order=["c", "b", "a"],
+        y_order=["c", "b", "a"],
+    )
+
+    matrix = np.asarray(ax.images[0].get_array())
+    assert int(matrix.sum()) == len(data)
+    np.testing.assert_array_equal(matrix, np.eye(3, dtype=int))
+    assert [tick.get_text() for tick in ax.get_xticklabels()] == ["c", "b", "a"]
+    assert [tick.get_text() for tick in ax.get_yticklabels()] == ["c", "b", "a"]
+
+
+def test_confusionplot_checks_count_conservation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame({"pred": ["a", "a", "b"], "truth": ["a", "b", "b"]})
+    monkeypatch.setattr(
+        pd,
+        "crosstab",
+        lambda *args, **kwargs: pd.DataFrame([[1, 0], [0, 1]]),
+    )
+
+    with pytest.raises(RuntimeError, match="expected 3 input rows, counted 2"):
+        cns.confusionplot(data, x="pred", y="truth", annot=False)
+
+
 @pytest.mark.parametrize("horizontal", [False, True])
 @pytest.mark.parametrize("with_hue", [False, True])
 def test_lollipop_geometry_is_consistent_across_orientations_and_hue(

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -462,29 +462,7 @@ def test_confusionplot_metrics_and_errors(confusion_df: pd.DataFrame) -> None:
             add_pvalue=True,
         )
 
-    with pytest.raises(ValueError, match="Could not find negative label in y_order"):
-        cns.confusionplot(
-            confusion_df,
-            x="pred",
-            y="truth",
-            add_pvalue=True,
-            x_order=["neg", "pos"],
-            y_order=["pos"],
-            positive_y="pos",
-        )
-
-    with pytest.raises(ValueError, match="2x2 confusion matrix"):
-        cns.confusionplot(
-            confusion_df,
-            x="pred",
-            y="truth",
-            add_pvalue=True,
-            x_order=["pos"],
-            y_order=["neg", "pos"],
-            positive_x="pos",
-        )
-
-    with pytest.raises(ValueError, match="Categorical categories cannot be null"):
+    with pytest.raises(ValueError, match="Null values found"):
         cns.confusionplot(
             pd.DataFrame({"pred": ["neg", "pos"], "truth": ["neg", np.nan]}),
             x="pred",


### PR DESCRIPTION
## What changed
- require x_order and y_order to contain every observed label exactly once, rejecting missing, extra, duplicate, and null labels
- verify the generated confusion matrix counts every input row before plotting
- add regression coverage for rejected orders, valid reordering, and count conservation

## Testing
- make test — 272 passed with 100% coverage
- make lint — all checks passed

## Risks and follow-ups
- callers that previously used order arguments for implicit filtering or zero-count padding now receive a ValueError; this is the intended ordering-only contract
- no follow-up work identified