### PR TITLE
💥 Replace stackplot orientation flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ cns.boxplot(data=df, x="group", y="value", pairs="all")
 cns.barplot(data=df, x="group", y="value", pairs=[("A", "B")])
 
 # Stackplot with Fisher's exact test
-cns.stackplot(data=df, x="group", y="category", pairs=[("A", "B")])
+cns.stackplot(data=df, x="group", stack="category", pairs=[("A", "B")])
 ```
 
 ### Export for Publication

--- a/examples/showcase.py
+++ b/examples/showcase.py
@@ -124,7 +124,7 @@ ax.set_title("Stripplot")
 
 # Panel D: stackplot
 mp.panel("D", 100, 50, color_cycle=cns.get_hexcolors_from_apalette([2, 4], "Bold"))
-ax = cns.stackplot(data=tips_df, x="day", y="sex", pairs=[("Thur", "Sun")])
+ax = cns.stackplot(data=tips_df, x="day", stack="sex", pairs=[("Thur", "Sun")])
 ax.set_title("Stackplot")
 ax.get_legend().set_title(None)
 

--- a/examples/stackplot.py
+++ b/examples/stackplot.py
@@ -27,7 +27,7 @@ tips = cns.datasets.load_dataset("tips")
 # Use ``addcount=True`` to display total counts in the tick labels.
 cns.figure(120, 100)
 ax = cns.stackplot(
-    data=tips, x="sex", y="day", width=0.4, normalize=True, addcount=True
+    data=tips, x="sex", stack="day", width=0.4, normalize=True, addcount=True
 )
 ax.set_title("Basic Stacked Plot")
 
@@ -38,7 +38,11 @@ ax.set_title("Basic Stacked Plot")
 # Set ``normalize=False`` to show actual counts instead of proportions.
 cns.figure(120, 100)
 ax = cns.stackplot(
-    data=tips, x="day", y="sex", stack_order=["Female", "Male"], normalize=False
+    data=tips,
+    x="day",
+    stack="sex",
+    stack_order=["Female", "Male"],
+    normalize=False,
 )
 ax.set_title("Stacked Bar with Counts")
 
@@ -52,7 +56,7 @@ cns.figure(120, 100)
 ax = cns.stackplot(
     data=tips,
     x="day",
-    y="sex",
+    stack="sex",
     normalize=True,
     pairs=[("Thur", "Fri"), ("Fri", "Sat")],
 )
@@ -67,7 +71,7 @@ cns.figure(120, 100)
 ax = cns.stackplot(
     data=tips,
     x="sex",
-    y="day",
+    stack="day",
     normalize=True,
     stack_order=["Sun", "Sat", "Fri", "Thur"],
     pairs=[("Male", "Female")],
@@ -80,20 +84,19 @@ ax.set_title("Custom Stack Order")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``pairs="all"`` to test all possible pairs.
 cns.figure(150, 100, "Tableau")
-ax = cns.stackplot(data=tips, x="day", y="sex", normalize=True, pairs="all")
+ax = cns.stackplot(data=tips, x="day", stack="sex", normalize=True, pairs="all")
 ax.set_title("All Pairwise Comparisons")
 
 
 # %%
 # Horizontal stacked bar plot
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Set ``horizontal=True`` for horizontal orientation.
+# Pass the bar variable to ``y`` for horizontal orientation.
 cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips,
-    x="sex",
     y="day",
-    horizontal=True,
+    stack="sex",
     normalize=True,
     pairs=[("Thur", "Fri"), ("Fri", "Sat")],
     bar_order=["Fri", "Sat", "Sun", "Thur"],
@@ -109,7 +112,7 @@ cns.figure(120, 100)
 ax = cns.stackplot(
     data=tips,
     x="day",
-    y="sex",
+    stack="sex",
     normalize=True,
     bar_order=["Sun", "Sat", "Fri", "Thur"],
 )
@@ -123,11 +126,11 @@ ax.set_title("Custom Bar Order")
 mp = cns.multipanel(max_width=250)
 
 mp.panel("A", 80, 100)
-cns.stackplot(data=tips, x="day", y="sex", normalize=True, width=0.3)
+cns.stackplot(data=tips, x="day", stack="sex", normalize=True, width=0.3)
 mp.get_axes("A").set_title("width=0.3 (narrow)")
 
 mp.panel("B", 80, 100, margin_right=0)
-cns.stackplot(data=tips, x="day", y="sex", normalize=True, width=0.8)
+cns.stackplot(data=tips, x="day", stack="sex", normalize=True, width=0.8)
 mp.get_axes("B").set_title("width=0.8 (wide)")
 
 
@@ -136,7 +139,7 @@ mp.get_axes("B").set_title("width=0.8 (wide)")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use different color palettes for visual variety.
 cns.figure(120, 100, "Set2")
-ax = cns.stackplot(data=tips, x="day", y="sex", normalize=True)
+ax = cns.stackplot(data=tips, x="day", stack="sex", normalize=True)
 ax.set_title("Set2 Palette")
 
 
@@ -147,20 +150,20 @@ ax.set_title("Set2 Palette")
 mp = cns.multipanel(max_width=250)
 
 mp.panel("A", 80, 100, color_cycle="Bold")
-cns.stackplot(data=tips, x="day", y="sex", normalize=True)
+cns.stackplot(data=tips, x="day", stack="sex", normalize=True)
 mp.get_axes("A").set_title("Bold")
 
 mp.panel("B", 80, 100, color_cycle="BlueRed", margin_right=0)
-cns.stackplot(data=tips, x="day", y="sex", normalize=True)
+cns.stackplot(data=tips, x="day", stack="sex", normalize=True)
 mp.get_axes("B").set_title("BlueRed")
 
 
 # %%
 # Stacked bar plot with more than two categories
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Stack plots work with multiple categories in the y variable.
+# Stack plots work with multiple categories in the stack variable.
 cns.figure(150, 100, "Ecotyper1")
-ax = cns.stackplot(data=tips, x="sex", y="time", normalize=True, addcount=True)
+ax = cns.stackplot(data=tips, x="sex", stack="time", normalize=True, addcount=True)
 ax.set_title("Multiple Stack Categories")
 
 
@@ -187,7 +190,7 @@ cns.figure(180, 120, "Ecotyper2")
 ax = cns.stackplot(
     data=cell_data,
     x="sample",
-    y="cell_type",
+    stack="cell_type",
     normalize=True,
     pairs=[("Control", "Treatment A"), ("Control", "Treatment B")],
     stack_order=["CD4+ T", "CD8+ T", "B cell", "NK cell", "Monocyte"],
@@ -206,9 +209,8 @@ ax.set_ylabel("Proportion")
 cns.figure(120, 100, "Pastel1")
 ax = cns.stackplot(
     data=tips,
-    x="day",
-    y="sex",
-    horizontal=True,
+    y="day",
+    stack="sex",
     normalize=True,
     addcount=True,
     width=0.6,
@@ -223,13 +225,13 @@ ax.set_title("Horizontal with Labels")
 mp = cns.multipanel(max_width=160)
 
 mp.panel("A", 80, 130)
-cns.stackplot(data=tips, x="day", y="sex", normalize=False)
+cns.stackplot(data=tips, x="day", stack="sex", normalize=False)
 mp.get_axes("A").set_title("Absolute Counts")
 mp.get_axes("A").set_ylabel("Count")
 
 mp.newline()
 
 mp.panel("B", 80, 130, margin_top=10)
-cns.stackplot(data=tips, x="day", y="sex", normalize=True, addcount=True)
+cns.stackplot(data=tips, x="day", stack="sex", normalize=True, addcount=True)
 mp.get_axes("B").set_title("Normalized Proportions")
 mp.get_axes("B").set_ylabel("Proportion")

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -572,11 +572,12 @@ def lollipopplot(
 
 def stackplot(
     data: pd.DataFrame,
-    x: str,
-    y: str,
+    x: str | None = None,
+    y: str | None = None,
+    *,
+    stack: str,
     bar_order: list[str] | None = None,
     stack_order: list[str] | None = None,
-    horizontal: bool = False,
     width: float = 0.5,
     normalize: bool = True,
     pairs: list[tuple[str, str]] | None = None,
@@ -586,31 +587,36 @@ def stackplot(
     """
     Create a stacked bar plot showing categorical distributions.
 
-    This function creates a stacked bar plot (or horizontal stacked bar plot)
-    displaying the distribution or count of one categorical variable across
-    levels of another categorical variable.
+    This function creates a vertical or horizontal stacked bar plot displaying
+    the distribution or count of one categorical variable across levels of
+    another categorical variable. Provide exactly one of ``x`` or ``y`` to
+    select the bar axis, and use ``stack`` for the stack segments.
 
     Parameters
     ----------
     data : pd.DataFrame
         The input DataFrame containing the data to be plotted.
-    x : str
-        Column name for the categorical variable determining bar positions.
-    y : str
+    x : str, optional
+        Column name for the categorical variable determining bar positions on
+        the x-axis. Produces vertical bars. Exactly one of ``x`` or ``y`` must
+        be provided.
+    y : str, optional
+        Column name for the categorical variable determining bar positions on
+        the y-axis. Produces horizontal bars. Exactly one of ``x`` or ``y`` must
+        be provided.
+    stack : str
         Column name for the categorical variable determining stack segments.
     bar_order : list, optional
-        Order of categories from x to display.
+        Order of categories from the selected bar variable to display.
     stack_order : list, optional
-        Order of categories from y for stacking.
-    horizontal : bool, default: False
-        Whether to create horizontal bars instead of vertical bars.
+        Order of categories from ``stack`` for stacking.
     width : float, default: 0.5
         Width of the bars.
     normalize : bool, default: True
         Whether to normalize counts to frequencies (proportions summing to 1).
     pairs : list of tuple of str, optional
         List of pairs of bar-category names for pairwise statistical comparisons
-        (levels of ``x`` vertically and levels of ``y`` horizontally).
+        from the selected bar variable.
     addcount : bool, default: False
         Whether to append total counts to the category tick labels in the
         format ``n=...``.
@@ -634,33 +640,32 @@ def stackplot(
     >>> ax = cns.stackplot(
     ...     data=df,
     ...     x="tissue",
-    ...     y="cell_type",
+    ...     stack="cell_type",
     ...     normalize=True,
     ...     pairs=[("lung", "liver")],
     ... )
     >>> ax.set_title("Cell Type Distribution by Tissue")
 
     >>> # Horizontal stacked bar plot
-    >>> ax = cns.stackplot(
-    ...     data=df, x="patient", y="mutation", horizontal=True, normalize=False
-    ... )
+    >>> ax = cns.stackplot(data=df, y="patient", stack="mutation", normalize=False)
     >>> ax.set_xlabel("Mutation Count")
     """
     # Validate inputs
     validate_dataframe(data, "data", "stackplot")
-    validate_columns_exist(data, [x, y], "stackplot")
+    if (x is None) == (y is None):
+        raise ValueError("stackplot requires exactly one of `x` or `y`.")
+    bar = x if x is not None else y
+    assert bar is not None
+    validate_columns_exist(data, [bar, stack], "stackplot")
     validate_dataframe_not_empty(data, "stackplot")
 
-    data2 = data.value_counts([x, y]).reset_index()
-    if horizontal:
-        df = data2.pivot(index=y, columns=x, values="count")
-    else:
-        df = data2.pivot(index=x, columns=y, values="count")
+    data2 = data.value_counts([bar, stack]).reset_index()
+    df = data2.pivot(index=bar, columns=stack, values="count")
     df = df.fillna(0)
     contingency = df.copy()
     if stack_order is not None:
         df.columns = pd.CategoricalIndex(
-            df.columns.values, ordered=True, categories=stack_order, name=y
+            df.columns.values, ordered=True, categories=stack_order, name=stack
         )
         df = df.sort_index(axis=1)
     if normalize:
@@ -671,7 +676,7 @@ def stackplot(
     df = df.reindex(index=bar_order)
     df = df / n_factor
     ax = plt.gca()
-    if horizontal:
+    if y is not None:
         ax = df.plot.barh(stacked=True, width=width, ax=ax, rot=0)
         ax.set_ylabel("")
         ax.set_xlabel(value_label)
@@ -681,14 +686,13 @@ def stackplot(
         ax.set_xlabel("")
     utils.take_legend_out()
     if addcount:
-        count_attr = y if horizontal else x
-        count_axis = "y" if horizontal else "x"
-        utils._addcount_helper(data, count_attr, ax, axis=count_axis)
+        count_axis = "y" if y is not None else "x"
+        utils._addcount_helper(data, bar, ax, axis=count_axis)
     if pairs is not None:
-        if horizontal:
-            plotting = {"data": data2, "x": "count", "y": y, "order": bar_order}
+        if y is not None:
+            plotting = {"data": data2, "x": "count", "y": bar, "order": bar_order}
         else:
-            plotting = {"data": data2, "x": x, "y": "count", "order": bar_order}
+            plotting = {"data": data2, "x": bar, "y": "count", "order": bar_order}
         if contingency.shape[1] == 2:
             utils._p_value_helper(
                 "fisher-exact", data2, ax, plotting, pairs, contingency

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -826,19 +826,17 @@ def test_plot_internal_coverage(
     cns.figure(120, 120)
     stack_ax = cns.stackplot(
         stack_df,
-        x="treatment",
-        y="response",
-        horizontal=True,
+        y="treatment",
+        stack="response",
         normalize=True,
         addcount=True,
-        bar_order=["Yes", "No"],
+        bar_order=["C", "B", "A"],
     )
-    assert [patch.get_width() for patch in stack_ax.patches] == pytest.approx(
-        [1 / 3] * 6
-    )
+    assert [patch.get_width() for patch in stack_ax.patches] == pytest.approx([0.5] * 6)
     assert [tick.get_text() for tick in stack_ax.get_yticklabels()] == [
-        "Yes\n(n=6)",
-        "No\n(n=6)",
+        "C\n(n=4)",
+        "B\n(n=4)",
+        "A\n(n=4)",
     ]
 
     class SizeHandle:

--- a/tests/test_plot_behavior_regressions.py
+++ b/tests/test_plot_behavior_regressions.py
@@ -256,7 +256,7 @@ def test_stackplot_fills_sparse_cells_before_testing(
     )
 
     cns.figure(120, 120)
-    cns.stackplot(data, x="group", y="outcome", pairs=[("A", "B")])
+    cns.stackplot(data, x="group", stack="outcome", pairs=[("A", "B")])
 
     contingency = calls[0][5]
     assert isinstance(contingency, pd.DataFrame)
@@ -264,7 +264,79 @@ def test_stackplot_fills_sparse_cells_before_testing(
     assert contingency.loc["B", "No"] == 0
 
 
-def test_stackplot_tests_sparse_table_with_zero_filled_cells() -> None:
+def test_stackplot_y_axis_preserves_bar_and_stack_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "patient": ["P1"] * 6 + ["P2"] * 4,
+            "mutation": [
+                "M1",
+                "M1",
+                "M1",
+                "M2",
+                "M3",
+                "M3",
+                "M1",
+                "M2",
+                "M2",
+                "M3",
+            ],
+        }
+    )
+    calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        cns.utils,
+        "_p_value_helper",
+        lambda *args, **kwargs: calls.append(args),
+    )
+
+    cns.figure(120, 120)
+    ax = cns.stackplot(
+        data,
+        y="patient",
+        stack="mutation",
+        addcount=True,
+        pairs=[("P2", "P1")],
+        bar_order=["P2", "P1"],
+        stack_order=["M3", "M2", "M1"],
+    )
+
+    assert [tick.get_text() for tick in ax.get_yticklabels()] == [
+        "P2\n(n=4)",
+        "P1\n(n=6)",
+    ]
+    assert [text.get_text() for text in ax.get_legend().get_texts()] == [
+        "M3",
+        "M2",
+        "M1",
+    ]
+    np.testing.assert_allclose(
+        [patch.get_width() for patch in ax.patches],
+        [1 / 4, 1 / 3, 1 / 2, 1 / 6, 1 / 4, 1 / 2],
+    )
+
+    assert calls[0][0] == "chi-squared"
+    plotting = calls[0][3]
+    assert plotting == {
+        "data": calls[0][1],
+        "x": "count",
+        "y": "patient",
+        "order": ["P2", "P1"],
+    }
+    assert calls[0][4] == [("P2", "P1")]
+    contingency = calls[0][5]
+    assert isinstance(contingency, pd.DataFrame)
+    assert contingency.index.name == "patient"
+    assert contingency.columns.name == "mutation"
+    assert contingency.loc["P2", "M2"] == 2
+    assert contingency.loc["P1", "M1"] == 3
+
+
+@pytest.mark.parametrize("bar_axis", ["x", "y"])
+def test_stackplot_tests_sparse_table_with_zero_filled_cells(
+    bar_axis: str,
+) -> None:
     data = pd.DataFrame(
         {
             "group": ["A", "A", "B", "B"],
@@ -273,7 +345,7 @@ def test_stackplot_tests_sparse_table_with_zero_filled_cells() -> None:
     )
 
     cns.figure(120, 120)
-    ax = cns.stackplot(data, x="group", y="outcome", pairs=[("A", "B")])
+    ax = cns.stackplot(data, stack="outcome", pairs=[("A", "B")], **{bar_axis: "group"})
 
     assert ax.texts
 
@@ -288,7 +360,7 @@ def test_stackplot_rejects_degenerate_contingency_margins() -> None:
 
     cns.figure(120, 120)
     with pytest.raises(ValueError, match="nonzero row and column margins"):
-        cns.stackplot(data, x="group", y="outcome", pairs=[("A", "B")])
+        cns.stackplot(data, x="group", stack="outcome", pairs=[("A", "B")])
 
 
 def test_stackplot_requires_distinct_comparison_levels() -> None:
@@ -301,7 +373,23 @@ def test_stackplot_requires_distinct_comparison_levels() -> None:
 
     cns.figure(120, 120)
     with pytest.raises(ValueError, match="exactly two distinct levels"):
-        cns.stackplot(data, x="group", y="outcome", pairs=[("A", "A")])
+        cns.stackplot(data, x="group", stack="outcome", pairs=[("A", "A")])
+
+
+@pytest.mark.parametrize(
+    "axes",
+    [{}, {"x": "group", "y": "outcome"}],
+)
+def test_stackplot_requires_exactly_one_bar_axis(axes: dict[str, str]) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A", "B"],
+            "outcome": ["Yes", "No"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="exactly one of `x` or `y`"):
+        cns.stackplot(data, stack="outcome", **axes)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -192,7 +192,7 @@ def test_stack_strip_pie_and_donut_plots(
     ax = cns.stackplot(
         stack_df,
         x="treatment",
-        y="response",
+        stack="response",
         normalize=True,
         addcount=True,
         pairs=[("A", "B")],
@@ -211,12 +211,11 @@ def test_stack_strip_pie_and_donut_plots(
     cns.figure(120, 120)
     ax2 = cns.stackplot(
         categorical_df.rename(columns={"group": "treatment", "binary": "response"}),
-        x="treatment",
-        y="response",
-        horizontal=True,
+        y="treatment",
+        stack="response",
         normalize=False,
         pairs=[("A", "B")],
-        bar_order=["No", "Yes"],
+        bar_order=["A", "B", "C"],
         stack_order=["No", "Yes"],
     )
     assert ax2.get_xlabel() == "Count"
@@ -225,15 +224,15 @@ def test_stack_strip_pie_and_donut_plots(
     cns.figure(120, 120)
     ax2b = cns.stackplot(
         stack_df,
-        x="treatment",
-        y="response",
-        horizontal=True,
+        y="treatment",
+        stack="response",
         normalize=False,
         addcount=True,
     )
     assert {tick.get_text() for tick in ax2b.get_yticklabels()} == {
-        "No\n(n=6)",
-        "Yes\n(n=6)",
+        "A\n(n=4)",
+        "B\n(n=4)",
+        "C\n(n=4)",
     }
     assert not ax2b.texts
 

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -159,6 +159,11 @@ def test_public_namespace_contract() -> None:
 
 def test_public_stackplot_signature_contract() -> None:
     parameters = inspect.signature(cns.stackplot).parameters
+    assert parameters["x"].default is None
+    assert parameters["y"].default is None
+    assert parameters["stack"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["stack"].default is inspect.Parameter.empty
+    assert "horizontal" not in parameters
     assert "addcount" in parameters
     assert "addtip" not in parameters
 


### PR DESCRIPTION
## What changed

- Replace the `horizontal` flag with a required keyword-only `stack` variable.
- Require exactly one of `x` or `y`, using `x` for vertical bars and `y` for horizontal bars.
- Keep ordering, counts, normalization, and statistical pairs aligned with the selected bar variable.
- Migrate tests, README usage, and gallery examples to the new API.

## Testing

- `make test` — 276 passed with 100% coverage.
- `make lint` — all checks passed.
- `env MPLBACKEND=Agg uv run python examples/stackplot.py` — completed successfully.

## Risks and follow-ups

- This is a breaking API change. Vertical callers must use `x=<bars>, stack=<segments>`; horizontal callers must use `y=<bars>, stack=<segments>`.
- No known follow-up work.