### PR TITLE
💥 Standardize figure and panel dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ import cnsplots as cns
 mp = cns.multipanel(max_width=540)
 
 # Panel A
-mp.panel("A", height=150, width=150)
+mp.panel("A", width=150, height=150)
 cns.boxplot(data=df1, x="group", y="value")
 
 # Panel B
-mp.panel("B", height=150, width=150)
+mp.panel("B", width=150, height=150)
 cns.scatterplot(data=df2, x="x", y="y")
 
 # Continues...
@@ -127,8 +127,8 @@ import cnsplots as cns
 # Load example data
 df = cns.datasets.load_dataset("tips")
 
-# Create a figure (height, width in pixels)
-cns.figure(height=150, width=100)
+# Create a figure (width, height in pixels)
+cns.figure(width=100, height=150)
 
 # Create a publication-ready boxplot
 cns.boxplot(data=df, x="day", y="total_bill")
@@ -155,7 +155,7 @@ cns.boxplot(
 
 ```python
 # Use custom color palette
-cns.figure(150, 200, color_cycle="Ecotyper1")
+cns.figure(200, 150, color_cycle="Ecotyper1")
 cns.violinplot(data=df, x="day", y="total_bill", hue="sex")
 ```
 
@@ -185,7 +185,7 @@ Full documentation is available at [cnsplots.farid.one](https://cnsplots.farid.o
 Specify sizes in **pixels** for precise control:
 
 ```python
-cns.figure(height=150, width=100)  # Final canvas size is 150px × 100px
+cns.figure(width=100, height=150)  # Final canvas size is 100px × 150px
 ```
 
 ### Color Palettes

--- a/docs/_ext/root_page_autosummary.py
+++ b/docs/_ext/root_page_autosummary.py
@@ -51,7 +51,12 @@ class ApiRootSummary(Autosummary):
         group.append(body)
 
         source, line = self.state_machine.get_source_and_line()
-        current_doc = self.env.current_document.docname
+        current_document = getattr(self.env, "current_document", None)
+        current_doc = (
+            current_document.docname
+            if current_document is not None
+            else self.env.docname
+        )
         dirname = posixpath.dirname(current_doc)
         tree_prefix = self.options["toctree"].strip()
         filename_map = self.config.autosummary_filename_map

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,8 +11,8 @@ import matplotlib.pyplot as plt
 # Load example data
 df = cns.datasets.load_dataset("tips")
 
-# Create a figure with specific dimensions (height x width in pixels)
-cns.figure(150, 100)
+# Create a figure with specific dimensions (width x height in pixels)
+cns.figure(100, 150)
 
 # Create a boxplot
 cns.boxplot(data=df, x="day", y="total_bill")
@@ -29,22 +29,22 @@ refer to column names in that DataFrame.
 cnsplots uses **pixels** for figure dimensions:
 
 ```python
-# Small figure: 100 px tall and 80 px wide
-cns.figure(100, 80)
+# Small figure: 80 px wide and 100 px tall
+cns.figure(80, 100)
 
-# Larger figure: 200 px tall and 150 px wide
-cns.figure(200, 150)
+# Larger figure: 150 px wide and 200 px tall
+cns.figure(150, 200)
 ```
 
-`cns.figure(height, width)` uses height first, and those values are the final
-canvas size in pixels.
+`cns.figure(width, height)` uses the conventional width-first order, and those
+values are the final canvas size in pixels.
 
 ## Basic Plot Types
 
 ### Boxplot
 
 ```python
-cns.figure(100, 80)
+cns.figure(80, 100)
 cns.boxplot(data=df, x="day", y="total_bill", hue="sex")
 cns.savefig("boxplot.svg")
 ```
@@ -52,7 +52,7 @@ cns.savefig("boxplot.svg")
 ### Barplot
 
 ```python
-cns.figure(100, 80)
+cns.figure(80, 100)
 cns.barplot(data=df, x="day", y="total_bill", hue="sex")
 cns.savefig("barplot.svg")
 ```
@@ -60,7 +60,7 @@ cns.savefig("barplot.svg")
 ### Scatter Plot
 
 ```python
-cns.figure(100, 80)
+cns.figure(80, 100)
 cns.scatterplot(data=df, x="total_bill", y="tip", hue="day")
 cns.savefig("scatter.svg")
 ```
@@ -70,7 +70,7 @@ cns.savefig("scatter.svg")
 ### Adding Labels
 
 ```python
-cns.figure(100, 80)
+cns.figure(80, 100)
 ax = cns.boxplot(data=df, x="day", y="total_bill")
 ax.set_xlabel("Day of Week")
 ax.set_ylabel("Total Bill ($)")

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ cnsplots is a Python visualization library built on matplotlib and fully compati
 import cnsplots as cns
 
 df = cns.datasets.load_dataset("tips")
-cns.figure(150, 100)  # Height x Width in pixels
+cns.figure(100, 150)  # Width x Height in pixels
 cns.boxplot(data=df, x="day", y="total_bill")
 cns.savefig("figure.svg")
 ```

--- a/examples/barplot.py
+++ b/examples/barplot.py
@@ -26,7 +26,7 @@ tips = cns.datasets.load_dataset("tips")
 # Basic barplot
 # ~~~~~~~~~~~~~
 # Simple bar plot with standard error bars.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.barplot(data=tips, x="day", y="total_bill", errorbar="se")
 ax.set_title("Basic Barplot")
 
@@ -38,7 +38,7 @@ ax.set_title("Basic Barplot")
 # Use one palette so both bars and points share the same group colors.
 day_order = ["Thur", "Fri", "Sat", "Sun"]
 overlay_palette = dict(zip(day_order, sns.color_palette("NEJM", len(day_order))))
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.barplot(
     data=tips,
     x="day",
@@ -68,7 +68,7 @@ ax.set_title("Barplot with Stripplot Overlay")
 # Barplot with standard deviation
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Show variability with standard deviation error bars.
-cns.figure(150, 100)
+cns.figure(100, 150)
 palette = {
     "Sat": cns.BLUE,
     "Fri": cns.BLUE,
@@ -82,7 +82,7 @@ cns.barplot(data=tips, x="day", y="total_bill", errorbar="sd", palette=palette)
 # Barplot with confidence intervals
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Display 95% confidence intervals.
-cns.figure(150, 100)
+cns.figure(100, 150)
 cns.barplot(data=tips, x="day", y="total_bill", errorbar="ci")
 
 
@@ -90,7 +90,7 @@ cns.barplot(data=tips, x="day", y="total_bill", errorbar="ci")
 # No error bars
 # ~~~~~~~~~~~~~
 # Clean bars without error indicators.
-cns.figure(150, 100)
+cns.figure(100, 150)
 cns.barplot(data=tips, x="day", y="total_bill", errorbar=None)
 
 
@@ -100,7 +100,7 @@ cns.barplot(data=tips, x="day", y="total_bill", errorbar=None)
 # Color bars based on value thresholds.
 mean_bills = tips.groupby("day")["total_bill"].mean()
 cols = ["grey" if x < 21.0 else "orange" for x in mean_bills]
-cns.figure(150, 100)
+cns.figure(100, 150)
 cns.barplot(data=tips, x="day", y="total_bill", palette=cols)
 
 
@@ -108,7 +108,7 @@ cns.barplot(data=tips, x="day", y="total_bill", palette=cols)
 # Statistical comparisons (all pairs)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Add significance annotations for all pairwise comparisons.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 cns.barplot(data=tips, x="day", y="total_bill", pairs="all", addtip=True)
 
 
@@ -116,7 +116,7 @@ cns.barplot(data=tips, x="day", y="total_bill", pairs="all", addtip=True)
 # Statistical comparisons (specific pairs)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare only selected pairs of groups.
-cns.figure(150, 100, "Set1")
+cns.figure(100, 150, "Set1")
 cns.barplot(
     data=tips,
     x="day",
@@ -130,7 +130,7 @@ cns.barplot(
 # Grouped barplot with hue
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 # Split bars by a secondary categorical variable.
-cns.figure(180, 100, "BlueRed")
+cns.figure(100, 180, "BlueRed")
 cns.barplot(data=tips, x="day", y="total_bill", hue="sex")
 cns.take_legend_out()
 
@@ -139,7 +139,7 @@ cns.take_legend_out()
 # Grouped barplot with statistical testing
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare specific groups across hue levels.
-cns.figure(180, 100, "BlueRed")
+cns.figure(100, 180, "BlueRed")
 cns.barplot(
     data=tips,
     x="day",
@@ -154,7 +154,7 @@ cns.take_legend_out()
 # Horizontal barplot
 # ~~~~~~~~~~~~~~~~~~
 # Flip axes for horizontal layout.
-cns.figure(100, 180, "Set1")
+cns.figure(180, 100, "Set1")
 cns.barplot(
     data=tips,
     x="total_bill",
@@ -168,7 +168,7 @@ cns.barplot(
 # Custom order
 # ~~~~~~~~~~~~
 # Specify the order of categories.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 cns.barplot(
     data=tips,
     x="day",
@@ -185,7 +185,7 @@ tips_centered = tips.copy()
 tips_centered["bill_deviation"] = (
     tips_centered["total_bill"] - tips_centered["total_bill"].mean()
 )
-cns.figure(100, 150, "Tableau")
+cns.figure(150, 100, "Tableau")
 ax = cns.barplot(data=tips_centered, x="day", y="bill_deviation")
 ax.axhline(0, color="k", clip_on=False, lw=0.8)
 ax.spines["bottom"].set_visible(False)
@@ -195,7 +195,7 @@ ax.spines["bottom"].set_visible(False)
 # Horizontal diverging barplot
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Horizontal layout for diverging bars.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 ax = cns.barplot(data=tips_centered, y="day", x="bill_deviation")
 ax.axvline(0, color="k", clip_on=False, lw=0.8)
 ax.spines["left"].set_visible(False)
@@ -205,7 +205,7 @@ ax.spines["left"].set_visible(False)
 # Barplot with species data
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare measurements across species.
-cns.figure(150, 100, "Bold")
+cns.figure(100, 150, "Bold")
 ax = cns.barplot(data=iris, x="species", y="sepal_width", pairs="all", addtip=True)
 ax.set_xticklabels(
     ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor"
@@ -226,21 +226,21 @@ cns.barplot(data=iris, x="species", y="sepal_length", addtip=True)
 # Compare different measurements using multipanel.
 mp = cns.multipanel(max_width=310)
 
-mp.panel("A", 80, 120, margin_bottom=20)
+mp.panel("A", 120, 80, margin_bottom=20)
 cns.barplot(data=iris, x="species", y="sepal_length")
 mp.get_axes("A").set_title("Sepal Length")
 
-mp.panel("B", 80, 120, margin_right=0)
+mp.panel("B", 120, 80, margin_right=0)
 cns.barplot(data=iris, x="species", y="sepal_width")
 mp.get_axes("B").set_title("Sepal Width")
 
 mp.newline()
 
-mp.panel("C", 80, 120)
+mp.panel("C", 120, 80)
 cns.barplot(data=iris, x="species", y="petal_length")
 mp.get_axes("C").set_title("Petal Length")
 
-mp.panel("D", 80, 120, margin_right=0)
+mp.panel("D", 120, 80, margin_right=0)
 cns.barplot(data=iris, x="species", y="petal_width")
 mp.get_axes("D").set_title("Petal Width")
 
@@ -273,12 +273,12 @@ mp = cns.multipanel(max_width=410)
 lunch = tips[tips["time"] == "Lunch"]
 dinner = tips[tips["time"] == "Dinner"]
 
-mp.panel("A", 100, 150)
+mp.panel("A", 150, 100)
 cns.barplot(data=lunch, x="day", y="total_bill", hue="sex")
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Lunch")
 
-mp.panel("B", 100, 150, margin_right=0)
+mp.panel("B", 150, 100, margin_right=0)
 cns.barplot(data=dinner, x="day", y="total_bill", hue="sex")
 cns.take_legend_out()
 mp.get_axes("B").set_title("Dinner")
@@ -299,7 +299,7 @@ baseline = pd.DataFrame(
 colors = [
     "gray" if x == 0 else ("green" if x > 0 else "red") for x in baseline["pct_change"]
 ]
-cns.figure(150, 100, color_cycle=colors)
+cns.figure(100, 150, color_cycle=colors)
 ax = cns.barplot(data=baseline, x="treatment", y="pct_change", errorbar=None)
 ax.axhline(0, color="k", lw=0.8)
 ax.set_ylabel("% Change from Baseline")
@@ -327,7 +327,7 @@ gene_data = pd.DataFrame(
     }
 )
 
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.barplot(
     data=gene_data,
     x="gene",
@@ -345,20 +345,20 @@ cns.take_legend_out()
 # Different palettes for the same data.
 mp = cns.multipanel(max_width=310)
 
-mp.panel("A", 80, 120, color_cycle="Set1", margin_bottom=20)
+mp.panel("A", 120, 80, color_cycle="Set1", margin_bottom=20)
 cns.barplot(data=tips, x="day", y="total_bill")
 mp.get_axes("A").set_title("Set1")
 
-mp.panel("B", 80, 120, color_cycle="Tableau", margin_right=0)
+mp.panel("B", 120, 80, color_cycle="Tableau", margin_right=0)
 cns.barplot(data=tips, x="day", y="total_bill")
 mp.get_axes("B").set_title("Tableau")
 
 mp.newline()
 
-mp.panel("C", 80, 120, color_cycle="Bold")
+mp.panel("C", 120, 80, color_cycle="Bold")
 cns.barplot(data=tips, x="day", y="total_bill")
 mp.get_axes("C").set_title("Bold")
 
-mp.panel("D", 80, 120, color_cycle="Pastel1", margin_right=0)
+mp.panel("D", 120, 80, color_cycle="Pastel1", margin_right=0)
 cns.barplot(data=tips, x="day", y="total_bill")
 mp.get_axes("D").set_title("Pastel1")

--- a/examples/boxplot.py
+++ b/examples/boxplot.py
@@ -25,7 +25,7 @@ tips = cns.datasets.load_dataset("tips")
 # Basic boxplot
 # ~~~~~~~~~~~~~
 # Simple boxplot showing distribution of total bills across days.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 ax.set_xticklabels(
     ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor"
@@ -40,7 +40,7 @@ ax.set_title("Basic Boxplot")
 # Use one palette so both boxes and points share the same group colors.
 day_order = ["Thur", "Fri", "Sat", "Sun"]
 overlay_palette = dict(zip(day_order, sns.color_palette("NEJM", len(day_order))))
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.boxplot(
     data=tips,
     x="day",
@@ -74,7 +74,7 @@ ax.set_title("Boxplot with Stripplot Overlay")
 # Boxplot with rotated and colored labels
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Customize x-axis tick labels with rotation and conditional coloring.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 ax.set_xticklabels(
     ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor"
@@ -94,7 +94,7 @@ for index in range(tips["day"].nunique()):
 # Use ``pairs="all"`` to perform Mann-Whitney U tests between all groups.
 # The ``addcount=True`` parameter adds sample sizes below each box.
 with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
-    cns.figure(150, 100)
+    cns.figure(100, 150)
     ax = cns.boxplot(
         data=iris,
         x="species",
@@ -110,7 +110,7 @@ ax.set_title("All Pairwise Comparisons\nwith Sample Counts")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Test only specific pairs by providing a list of tuples.
 with cns.settings.context(pvalue_format="full", pvalue_fontsize=8):
-    cns.figure(150, 100)
+    cns.figure(100, 150)
     ax = cns.boxplot(
         data=iris,
         x="species",
@@ -126,7 +126,7 @@ ax.set_title("Selected Pair Comparisons")
 # Use ``hue`` parameter to create side-by-side boxes for subgroups.
 # Statistical testing works across hue groups as well.
 with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
-    cns.figure(180, 100)
+    cns.figure(100, 180)
     ax = cns.boxplot(
         data=tips,
         x="day",
@@ -144,7 +144,7 @@ ax.set_title("Grouped Boxplot with\nCross-Group Comparison")
 # Create horizontal boxplots by swapping x and y.
 # Use ``order`` to specify the display order of categories.
 with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
-    cns.figure(100, 150)
+    cns.figure(150, 100)
     ax = cns.boxplot(
         data=iris,
         x="sepal_width",
@@ -159,7 +159,7 @@ ax.set_title("Horizontal Boxplot")
 # Boxplot with outliers displayed
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``showoutliers=True`` to display outlier points.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.boxplot(
     data=tips,
     x="day",
@@ -176,11 +176,11 @@ ax.set_title("Boxplot with Outliers")
 # Default is 1.5 (1.5×IQR). Use larger values for fewer outliers.
 mp = cns.multipanel(max_width=310)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 120, 80)
 cns.boxplot(data=tips, x="day", y="total_bill", whis=1.0, showoutliers=True)
 mp.get_axes("A").set_title("whis=1.0 (more outliers)")
 
-mp.panel("B", 80, 120, margin_right=0)
+mp.panel("B", 120, 80, margin_right=0)
 cns.boxplot(data=tips, x="day", y="total_bill", whis=3.0, showoutliers=True)
 mp.get_axes("B").set_title("whis=3.0 (fewer outliers)")
 
@@ -189,7 +189,7 @@ mp.get_axes("B").set_title("whis=3.0 (fewer outliers)")
 # Boxplot with custom palette
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``palette`` parameter for custom colors.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 ax.set_title("Tableau Palette")
 
@@ -199,7 +199,7 @@ ax.set_title("Tableau Palette")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Pass a list of colors to ``palette``.
 custom_colors = [cns.RED, cns.BLUE, cns.GREEN, cns.ORANGE]
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.boxplot(data=tips, x="day", y="total_bill", palette=custom_colors)
 ax.set_title("Custom Color List")
 
@@ -215,7 +215,7 @@ iris_melted = iris.melt(
     value_name="value",
 )
 
-cns.figure(120, 200)
+cns.figure(200, 120)
 ax = cns.boxplot(
     data=iris_melted,
     x="measurement",
@@ -235,7 +235,7 @@ plt.setp(ax.get_xticklabels(), ha="right", rotation_mode="anchor")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # When using hue, you can compare all subgroups within a category.
 with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
-    cns.figure(120, 180)
+    cns.figure(180, 120)
     ax = cns.boxplot(
         data=tips,
         x="day",

--- a/examples/confusionplot.py
+++ b/examples/confusionplot.py
@@ -47,7 +47,7 @@ ax.set_title("Basic Confusion Matrix")
 # Confusion matrix with Fisher's exact test
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Add p-value from Fisher's exact test.
-cns.figure(100, 80)
+cns.figure(80, 100)
 ax = cns.confusionplot(
     data=data2,
     x="truth",

--- a/examples/distplot.py
+++ b/examples/distplot.py
@@ -65,12 +65,12 @@ cns.take_legend_out()
 # Compare different variables.
 mp = cns.multipanel(max_width=400)
 
-mp.panel("A", 80, 140)
+mp.panel("A", 140, 80)
 cns.distplot(data=iris, x="sepal_length", hue="species")
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Sepal Length")
 
-mp.panel("B", 80, 140)
+mp.panel("B", 140, 80)
 cns.distplot(data=iris, x="petal_length", hue="species")
 mp.get_axes("B").legend().remove()
 mp.get_axes("B").set_title("Petal Length")
@@ -82,12 +82,12 @@ mp.get_axes("B").set_title("Petal Length")
 # Showcase color palette options.
 mp = cns.multipanel(max_width=400)
 
-mp.panel("A", 80, 140, color_cycle="Set2")
+mp.panel("A", 140, 80, color_cycle="Set2")
 cns.distplot(data=tips, x="total_bill", hue="sex")
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Set2 Palette")
 
-mp.panel("B", 80, 140, color_cycle="Bold")
+mp.panel("B", 140, 80, color_cycle="Bold")
 cns.distplot(data=tips, x="total_bill", hue="sex")
 mp.get_axes("B").legend().remove()
 mp.get_axes("B").set_title("Bold Palette")
@@ -120,7 +120,7 @@ synthetic = pd.DataFrame(
     }
 )
 
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.distplot(data=synthetic, x="value", hue="group")
 ax.set_title("Comparing Two Distributions")
 cns.take_legend_out()

--- a/examples/dotplot.py
+++ b/examples/dotplot.py
@@ -29,7 +29,7 @@ tips_agg = tips.groupby(["day", "sex"]).agg({"total_bill": ["mean", "count"]})
 tips_agg.columns = ["mean_bill", "count"]
 tips_agg = tips_agg.reset_index()
 
-cns.figure(80, 50)
+cns.figure(50, 80)
 dp = cns.dotplot(
     tips_agg,
     x="sex",
@@ -50,7 +50,7 @@ tips_minmax = tips.groupby(["day", "sex"]).agg({"total_bill": ["min", "size"]})
 tips_minmax.columns = ["min", "size"]
 tips_minmax = tips_minmax.reset_index()
 
-cns.figure(80, 50)
+cns.figure(50, 80)
 cns.dotplot(
     tips_minmax,
     x="sex",
@@ -79,7 +79,7 @@ for gene in genes:
         )
 gene_df = pd.DataFrame(gene_expr)
 
-cns.figure(120, 100)
+cns.figure(100, 120)
 dp = cns.dotplot(
     gene_df,
     x="gene",
@@ -117,7 +117,7 @@ for gene in genes:
         )
 gene_df = pd.DataFrame(gene_expr)
 
-cns.figure(150, 120)
+cns.figure(120, 150)
 cns.dotplot(
     gene_df,
     x="gene",
@@ -134,7 +134,7 @@ cns.dotplot(
 # Dotplot with custom colormap
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use a different colormap for color encoding.
-cns.figure(150, 100)
+cns.figure(100, 150)
 cns.dotplot(
     gene_df,
     x="gene",
@@ -153,7 +153,7 @@ cns.dotplot(
 # Dotplot with size encoding only
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Display dots with size encoding.
-cns.figure(150, 100)
+cns.figure(100, 150)
 cns.dotplot(
     gene_df,
     x="gene",
@@ -180,7 +180,7 @@ cox_summary = pd.DataFrame(
     }
 )
 
-cns.figure(80, 100)
+cns.figure(100, 80)
 dp = cns.dotplot(
     cox_summary,
     x="covariate",
@@ -253,7 +253,7 @@ for tp in timepoints:
         )
 time_df = pd.DataFrame(time_data)
 
-cns.figure(100, 80)
+cns.figure(80, 100)
 dp = cns.dotplot(
     time_df,
     x="timepoint",

--- a/examples/figure_setup.py
+++ b/examples/figure_setup.py
@@ -24,8 +24,8 @@ iris = cns.datasets.load_dataset("iris")
 # Basic figure creation
 # ~~~~~~~~~~~~~~~~~~~~~
 # Create a figure with specified dimensions in pixels.
-# figure(height, width) uses height first, and those requested dimensions are
-# the final canvas size.
+# figure(width, height) uses the conventional width-first order, and those
+# requested dimensions are the final canvas size.
 cns.figure(150, 150)
 ax = cns.placeholderplot("150x150 Figure")
 ax.set_title("Figure Setup")
@@ -35,7 +35,7 @@ ax.set_title("Figure Setup")
 # Different figure sizes
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Adjust figure dimensions for different purposes.
-cns.figure(100, 80)  # Small/compact
+cns.figure(80, 100)  # Small/compact
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 ax.set_title("Small Figure")
 
@@ -43,7 +43,7 @@ ax.set_title("Small Figure")
 # %%
 # Wider figure for more categories
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-cns.figure(200, 100)  # Wide
+cns.figure(100, 200)  # Wide
 ax = cns.boxplot(data=tips, x="day", y="total_bill", hue="sex")
 cns.take_legend_out()
 ax.set_title("Wide Figure")
@@ -62,7 +62,7 @@ ax.set_title("Square Figure")
 # Using different color palettes
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Pass palette name as third argument to ``figure()``.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Tableau Palette")
 
@@ -70,7 +70,7 @@ ax.set_title("Tableau Palette")
 # %%
 # Set1 palette
 # ~~~~~~~~~~~~
-cns.figure(150, 100, "Set1")
+cns.figure(100, 150, "Set1")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Set1 Palette")
 
@@ -78,7 +78,7 @@ ax.set_title("Set1 Palette")
 # %%
 # Set2 palette
 # ~~~~~~~~~~~~
-cns.figure(150, 100, "Set2")
+cns.figure(100, 150, "Set2")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Set2 Palette")
 
@@ -86,7 +86,7 @@ ax.set_title("Set2 Palette")
 # %%
 # Bold palette
 # ~~~~~~~~~~~~
-cns.figure(150, 100, "Bold")
+cns.figure(100, 150, "Bold")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Bold Palette")
 
@@ -94,7 +94,7 @@ ax.set_title("Bold Palette")
 # %%
 # BlueRed diverging palette
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
-cns.figure(150, 100, "BlueRed")
+cns.figure(100, 150, "BlueRed")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("BlueRed Palette")
 
@@ -103,7 +103,7 @@ ax.set_title("BlueRed Palette")
 # Using palettes() function
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # Get palette colors programmatically.
-cns.figure(150, 100, color_cycle="Ecotyper1")
+cns.figure(100, 150, color_cycle="Ecotyper1")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Ecotyper1 Palette")
 
@@ -113,7 +113,7 @@ ax.set_title("Ecotyper1 Palette")
 # ~~~~~~~~~~~~~~~~~
 # Pass a list of specific colors.
 custom_colors = [cns.RED, cns.BLUE, cns.GREEN, cns.ORANGE]
-cns.figure(150, 100, color_cycle=custom_colors)
+cns.figure(100, 150, color_cycle=custom_colors)
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Custom Color List")
 
@@ -138,7 +138,7 @@ print(f"  GRAY: {cns.GRAY}")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``get_hexcolors_from_apalette()`` to pick specific colors.
 selected_colors = cns.get_hexcolors_from_apalette([0, 2, 4, 6])
-cns.figure(150, 100, color_cycle=selected_colors)
+cns.figure(100, 150, color_cycle=selected_colors)
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Selected Colors from Set1")
 
@@ -148,7 +148,7 @@ ax.set_title("Selected Colors from Set1")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``take_legend_out()`` to move legend to the right margin.
 # Small figures can expand on draw so the outside legend is not clipped.
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.boxplot(data=tips, x="day", y="total_bill", hue="sex")
 cns.take_legend_out()
 ax.set_title("Legend Outside")
@@ -157,7 +157,7 @@ ax.set_title("Legend Outside")
 # %%
 # Legend with custom title
 # ~~~~~~~~~~~~~~~~~~~~~~~~
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.boxplot(data=tips, x="day", y="total_bill", hue="sex")
 cns.take_legend_out(title="Gender")
 ax.set_title("Legend with Title")
@@ -167,7 +167,7 @@ ax.set_title("Legend with Title")
 # Adding panel labels manually
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``add_panel_label()`` for manual figure composition.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 cns.add_panel_label("A")
 ax.set_title("With Panel Label")
@@ -176,7 +176,7 @@ ax.set_title("With Panel Label")
 # %%
 # Panel label with custom padding
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 cns.add_panel_label("B", pad_left=14, pad_top=4)
 ax.set_title("Custom Label Padding")
@@ -212,7 +212,7 @@ ax.set_title("Custom Font Sizes")
 # ~~~~~~~~~~~~~~
 # Use ``savefig()`` to save figures in various formats.
 # Supported formats: PDF, PNG, SVG, EPS, JPG
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 ax.set_title("Save Example")
 
@@ -236,6 +236,6 @@ ax.set_title("Save Example")
 # cnsplots uses pixels at 72 DPI base for sizing.
 # The default max_width=540 in multipanel matches double column.
 
-cns.figure(252, 150)  # Single column width
+cns.figure(150, 252)  # Single column width
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 ax.set_title("Single Column Width (89mm)")

--- a/examples/forestplot.py
+++ b/examples/forestplot.py
@@ -63,7 +63,7 @@ model = cns.methods.CoxModel(
     hue="Group",
 )
 model.fit()
-cns.figure(150, 210)
+cns.figure(210, 150)
 ax = cns.forestplot(model)
 ax.set_title("Forest Plot")
 model.results.head()
@@ -108,7 +108,7 @@ model = cns.methods.CoxModel(
     ],
 )
 model.fit()
-cns.figure(120, 210, ["black"])
+cns.figure(210, 120, ["black"])
 cns.forestplot(model)
 model.results.head()
 
@@ -157,7 +157,7 @@ model = cns.methods.CoxModel(
     ],
 )
 model.fit()
-cns.figure(90, 210, ["black"])
+cns.figure(210, 90, ["black"])
 ax = cns.forestplot(model)
 ax.set_title("Univariate Cox Regression")
 
@@ -175,7 +175,7 @@ model = cns.methods.CoxModel(
     ],
 )
 model.fit()
-cns.figure(40, 210, ["black"])
+cns.figure(210, 40, ["black"])
 ax = cns.forestplot(model)
 ax.set_title("Multivariate Cox Regression")
 
@@ -195,7 +195,7 @@ model = cns.methods.CoxModel(
     ],
 )
 model.fit()
-cns.figure(80, 210, ["black"])
+cns.figure(210, 80, ["black"])
 ax = cns.forestplot(model)
 ax.set_title("Categorical Covariates")
 
@@ -216,7 +216,7 @@ model = cns.methods.CoxModel(
     hue="horTh",
 )
 model.fit()
-cns.figure(100, 210)
+cns.figure(210, 100)
 ax = cns.forestplot(model)
 ax.set_title("Stratified by Hormone Therapy")
 
@@ -237,7 +237,7 @@ model = cns.methods.CoxModel(
     ],
 )
 model.fit()
-cns.figure(80, 210, ["black"])
+cns.figure(210, 80, ["black"])
 ax = cns.forestplot(model)
 ax.set_title("With Interaction Term")
 
@@ -256,7 +256,7 @@ model = cns.methods.LogisticModel(
     ],
 )
 model.fit()
-cns.figure(80, 150, ["black"])
+cns.figure(150, 80, ["black"])
 ax = cns.forestplot(model)
 ax.set_title("Univariate Logistic Regression")
 
@@ -276,6 +276,6 @@ model = cns.methods.CoxModel(
     ],
 )
 model.fit()
-cns.figure(80, 210, [cns.BLUE])
+cns.figure(210, 80, [cns.BLUE])
 ax = cns.forestplot(model)
 ax.set_title("Custom Color")

--- a/examples/gseaplot.py
+++ b/examples/gseaplot.py
@@ -154,7 +154,7 @@ gsea_res.head()
 # Basic GSEA plot - GO Biological Process
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Visualize the strongest enriched terms from prerank-style results.
-cns.figure(180, 130)
+cns.figure(130, 180)
 ax = cns.gseaplot(gsea_res, y="Clean_Term", top_term=12, size=1.5)
 ax.set_title("GSEA Plot")
 
@@ -163,7 +163,7 @@ ax.set_title("GSEA Plot")
 # Top 8 enriched terms
 # ~~~~~~~~~~~~~~~~~~~~
 # Display fewer terms for a cleaner plot.
-cns.figure(150, 100)
+cns.figure(100, 150)
 cns.gseaplot(gsea_res, y="Clean_Term", top_term=8, size=1.5)
 
 
@@ -171,7 +171,7 @@ cns.gseaplot(gsea_res, y="Clean_Term", top_term=8, size=1.5)
 # All enriched terms
 # ~~~~~~~~~~~~~~~~~~
 # Show the complete result table.
-cns.figure(200, 180)
+cns.figure(180, 200)
 cns.gseaplot(gsea_res, y="Clean_Term", top_term=len(gsea_res), size=1.5)
 
 
@@ -179,7 +179,7 @@ cns.gseaplot(gsea_res, y="Clean_Term", top_term=len(gsea_res), size=1.5)
 # KEGG pathway enrichment
 # ~~~~~~~~~~~~~~~~~~~~~~~
 # Use prerank-style KEGG results for pathway analysis.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.gseaplot(gsea_kegg, y="Clean_Term", top_term=10, size=1.5)
 ax.set_title("KEGG Pathways")
 
@@ -188,7 +188,7 @@ ax.set_title("KEGG Pathways")
 # Reactome pathway enrichment
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use prerank-style Reactome results for biological pathways.
-cns.figure(180, 120)
+cns.figure(120, 180)
 ax = cns.gseaplot(gsea_reactome, y="Clean_Term", top_term=10, size=1.5)
 ax.set_title("Reactome Pathways")
 
@@ -197,7 +197,7 @@ ax.set_title("Reactome Pathways")
 # GO Molecular Function
 # ~~~~~~~~~~~~~~~~~~~~~
 # Enrichment analysis for molecular functions.
-cns.figure(250, 100)
+cns.figure(100, 250)
 ax = cns.gseaplot(gsea_mf, y="Clean_Term", top_term=8, size=1.5)
 ax.set_title("GO Molecular Function")
 
@@ -206,7 +206,7 @@ ax.set_title("GO Molecular Function")
 # GO Cellular Component
 # ~~~~~~~~~~~~~~~~~~~~~
 # Enrichment analysis for cellular locations.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.gseaplot(gsea_cc, y="Clean_Term", top_term=8, size=1.5)
 ax.set_title("GO Cellular Component")
 
@@ -215,7 +215,7 @@ ax.set_title("GO Cellular Component")
 # WikiPathways enrichment
 # ~~~~~~~~~~~~~~~~~~~~~~~
 # Use prerank-style WikiPathways results.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.gseaplot(gsea_wiki, y="Clean_Term", top_term=8, size=1.5)
 ax.set_title("WikiPathways")
 
@@ -233,7 +233,7 @@ ax.set_title("Larger Dots")
 # Smaller dot size
 # ~~~~~~~~~~~~~~~~
 # Decrease dot size for denser plots.
-cns.figure(180, 150)
+cns.figure(150, 180)
 ax = cns.gseaplot(gsea_res, y="Clean_Term", top_term=12, size=1.2)
 ax.set_title("Smaller Dots")
 

--- a/examples/heatmapplot.py
+++ b/examples/heatmapplot.py
@@ -36,7 +36,7 @@ blobs_annot = blobs[:240, :].copy()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Complete heatmap with clustering, annotations, and dendrograms.
 # Use a display subset to keep the gallery image readable and stable to render.
-cns.figure(300, 250)
+cns.figure(250, 300)
 cmp = cns.heatmapplot(
     blobs_full,
     label="Expression",
@@ -72,7 +72,7 @@ print(f"Row clusters: {len(cmp.row_order)}, Col clusters: {len(cmp.col_order)}")
 # Simple heatmap without clustering
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Basic heatmap showing raw data without reordering.
-cns.figure(250, 200)
+cns.figure(200, 250)
 cmp = cns.heatmapplot(
     blobs[:50, :],  # Subset for visibility
     label="Expression",
@@ -93,7 +93,7 @@ cmp = cns.heatmapplot(
 # Heatmap with row clustering only
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Cluster samples but keep gene order fixed.
-cns.figure(250, 200)
+cns.figure(200, 250)
 cmp = cns.heatmapplot(
     blobs[:50, :],
     label="Expression",
@@ -112,7 +112,7 @@ cmp = cns.heatmapplot(
 # Heatmap with categorical split
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Split rows by a categorical variable.
-cns.figure(300, 220)
+cns.figure(220, 300)
 cmp = cns.heatmapplot(
     blobs,
     label="Expression",
@@ -134,7 +134,7 @@ cmp = cns.heatmapplot(
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Add both categorical and continuous annotations.
 # Use a display subset to keep the gallery image readable and stable to render.
-cns.figure(320, 250)
+cns.figure(250, 320)
 cmp = cns.heatmapplot(
     blobs_annot,
     label="Expression",
@@ -155,7 +155,7 @@ cmp = cns.heatmapplot(
 # Heatmap with different colormaps
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Showcase different colormap options.
-cns.figure(250, 200)
+cns.figure(200, 250)
 cmp = cns.heatmapplot(
     blobs[:50, :],
     label="Expression",
@@ -177,7 +177,7 @@ cmp = cns.heatmapplot(
 centered_data = blobs.copy()
 centered_data.X = centered_data.X - centered_data.X.mean()
 
-cns.figure(250, 200)
+cns.figure(200, 250)
 cmp = cns.heatmapplot(
     centered_data[:50, :],
     label="Z-score",
@@ -201,7 +201,7 @@ discrete.var["ensemble"] = [
 ]
 discrete.obs["group"] = [f"G{x}" for x in np.random.randint(0, 3, discrete.shape[0])]
 
-cns.figure(250, 180)
+cns.figure(180, 250)
 cmp = cns.heatmapplot(
     discrete,
     label="Category",
@@ -224,7 +224,7 @@ custom_colors = {
     "blobs": {0: "#e41a1c", 1: "#377eb8", 2: "#4daf4a"},
 }
 
-cns.figure(280, 220)
+cns.figure(220, 280)
 cmp = cns.heatmapplot(
     blobs[:60, :],
     label="Expression",
@@ -244,7 +244,7 @@ cmp = cns.heatmapplot(
 # Heatmap with value range limits
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Set explicit vmin/vmax for consistent coloring.
-cns.figure(250, 200)
+cns.figure(200, 250)
 cmp = cns.heatmapplot(
     blobs[:50, :],
     label="Expression",
@@ -267,7 +267,7 @@ small_data = sc.AnnData(pd.DataFrame(np.random.randn(15, 10)))
 small_data.var["type"] = [f"T{x}" for x in np.random.randint(0, 2, 10)]
 small_data.obs["group"] = [f"G{x}" for x in np.random.randint(0, 3, 15)]
 
-cns.figure(200, 180)
+cns.figure(180, 200)
 cmp = cns.heatmapplot(
     small_data,
     label="Value",
@@ -286,7 +286,7 @@ cmp = cns.heatmapplot(
 # Large heatmap with rasterization
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``rasterized=True`` for large datasets to reduce file size.
-cns.figure(300, 250)
+cns.figure(250, 300)
 cmp = cns.heatmapplot(
     blobs,
     label="Expression",
@@ -305,7 +305,7 @@ cmp = cns.heatmapplot(
 # Heatmap with different clustering methods
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare different linkage methods.
-cns.figure(250, 200)
+cns.figure(200, 250)
 cmp = cns.heatmapplot(
     blobs[:60, :],
     label="Expression",

--- a/examples/histplot.py
+++ b/examples/histplot.py
@@ -35,15 +35,15 @@ ax.set_title("Basic Histogram")
 # Control the number of bins.
 mp = cns.multipanel(max_width=420)
 
-mp.panel("A", 80, 100)
+mp.panel("A", 100, 80)
 cns.histplot(data=tips, x="total_bill", bins=10)
 mp.get_axes("A").set_title("10 bins")
 
-mp.panel("B", 80, 100)
+mp.panel("B", 100, 80)
 cns.histplot(data=tips, x="total_bill", bins=20)
 mp.get_axes("B").set_title("20 bins")
 
-mp.panel("C", 80, 100)
+mp.panel("C", 100, 80)
 cns.histplot(data=tips, x="total_bill", bins=30)
 mp.get_axes("C").set_title("30 bins")
 
@@ -141,7 +141,7 @@ ax.set_ylabel("Probability")
 # 2D histogram (heatmap)
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Visualize joint distribution of two variables.
-cns.figure(100, 150)
+cns.figure(150, 100)
 ax = cns.histplot(
     data=iris, x="sepal_length", y="sepal_width", cbar=True, cmap="gnuplot"
 )
@@ -152,7 +152,7 @@ ax.set_title("2D Histogram (gnuplot)")
 # 2D histogram with parula colormap
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use cnsplots parula colormap.
-cns.figure(100, 150)
+cns.figure(150, 100)
 ax = cns.histplot(
     data=iris, x="sepal_length", y="sepal_width", cbar=True, cmap="parula"
 )
@@ -202,7 +202,7 @@ cns.take_legend_out()
 # Horizontal histogram
 # ~~~~~~~~~~~~~~~~~~~~
 # Swap x and y for horizontal orientation.
-cns.figure(100, 150)
+cns.figure(150, 100)
 ax = cns.histplot(data=tips, y="total_bill", bins=15)
 ax.set_title("Horizontal Histogram")
 
@@ -226,10 +226,10 @@ log_data = pd.DataFrame({"value": np.random.lognormal(3, 1, 1000)})
 
 mp = cns.multipanel(max_width=320)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 120, 80)
 cns.histplot(data=log_data, x="value", bins=30)
 mp.get_axes("A").set_title("Linear Scale")
 
-mp.panel("B", 80, 120, margin_right=0)
+mp.panel("B", 120, 80, margin_right=0)
 cns.histplot(data=log_data, x="value", bins=30, log_scale=True)
 mp.get_axes("B").set_title("Log Scale")

--- a/examples/kdeplot.py
+++ b/examples/kdeplot.py
@@ -103,15 +103,15 @@ cns.take_legend_out()
 # Adjust smoothness with ``bw_adjust``.
 mp = cns.multipanel(max_width=480)
 
-mp.panel("A", 80, 100)
+mp.panel("A", 100, 80)
 cns.kdeplot(data=tips, x="total_bill", bw_adjust=0.3)
 mp.get_axes("A").set_title("bw_adjust=0.3 (rough)")
 
-mp.panel("B", 80, 100)
+mp.panel("B", 100, 80)
 cns.kdeplot(data=tips, x="total_bill", bw_adjust=1.0)
 mp.get_axes("B").set_title("bw_adjust=1.0 (default)")
 
-mp.panel("C", 80, 100)
+mp.panel("C", 100, 80)
 cns.kdeplot(data=tips, x="total_bill", bw_adjust=2.0)
 mp.get_axes("C").set_title("bw_adjust=2.0 (smooth)")
 
@@ -122,11 +122,11 @@ mp.get_axes("C").set_title("bw_adjust=2.0 (smooth)")
 # Customize line width and style.
 mp = cns.multipanel(max_width=350)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 120, 80)
 cns.kdeplot(data=tips, x="total_bill", linewidth=0.5)
 mp.get_axes("A").set_title("Thin line")
 
-mp.panel("B", 80, 120)
+mp.panel("B", 120, 80)
 cns.kdeplot(data=tips, x="total_bill", linewidth=2)
 mp.get_axes("B").set_title("Thick line")
 
@@ -147,12 +147,12 @@ cns.take_legend_out()
 # Compare distributions across different variables.
 mp = cns.multipanel(max_width=350)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 120, 80)
 cns.kdeplot(data=iris, x="sepal_length", hue="species")
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Sepal Length")
 
-mp.panel("B", 80, 120)
+mp.panel("B", 120, 80)
 cns.kdeplot(data=iris, x="petal_length", hue="species")
 mp.get_axes("B").legend().remove()
 mp.get_axes("B").set_title("Petal Length")

--- a/examples/lineplot.py
+++ b/examples/lineplot.py
@@ -52,7 +52,7 @@ cns.take_legend_out()
 # Line plot with hue and error bars
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Combine grouping with error visualization.
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.lineplot(data=fmri, x="timepoint", y="signal", hue="event", err_style="bars")
 ax.set_title("Grouped with Error Bars")
 cns.take_legend_out()
@@ -62,7 +62,7 @@ cns.take_legend_out()
 # Line plot with style differentiation
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use different line styles for groups.
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.lineplot(data=fmri, x="timepoint", y="signal", hue="event", style="event")
 ax.set_title("Different Line Styles")
 cns.take_legend_out()
@@ -72,7 +72,7 @@ cns.take_legend_out()
 # Multiple grouping levels
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 # Use both hue and style for complex comparisons.
-cns.figure(180, 120)
+cns.figure(120, 180)
 ax = cns.lineplot(data=fmri, x="timepoint", y="signal", hue="event", style="region")
 ax.set_title("Multiple Grouping Levels")
 cns.take_legend_out()
@@ -107,7 +107,7 @@ ts_data = pd.DataFrame(
     }
 )
 
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.lineplot(data=ts_data, x="date", y="value", hue="group")
 ax.set_title("Time Series Data")
 ax.set_xticklabels(
@@ -168,14 +168,14 @@ ax.set_title("Dose-Response Curve")
 # Side-by-side line plot comparison.
 mp = cns.multipanel(max_width=360)
 
-mp.panel("A", 80, 140)
+mp.panel("A", 140, 80)
 cns.lineplot(
     data=fmri[fmri["region"] == "parietal"], x="timepoint", y="signal", hue="event"
 )
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Parietal Region")
 
-mp.panel("B", 80, 140, margin_right=0)
+mp.panel("B", 140, 80, margin_right=0)
 cns.lineplot(
     data=fmri[fmri["region"] == "frontal"], x="timepoint", y="signal", hue="event"
 )

--- a/examples/lollipopplot.py
+++ b/examples/lollipopplot.py
@@ -25,7 +25,7 @@ iris = cns.datasets.load_dataset("iris")
 # Basic lollipop plot
 # ~~~~~~~~~~~~~~~~~~~
 # Simple vertical lollipop plot showing mean values per category.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.lollipopplot(data=tips, x="day", y="total_bill")
 ax.set_title("Basic Lollipop Plot")
 
@@ -34,7 +34,7 @@ ax.set_title("Basic Lollipop Plot")
 # Horizontal lollipop plot
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 # Swap x and y to create a horizontal layout automatically.
-cns.figure(100, 180)
+cns.figure(180, 100)
 ax = cns.lollipopplot(data=tips, x="total_bill", y="day")
 ax.set_title("Horizontal Lollipop")
 
@@ -43,7 +43,7 @@ ax.set_title("Horizontal Lollipop")
 # With error bars
 # ~~~~~~~~~~~~~~~
 # Add standard error bars to show variability.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.lollipopplot(data=tips, x="day", y="total_bill", errorbar="se")
 ax.set_title("With Standard Error")
 
@@ -52,7 +52,7 @@ ax.set_title("With Standard Error")
 # With standard deviation
 # ~~~~~~~~~~~~~~~~~~~~~~~
 # Show variability with standard deviation error bars.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.lollipopplot(data=tips, x="day", y="total_bill", errorbar="sd")
 ax.set_title("With Standard Deviation")
 
@@ -61,7 +61,7 @@ ax.set_title("With Standard Deviation")
 # Grouped lollipop plot with hue
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Split lollipops by a secondary categorical variable.
-cns.figure(180, 100, "BlueRed")
+cns.figure(100, 180, "BlueRed")
 ax = cns.lollipopplot(data=tips, x="day", y="total_bill", hue="sex")
 cns.take_legend_out()
 
@@ -70,7 +70,7 @@ cns.take_legend_out()
 # Grouped with error bars
 # ~~~~~~~~~~~~~~~~~~~~~~~
 # Combine hue grouping with error bars.
-cns.figure(180, 100, "BlueRed")
+cns.figure(100, 180, "BlueRed")
 ax = cns.lollipopplot(data=tips, x="day", y="total_bill", hue="sex", errorbar="se")
 cns.take_legend_out()
 
@@ -79,7 +79,7 @@ cns.take_legend_out()
 # Statistical comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~
 # Add significance annotations for specific pairs.
-cns.figure(150, 100, "Set1")
+cns.figure(100, 150, "Set1")
 cns.lollipopplot(
     data=tips,
     x="day",
@@ -92,7 +92,7 @@ cns.lollipopplot(
 # With value labels
 # ~~~~~~~~~~~~~~~~~
 # Display the mean value at each dot.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 cns.lollipopplot(data=tips, x="day", y="total_bill", addtip=True)
 
 
@@ -100,7 +100,7 @@ cns.lollipopplot(data=tips, x="day", y="total_bill", addtip=True)
 # Custom order
 # ~~~~~~~~~~~~
 # Specify the order of categories.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 cns.lollipopplot(
     data=tips,
     x="day",
@@ -113,7 +113,7 @@ cns.lollipopplot(
 # Custom styling
 # ~~~~~~~~~~~~~~
 # Adjust marker size, line width, and marker shape.
-cns.figure(150, 100, "Bold")
+cns.figure(100, 150, "Bold")
 cns.lollipopplot(
     data=tips,
     x="day",
@@ -128,7 +128,7 @@ cns.lollipopplot(
 # Horizontal with hue
 # ~~~~~~~~~~~~~~~~~~~~
 # Horizontal grouped lollipop plot.
-cns.figure(120, 180, "BlueRed")
+cns.figure(180, 120, "BlueRed")
 ax = cns.lollipopplot(
     data=tips,
     x="total_bill",
@@ -143,7 +143,7 @@ cns.take_legend_out()
 # Species comparison
 # ~~~~~~~~~~~~~~~~~~
 # Compare measurements across species with value labels.
-cns.figure(150, 100, "Bold")
+cns.figure(100, 150, "Bold")
 ax = cns.lollipopplot(
     data=iris, x="species", y="sepal_width", addtip=True, errorbar="se"
 )
@@ -171,7 +171,7 @@ gene_data = pd.DataFrame(
     }
 )
 
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.lollipopplot(
     data=gene_data,
     x="gene",
@@ -187,7 +187,7 @@ cns.take_legend_out()
 # Median estimator
 # ~~~~~~~~~~~~~~~~
 # Use median instead of mean for robust estimation.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.lollipopplot(
     data=tips, x="day", y="total_bill", estimator="median", addtip=True
 )

--- a/examples/matplotlib_integration.py
+++ b/examples/matplotlib_integration.py
@@ -35,7 +35,7 @@ observed = signal_a + rng.normal(0, 0.12, size=time.size)
 # Line plot with confidence band
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # cnsplots handles the figure setup while matplotlib draws everything.
-cns.figure(160, 220)
+cns.figure(220, 160)
 ax = plt.gca()
 ax.plot(time, signal_a, color="#1f77b4", linewidth=2, label="Condition A")
 ax.plot(time, signal_b, color="#d62728", linewidth=2, label="Condition B")
@@ -57,7 +57,7 @@ ax.legend(frameon=False, loc="upper right")
 # Two-panel matplotlib layout
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The cnsplots canvas also works with matplotlib's subplot helpers.
-cns.figure(160, 300)
+cns.figure(300, 160)
 fig = plt.gcf()
 ax_left, ax_right = fig.subplots(1, 2)
 
@@ -93,7 +93,7 @@ fig.tight_layout()
 export_dir = Path(os.environ.get("CNSPLOTS_GALLERY_OUTPUT_DIR", "."))
 export_dir.mkdir(parents=True, exist_ok=True)
 
-cns.figure(140, 180)
+cns.figure(180, 140)
 ax = plt.gca()
 ax.plot(time, signal_a, color="#1f77b4", linewidth=2, label="Condition A")
 ax.plot(time, observed, color="#7f7f7f", linewidth=1.2, alpha=0.85, label="Observed")

--- a/examples/multipanel.py
+++ b/examples/multipanel.py
@@ -23,7 +23,7 @@ iris = cns.datasets.load_dataset("iris")
 # Basic 2x2 multi-panel figure
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Create a simple grid layout with different panel sizes.
-# Each panel has explicit size: ``mp.panel(label, height, width)``.
+# Each panel has explicit size: ``mp.panel(label, width, height)``.
 # Labels (A, B, C, D) are automatically added in bold, 8pt font.
 mp = cns.multipanel(max_width=265)
 
@@ -33,10 +33,10 @@ cns.boxplot(data=tips, x="day", y="total_bill")
 mp.panel("B", 100, 100, margin_bottom=20)
 cns.barplot(data=tips, x="day", y="total_bill", errorbar="se")
 
-mp.panel("C", 100, 80)
+mp.panel("C", 80, 100)
 cns.violinplot(data=iris, x="species", y="sepal_width")
 
-mp.panel("D", 120, 80)
+mp.panel("D", 80, 120)
 cns.stripplot(data=tips, x="day", y="tip", hue="sex")
 
 

--- a/examples/palettes.py
+++ b/examples/palettes.py
@@ -32,8 +32,8 @@ gradient = np.linspace(0, 1, 256)
 gradient = np.vstack((gradient, gradient))
 
 
-def plot_palettes(cmap_list, height, width, title="", ncols=1):
-    cns.figure(height, width)
+def plot_palettes(cmap_list, width, height, title="", ncols=1):
+    cns.figure(width, height)
     fig = plt.gcf()
     nrows = (len(cmap_list) + ncols - 1) // ncols
     axes = fig.subplots(nrows=nrows, ncols=ncols, squeeze=False)
@@ -102,8 +102,8 @@ plot_palettes(
         "OrBu_custom",
         "YlGnBu_custom",
     ],
-    1020,
     1200,
+    1020,
     ncols=2,
 )
 
@@ -154,8 +154,8 @@ plot_palettes(
         "Science",
         "JAMA",
     ],
-    540,
     600,
+    540,
 )
 
 
@@ -172,8 +172,8 @@ plot_palettes(
         "WhYlOrRd_custom",
         "YlGnBu_custom",
     ],
-    300,
     600,
+    300,
 )
 
 
@@ -188,8 +188,8 @@ plot_palettes(
         "OrBu_custom",
         "BlueRed",
     ],
-    180,
     600,
+    180,
 )
 
 
@@ -197,7 +197,7 @@ plot_palettes(
 # Using palettes with figure()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Pass palette name as third argument to ``figure()``.
-cns.figure(150, 100, "Set1")
+cns.figure(100, 150, "Set1")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Set1 Palette")
 
@@ -205,7 +205,7 @@ ax.set_title("Set1 Palette")
 # %%
 # Tableau palette
 # ~~~~~~~~~~~~~~~
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Tableau Palette")
 
@@ -213,7 +213,7 @@ ax.set_title("Tableau Palette")
 # %%
 # Bold palette
 # ~~~~~~~~~~~~
-cns.figure(150, 100, "Bold")
+cns.figure(100, 150, "Bold")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Bold Palette")
 
@@ -222,7 +222,7 @@ ax.set_title("Bold Palette")
 # Using palettes() function
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # Get palette colors programmatically.
-cns.figure(150, 100, color_cycle="Ecotyper1")
+cns.figure(100, 150, color_cycle="Ecotyper1")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Ecotyper1 Palette")
 
@@ -230,7 +230,7 @@ ax.set_title("Ecotyper1 Palette")
 # %%
 # Ecotyper2 palette
 # ~~~~~~~~~~~~~~~~~
-cns.figure(150, 100, color_cycle="Ecotyper2")
+cns.figure(100, 150, color_cycle="Ecotyper2")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Ecotyper2 Palette")
 
@@ -238,7 +238,7 @@ ax.set_title("Ecotyper2 Palette")
 # %%
 # Ecotyper3 palette
 # ~~~~~~~~~~~~~~~~~
-cns.figure(150, 100, color_cycle="Ecotyper3")
+cns.figure(100, 150, color_cycle="Ecotyper3")
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Ecotyper3 Palette")
 
@@ -279,7 +279,7 @@ ax.set_title("Reversed Accent Palette")
 # ~~~~~~~~~~~~~~~~~
 # Define your own color sequence.
 custom_colors = ["#E41A1C", "#377EB8", "#4DAF4A", "#984EA3"]
-cns.figure(150, 100, color_cycle=custom_colors)
+cns.figure(100, 150, color_cycle=custom_colors)
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Custom Color List")
 
@@ -306,7 +306,7 @@ print(f"  CHOCOLATE: {cns.CHOCOLATE}")
 # ~~~~~~~~~~~~~~~~~~~~~
 # Apply color constants to plots.
 custom_colors = [cns.RED, cns.BLUE, cns.GREEN, cns.ORANGE]
-cns.figure(150, 100, color_cycle=custom_colors)
+cns.figure(100, 150, color_cycle=custom_colors)
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Using Color Constants")
 
@@ -317,19 +317,19 @@ ax.set_title("Using Color Constants")
 # Use multipanel to compare different palettes.
 mp = cns.multipanel(max_width=330)
 
-mp.panel("A", 80, 120, color_cycle="Set1", margin_bottom=20)
+mp.panel("A", 120, 80, color_cycle="Set1", margin_bottom=20)
 cns.barplot(data=tips, x="day", y="total_bill")
 mp.get_axes("A").set_title("Set1")
 
-mp.panel("B", 80, 120, color_cycle="Tableau")
+mp.panel("B", 120, 80, color_cycle="Tableau")
 cns.barplot(data=tips, x="day", y="total_bill")
 mp.get_axes("B").set_title("Tableau")
 
-mp.panel("C", 80, 120, color_cycle="Bold")
+mp.panel("C", 120, 80, color_cycle="Bold")
 cns.barplot(data=tips, x="day", y="total_bill")
 mp.get_axes("C").set_title("Bold")
 
-mp.panel("D", 80, 120, color_cycle="Set2")
+mp.panel("D", 120, 80, color_cycle="Set2")
 cns.barplot(data=tips, x="day", y="total_bill")
 mp.get_axes("D").set_title("Set2")
 

--- a/examples/regplot.py
+++ b/examples/regplot.py
@@ -59,11 +59,11 @@ ax.set_title("Regression by Day")
 # Adjust point size with the ``s`` parameter.
 mp = cns.multipanel(max_width=350)
 
-mp.panel("A", 100, 120)
+mp.panel("A", 120, 100)
 cns.regplot(data=tips, x="tip", y="total_bill", s=2)
 mp.get_axes("A").set_title("s=2 (small)")
 
-mp.panel("B", 100, 120)
+mp.panel("B", 120, 100)
 cns.regplot(data=tips, x="tip", y="total_bill", s=10)
 mp.get_axes("B").set_title("s=10 (large)")
 
@@ -86,7 +86,7 @@ mp = cns.multipanel(max_width=560)
 
 for i, day in enumerate(["Thur", "Fri", "Sat", "Sun"]):
     label = chr(65 + i)  # A, B, C, D
-    mp.panel(label, 80, 100)
+    mp.panel(label, 100, 80)
     subset = tips[tips["day"] == day]
     cns.regplot(data=subset, x="tip", y="total_bill", s=5)
     mp.get_axes(label).set_title(day)
@@ -169,12 +169,12 @@ mp = cns.multipanel(max_width=305)
 male_tips = tips[tips["sex"] == "Male"]
 female_tips = tips[tips["sex"] == "Female"]
 
-mp.panel("A", 100, 120)
+mp.panel("A", 120, 100)
 cns.regplot(data=male_tips, x="total_bill", y="tip", s=5)
 r, p = stats.pearsonr(male_tips["total_bill"], male_tips["tip"])
 mp.get_axes("A").set_title(f"Male (r={r:.2f})")
 
-mp.panel("B", 100, 120, margin_right=0)
+mp.panel("B", 120, 100, margin_right=0)
 cns.regplot(data=female_tips, x="total_bill", y="tip", s=5)
 r, p = stats.pearsonr(female_tips["total_bill"], female_tips["tip"])
 mp.get_axes("B").set_title(f"Female (r={r:.2f})")
@@ -213,17 +213,17 @@ no_corr = pd.DataFrame(
 
 mp = cns.multipanel(max_width=450)
 
-mp.panel("A", 90, 110)
+mp.panel("A", 110, 90)
 cns.regplot(data=strong_pos, x="x", y="y", s=5)
 r = stats.pearsonr(strong_pos["x"], strong_pos["y"])[0]
 mp.get_axes("A").set_title(f"Strong (r={r:.2f})")
 
-mp.panel("B", 90, 110)
+mp.panel("B", 110, 90)
 cns.regplot(data=weak, x="x", y="y", s=5)
 r = stats.pearsonr(weak["x"], weak["y"])[0]
 mp.get_axes("B").set_title(f"Weak (r={r:.2f})")
 
-mp.panel("C", 90, 110)
+mp.panel("C", 110, 90)
 cns.regplot(data=no_corr, x="x", y="y", s=5)
 r = stats.pearsonr(no_corr["x"], no_corr["y"])[0]
 mp.get_axes("C").set_title(f"None (r={r:.2f})")

--- a/examples/ridgeplot.py
+++ b/examples/ridgeplot.py
@@ -42,7 +42,7 @@ ax.set_title("Total Bill by Day (plasma cmap)")
 # Ridge plot for iris data
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare species distributions.
-cns.figure(150, 120)
+cns.figure(120, 150)
 ax = cns.ridgeplot(data=iris, x="sepal_length", y="species")
 ax.set_title("Sepal Length by Species")
 
@@ -51,7 +51,7 @@ ax.set_title("Sepal Length by Species")
 # Ridge plot with different measurements
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare petal measurements.
-cns.figure(150, 120)
+cns.figure(120, 150)
 ax = cns.ridgeplot(data=iris, x="petal_length", y="species")
 ax.set_title("Petal Length by Species")
 
@@ -62,11 +62,11 @@ ax.set_title("Petal Length by Species")
 # Side-by-side comparison.
 mp = cns.multipanel(max_width=400)
 
-mp.panel("A", 100, 150, pad_left=100, margin_right=20)
+mp.panel("A", 150, 100, pad_left=100, margin_right=20)
 cns.ridgeplot(data=iris, x="sepal_length", y="species")
 mp.get_axes("A").set_title("Sepal Length")
 
-mp.panel("B", 100, 150, pad_left=100, margin_right=0)
+mp.panel("B", 150, 100, pad_left=100, margin_right=0)
 cns.ridgeplot(data=iris, x="sepal_width", y="species")
 mp.get_axes("B").set_title("Sepal Width")
 
@@ -75,7 +75,7 @@ mp.get_axes("B").set_title("Sepal Width")
 # Ridge plot with tips by time
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare lunch and dinner distributions.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.ridgeplot(data=tips, x="tip", y="time")
 ax.set_title("Tip by Time")
 
@@ -94,7 +94,7 @@ for month in ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]:
 
 temporal_df = pd.DataFrame(temporal_data)
 
-cns.figure(150, 180)
+cns.figure(180, 150)
 ax = cns.ridgeplot(data=temporal_df, x="value", y="month")
 ax.set_title("Value Distribution Over Months")
 

--- a/examples/sankeyplot.py
+++ b/examples/sankeyplot.py
@@ -32,7 +32,7 @@ data = pd.DataFrame(
 # Basic Sankey diagram
 # ~~~~~~~~~~~~~~~~~~~~
 # Show flows from categories A, B, C to X, Y, Z.
-cns.figure(100, 80)
+cns.figure(80, 100)
 ax = cns.sankeyplot(data=data, x="x", y="y")
 ax.set_title("Basic Sankey")
 
@@ -62,7 +62,7 @@ rotated_label_data = pd.DataFrame(
     }
 )
 
-cns.figure(90, 110)
+cns.figure(110, 90)
 ax = cns.sankeyplot(data=rotated_label_data, x="source", y="target", label_rotation=45)
 ax.set_title("Rotated Labels")
 
@@ -84,7 +84,7 @@ treatment_data = pd.DataFrame(
     }
 )
 
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.sankeyplot(data=treatment_data, x="treatment", y="outcome")
 ax.set_title("Treatment to Outcome")
 
@@ -106,7 +106,7 @@ stage_data = pd.DataFrame(
     }
 )
 
-cns.figure(140, 100)
+cns.figure(100, 140)
 ax = cns.sankeyplot(data=stage_data, x="baseline", y="followup")
 ax.set_title("Disease Stage Progression")
 
@@ -126,7 +126,7 @@ cell_transition = pd.DataFrame(
     }
 )
 
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.sankeyplot(data=cell_transition, x="initial", y="final")
 ax.set_title("Cell Differentiation")
 
@@ -146,7 +146,7 @@ cluster_comparison = pd.DataFrame(
     }
 )
 
-cns.figure(140, 100)
+cns.figure(100, 140)
 ax = cns.sankeyplot(data=cluster_comparison, x="method_A", y="method_B")
 ax.set_title("Clustering Comparison")
 
@@ -164,7 +164,7 @@ response_flow = pd.DataFrame(
     }
 )
 
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.sankeyplot(data=response_flow, x="week_0", y="week_12")
 ax.set_title("Response at Week 0 to Week 12")
 
@@ -180,7 +180,7 @@ binary_data = pd.DataFrame(
     }
 )
 
-cns.figure(100, 80)
+cns.figure(80, 100)
 ax = cns.sankeyplot(data=binary_data, x="before", y="after")
 ax.set_title("Treatment Success")
 
@@ -196,6 +196,6 @@ biomarker_data = pd.DataFrame(
     }
 )
 
-cns.figure(120, 90)
+cns.figure(90, 120)
 ax = cns.sankeyplot(data=biomarker_data, x="biomarker", y="phenotype")
 ax.set_title("Biomarker to Phenotype")

--- a/examples/scanpy_integration.py
+++ b/examples/scanpy_integration.py
@@ -98,7 +98,7 @@ sc.pl.dotplot(
 # Dotplot with more genes
 # ~~~~~~~~~~~~~~~~~~~~~~~
 # Add additional markers.
-cns.figure(180, 150)
+cns.figure(150, 180)
 cns.setup_scanpy()
 ax = plt.gca()
 sc.pl.dotplot(
@@ -124,7 +124,7 @@ sc.pl.matrixplot(blobs, ["mitf", "axl"], groupby="blobs", ax=ax, show=False)
 # %%
 # Matrix plot with more genes
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-cns.figure(150, 100)
+cns.figure(100, 150)
 cns.setup_scanpy()
 ax = plt.gca()
 sc.pl.matrixplot(

--- a/examples/scatterplot.py
+++ b/examples/scatterplot.py
@@ -80,11 +80,11 @@ mp.get_axes("C").set_title("s=25 (large)")
 # Use ``alpha`` for overlapping points.
 mp = cns.multipanel(max_width=350)
 
-mp.panel("A", 100, 120)
+mp.panel("A", 120, 100)
 cns.scatterplot(data=tips, x="total_bill", y="tip", s=15, alpha=1.0)
 mp.get_axes("A").set_title("alpha=1.0 (opaque)")
 
-mp.panel("B", 100, 120)
+mp.panel("B", 120, 100)
 cns.scatterplot(data=tips, x="total_bill", y="tip", s=15, alpha=0.4)
 mp.get_axes("B").set_title("alpha=0.4 (transparent)")
 
@@ -125,7 +125,7 @@ cns.take_legend_out()
 # Scatter plot with style by category
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use different marker styles with ``style``.
-cns.figure(150, 120)
+cns.figure(120, 150)
 ax = cns.scatterplot(
     data=iris,
     x="sepal_length",
@@ -142,7 +142,7 @@ cns.take_legend_out()
 # Scatter plot with size encoding
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Map a variable to point size using ``size``.
-cns.figure(150, 120)
+cns.figure(120, 150)
 ax = cns.scatterplot(
     data=tips,
     x="total_bill",
@@ -171,7 +171,7 @@ cns.take_legend_out()
 # Scatter plot with quadrant labels
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Add annotations to different regions.
-cns.figure(140, 120)
+cns.figure(120, 140)
 ax = cns.scatterplot(data=iris, x="sepal_length", y="sepal_width", s=7, hue="species")
 
 mean_x = iris["sepal_length"].mean()
@@ -199,7 +199,7 @@ labels = ["A", "B", "C", "D"]
 label_idx = 0
 for var_y in ["sepal_width", "petal_width"]:
     for var_x in ["sepal_length", "petal_length"]:
-        mp.panel(labels[label_idx], 100, 120)
+        mp.panel(labels[label_idx], 120, 100)
         cns.scatterplot(data=iris, x=var_x, y=var_y, s=5, hue="species")
         mp.get_axes(labels[label_idx]).set_xlabel(var_x.replace("_", " ").title())
         mp.get_axes(labels[label_idx]).set_ylabel(var_y.replace("_", " ").title())

--- a/examples/seaborn_integration.py
+++ b/examples/seaborn_integration.py
@@ -34,7 +34,7 @@ flights = cns.datasets.load_dataset("flights")
 # Scatter plot with seaborn
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # cnsplots prepares the canvas while seaborn handles the plot.
-cns.figure(160, 220)
+cns.figure(220, 160)
 ax = plt.gca()
 sns.scatterplot(
     data=penguins,
@@ -54,7 +54,7 @@ ax.set_title("Seaborn with cns.figure")
 # Two seaborn plots on one cnsplots canvas
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Axes-level seaborn functions work naturally with matplotlib subplots.
-cns.figure(170, 320)
+cns.figure(320, 170)
 fig = plt.gcf()
 ax_left, ax_right = fig.subplots(1, 2)
 
@@ -97,7 +97,7 @@ monthly_passengers = (
 export_dir = Path(os.environ.get("CNSPLOTS_GALLERY_OUTPUT_DIR", "."))
 export_dir.mkdir(parents=True, exist_ok=True)
 
-cns.figure(150, 200)
+cns.figure(200, 150)
 ax = plt.gca()
 sns.lineplot(
     data=monthly_passengers,

--- a/examples/showcase.py
+++ b/examples/showcase.py
@@ -88,7 +88,7 @@ mp = cns.multipanel(
 )
 
 # Panel A: boxplot
-mp.panel("A", 100, 45, color_cycle=[cns.VIOLET])
+mp.panel("A", 45, 100, color_cycle=[cns.VIOLET])
 ax = cns.boxplot(
     data=tips_df, x="day", y="total_bill", pairs=[("Thur", "Sun"), ("Thur", "Fri")]
 )
@@ -99,7 +99,7 @@ ax.set_xticklabels(
 )
 
 # Panel B: violinplot
-mp.panel("B", 100, 45, color_cycle=[cns.CHOCOLATE])
+mp.panel("B", 45, 100, color_cycle=[cns.CHOCOLATE])
 ax = cns.violinplot(data=iris_df, x="species", y="sepal_width", pairs="all")
 ax.set_title("Violinplot")
 ax.set_xlabel("")
@@ -108,7 +108,7 @@ ax.set_xticklabels(
 )
 
 # Panel C: stripplot
-mp.panel("C", 100, 60, color_cycle="BlueRed")
+mp.panel("C", 60, 100, color_cycle="BlueRed")
 ax = cns.stripplot(data=tips_df, x="day", y="tip", hue="sex")
 legend = ax.get_legend()
 ax.legend(
@@ -123,13 +123,13 @@ ax.legend(
 ax.set_title("Stripplot")
 
 # Panel D: stackplot
-mp.panel("D", 100, 50, color_cycle=cns.get_hexcolors_from_apalette([2, 4], "Bold"))
+mp.panel("D", 50, 100, color_cycle=cns.get_hexcolors_from_apalette([2, 4], "Bold"))
 ax = cns.stackplot(data=tips_df, x="day", stack="sex", pairs=[("Thur", "Sun")])
 ax.set_title("Stackplot")
 ax.get_legend().set_title(None)
 
 # Panel E: barplot
-mp.panel("E", 40, 80, margin_left=35, margin_right=0, color_cycle=[cns.VIOLET])
+mp.panel("E", 80, 40, margin_left=35, margin_right=0, color_cycle=[cns.VIOLET])
 ax = cns.barplot(
     data=tips_df,
     y="day",
@@ -208,17 +208,17 @@ for text in ax.get_legend().get_texts():
 ax.set_title("Rocplot")
 
 # Panel N: sankeyplot
-mp.panel("N", 100, 30, pad_left=-30, color_cycle="Ecotyper4")
+mp.panel("N", 30, 100, pad_left=-30, color_cycle="Ecotyper4")
 ax = cns.sankeyplot(tips_df, x="day", y="sex", label_rotation=90)
 ax.set_title("Sankeyplot")
 
 # Panel O: ridgeplot
-mp.panel("O", 35, 80, pad_left=110, margin_right=0)
+mp.panel("O", 80, 35, pad_left=110, margin_right=0)
 ax = cns.ridgeplot(data=iris_df, x="petal_length", y="species")
 ax.set_title("Ridgeplot")
 
 # Panel P: slopeplot
-mp.panel("P", 65, 80, below="O", margin_top=10, pad_top=-5, margin_right=0)
+mp.panel("P", 80, 65, below="O", margin_top=10, pad_top=-5, margin_right=0)
 ax = cns.slopeplot(data=slope_df, x="site", y="value", hue="label", pair="pair")
 ax.set_title("Slopeplot")
 
@@ -254,7 +254,7 @@ ax.axvline(
 cns.take_legend_out()
 
 # Panel R: heatmapplot
-mp.panel("R", 90, 190, margin_top=-10, margin_right=0)
+mp.panel("R", 190, 90, margin_top=-10, margin_right=0)
 cmp = cns.heatmapplot(
     blobs,
     label="Z-score",
@@ -296,19 +296,19 @@ mp = cns.multipanel(
 detached_panel_layouts = []
 
 # Panel A: load pathology image
-ax = mp.panel("A", 237, 149, pad_left=-70)
+ax = mp.panel("A", 149, 237, pad_left=-70)
 ax.imshow(_read_showcase_image("image1.webp"))
 ax.set_title("Pathology Image")
 ax.set_axis_off()
 
 # Panel B: load immunofluorescence image
-ax = mp.panel("B", 102, 116, pad_left=-50)
+ax = mp.panel("B", 116, 102, pad_left=-50)
 ax.imshow(_read_showcase_image("image2.webp"))
 ax.set_title("Immunofluorescence")
 ax.set_axis_off()
 
 # Panel C: dotplot
-host_c = mp.panel("C", 90, 80, pad_top=20, pad_left=40, margin_right=20)
+host_c = mp.panel("C", 80, 90, pad_top=20, pad_left=40, margin_right=20)
 tips_minmax = tips_df.groupby(["day", "sex"]).agg({"total_bill": ["min", "size"]})
 tips_minmax.columns = ["min", "size"]
 tips_minmax = tips_minmax.reset_index()
@@ -364,7 +364,7 @@ ax.set_ylabel("Incidence")
 ax.set_title("Cumulative Incidence")
 
 # Panel E: load western blot image
-ax = mp.panel("E", 102, 116, below="B", pad_left=-50)
+ax = mp.panel("E", 116, 102, below="B", pad_left=-50)
 ax.imshow(_read_showcase_image("image4.webp"))
 ax.set_title("Western Blot")
 ax.set_axis_off()
@@ -392,20 +392,20 @@ ax.set_title("Qqplot")
 mp.newline()
 
 # Panel H: h&e histology image
-ax = mp.panel("H", 160, 319, pad_left=-60)
+ax = mp.panel("H", 319, 160, pad_left=-60)
 ax.imshow(_read_showcase_image("image3.webp"))
 ax.set_title("H&E Histology")
 ax.set_axis_off()
 
 # Panel I: placeholder plot
-ax = mp.panel("I", 155, 175, margin_right=0)
+ax = mp.panel("I", 175, 155, margin_right=0)
 cns.placeholderplot("A placeholder plot (155⨯175)\nYou can use to fill it up later.")
 ax.set_title("Placeholder")
 
 mp.newline()
 
 # Panel J: lollipopplot
-ax = mp.panel("J", 80, 40, color_cycle="NEJM", margin_right=15, margin_bottom=20)
+ax = mp.panel("J", 40, 80, color_cycle="NEJM", margin_right=15, margin_bottom=20)
 ax = cns.lollipopplot(data=tips_df, x="day", y="total_bill", pairs="all")
 ax.set_title("Lollipopplot")
 ax.set_xticklabels(
@@ -448,7 +448,7 @@ forest_ax.set_title("Forestplot")
 detached_panel_layouts.append((host_l, [forest_ax], 0.03, 0.04))
 
 # Panel M: upsetplot
-host_m = mp.panel("M", 120, 200, margin_right=0, pad_left=-100, pad_top=10)
+host_m = mp.panel("M", 200, 120, margin_right=0, pad_left=-100, pad_top=10)
 upset_axes = cns.upsetplot(
     upset_sets,
     fig=mp.fig,

--- a/examples/slopeplot.py
+++ b/examples/slopeplot.py
@@ -82,7 +82,7 @@ cns.slopeplot(data=data, x="site", y="value", hue="label", pair="subject")
 # ~~~~~~~~~~~~~~~~~~~
 # Compare only two sites for cleaner visualization.
 data_2sites = data[data["site"].isin(["site1", "site2"])]
-cns.figure(120, 150)
+cns.figure(150, 120)
 cns.slopeplot(data=data_2sites, x="site", y="value", hue="label", pair="subject")
 
 
@@ -106,7 +106,7 @@ treatment_data = pd.DataFrame(
     }
 )
 
-cns.figure(120, 150)
+cns.figure(150, 120)
 ax = cns.slopeplot(
     data=treatment_data,
     x="patient",
@@ -150,7 +150,7 @@ for gene in genes:
 gene_df = pd.DataFrame(gene_data)
 gene_df_tp53 = gene_df[gene_df["gene"] == "TP53"]
 
-cns.figure(120, 150)
+cns.figure(150, 120)
 ax = cns.slopeplot(
     data=gene_df_tp53,
     x="sample",
@@ -199,7 +199,7 @@ for subj in subjects:
 
 time_df = pd.DataFrame(time_data)
 
-cns.figure(180, 150)
+cns.figure(150, 180)
 two_timepoints = time_df[time_df["timepoint"].isin(["Day 0", "Day 14"])]
 ax = cns.slopeplot(
     data=two_timepoints,
@@ -214,7 +214,7 @@ ax.set_title("Time Course", pad=20)
 # %%
 # Wider figure for grouped comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-cns.figure(220, 150)
+cns.figure(150, 220)
 ax = cns.slopeplot(
     data=two_timepoints,
     x="group",
@@ -245,7 +245,7 @@ paired_data = pd.DataFrame(
     }
 )
 
-cns.figure(120, 150)
+cns.figure(150, 120)
 ax = cns.slopeplot(
     data=paired_data,
     x="patient",
@@ -264,14 +264,14 @@ mp = cns.multipanel(max_width=260)
 
 # Early stage
 early = paired_data[paired_data["stage"] == "Early"]
-mp.panel("A", 120, 100)
+mp.panel("A", 100, 120)
 cns.slopeplot(data=early, x="patient", y="expression", hue="tissue", pair="patient")
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Early Stage")
 
 # Late stage
 late = paired_data[paired_data["stage"] == "Late"]
-mp.panel("B", 120, 100, margin_right=0)
+mp.panel("B", 100, 120, margin_right=0)
 cns.slopeplot(data=late, x="patient", y="expression", hue="tissue", pair="patient")
 mp.get_axes("B").legend().remove()
 mp.get_axes("B").set_title("Late Stage")
@@ -324,17 +324,17 @@ cns.take_legend_out()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 mp = cns.multipanel(max_width=410)
 
-mp.panel("A", 120, 100, color_cycle="Set1")
+mp.panel("A", 100, 120, color_cycle="Set1")
 cns.slopeplot(data=data_2sites, x="site", y="value", hue="label", pair="subject")
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Set1")
 
-mp.panel("B", 120, 100, color_cycle="Tableau")
+mp.panel("B", 100, 120, color_cycle="Tableau")
 cns.slopeplot(data=data_2sites, x="site", y="value", hue="label", pair="subject")
 mp.get_axes("B").legend().remove()
 mp.get_axes("B").set_title("Tableau")
 
-mp.panel("C", 120, 100, color_cycle="Bold", margin_right=0)
+mp.panel("C", 100, 120, color_cycle="Bold", margin_right=0)
 cns.slopeplot(data=data_2sites, x="site", y="value", hue="label", pair="subject")
 mp.get_axes("C").legend().remove()
 mp.get_axes("C").set_title("Bold")

--- a/examples/stackplot.py
+++ b/examples/stackplot.py
@@ -25,7 +25,7 @@ tips = cns.datasets.load_dataset("tips")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Shows proportions that sum to 100% within each bar.
 # Use ``addcount=True`` to display total counts in the tick labels.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips, x="sex", stack="day", width=0.4, normalize=True, addcount=True
 )
@@ -36,7 +36,7 @@ ax.set_title("Basic Stacked Plot")
 # Stacked bar plot with absolute counts
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Set ``normalize=False`` to show actual counts instead of proportions.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips,
     x="day",
@@ -52,7 +52,7 @@ ax.set_title("Stacked Bar with Counts")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``pairs`` to test if proportions differ significantly between groups.
 # Fisher's exact test is used for 2x2 contingency tables.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips,
     x="day",
@@ -67,7 +67,7 @@ ax.set_title("With Selected Statistical Comparisons")
 # Stacked bar plot with custom stack order
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Control the order of stacked segments with ``stack_order``.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips,
     x="sex",
@@ -83,7 +83,7 @@ ax.set_title("Custom Stack Order")
 # Stacked bar plot with all pairwise comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``pairs="all"`` to test all possible pairs.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 ax = cns.stackplot(data=tips, x="day", stack="sex", normalize=True, pairs="all")
 ax.set_title("All Pairwise Comparisons")
 
@@ -92,7 +92,7 @@ ax.set_title("All Pairwise Comparisons")
 # Horizontal stacked bar plot
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Pass the bar variable to ``y`` for horizontal orientation.
-cns.figure(100, 120)
+cns.figure(120, 100)
 ax = cns.stackplot(
     data=tips,
     y="day",
@@ -108,7 +108,7 @@ ax.set_title("Horizontal Stacked Bar")
 # Stacked bar plot with custom bar order
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``bar_order`` to specify the order of bars on the axis.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips,
     x="day",
@@ -125,11 +125,11 @@ ax.set_title("Custom Bar Order")
 # Adjust bar width with the ``width`` parameter.
 mp = cns.multipanel(max_width=250)
 
-mp.panel("A", 80, 100)
+mp.panel("A", 100, 80)
 cns.stackplot(data=tips, x="day", stack="sex", normalize=True, width=0.3)
 mp.get_axes("A").set_title("width=0.3 (narrow)")
 
-mp.panel("B", 80, 100, margin_right=0)
+mp.panel("B", 100, 80, margin_right=0)
 cns.stackplot(data=tips, x="day", stack="sex", normalize=True, width=0.8)
 mp.get_axes("B").set_title("width=0.8 (wide)")
 
@@ -138,7 +138,7 @@ mp.get_axes("B").set_title("width=0.8 (wide)")
 # Stacked bar plot with custom palette
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use different color palettes for visual variety.
-cns.figure(120, 100, "Set2")
+cns.figure(100, 120, "Set2")
 ax = cns.stackplot(data=tips, x="day", stack="sex", normalize=True)
 ax.set_title("Set2 Palette")
 
@@ -149,11 +149,11 @@ ax.set_title("Set2 Palette")
 # Showcase multiple palette options.
 mp = cns.multipanel(max_width=250)
 
-mp.panel("A", 80, 100, color_cycle="Bold")
+mp.panel("A", 100, 80, color_cycle="Bold")
 cns.stackplot(data=tips, x="day", stack="sex", normalize=True)
 mp.get_axes("A").set_title("Bold")
 
-mp.panel("B", 80, 100, color_cycle="BlueRed", margin_right=0)
+mp.panel("B", 100, 80, color_cycle="BlueRed", margin_right=0)
 cns.stackplot(data=tips, x="day", stack="sex", normalize=True)
 mp.get_axes("B").set_title("BlueRed")
 
@@ -162,7 +162,7 @@ mp.get_axes("B").set_title("BlueRed")
 # Stacked bar plot with more than two categories
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Stack plots work with multiple categories in the stack variable.
-cns.figure(150, 100, "Ecotyper1")
+cns.figure(100, 150, "Ecotyper1")
 ax = cns.stackplot(data=tips, x="sex", stack="time", normalize=True, addcount=True)
 ax.set_title("Multiple Stack Categories")
 
@@ -186,7 +186,7 @@ cell_data = pd.DataFrame(
     }
 )
 
-cns.figure(180, 120, "Ecotyper2")
+cns.figure(120, 180, "Ecotyper2")
 ax = cns.stackplot(
     data=cell_data,
     x="sample",
@@ -206,7 +206,7 @@ ax.set_ylabel("Proportion")
 # Horizontal stacked bar with count labels
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Combine horizontal orientation with count labels on the category axis.
-cns.figure(120, 100, "Pastel1")
+cns.figure(100, 120, "Pastel1")
 ax = cns.stackplot(
     data=tips,
     y="day",
@@ -224,14 +224,14 @@ ax.set_title("Horizontal with Labels")
 # Compare the same data shown as counts vs proportions.
 mp = cns.multipanel(max_width=160)
 
-mp.panel("A", 80, 130)
+mp.panel("A", 130, 80)
 cns.stackplot(data=tips, x="day", stack="sex", normalize=False)
 mp.get_axes("A").set_title("Absolute Counts")
 mp.get_axes("A").set_ylabel("Count")
 
 mp.newline()
 
-mp.panel("B", 80, 130, margin_top=10)
+mp.panel("B", 130, 80, margin_top=10)
 cns.stackplot(data=tips, x="day", stack="sex", normalize=True, addcount=True)
 mp.get_axes("B").set_title("Normalized Proportions")
 mp.get_axes("B").set_ylabel("Proportion")

--- a/examples/stripplot.py
+++ b/examples/stripplot.py
@@ -22,7 +22,7 @@ iris = cns.datasets.load_dataset("iris")
 # Basic strip plot
 # ~~~~~~~~~~~~~~~~
 # Shows individual points with median line (default).
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stripplot(data=tips, x="day", y="total_bill", size=2, rasterized=True)
 ax.set_title("Basic Strip Plot with Median")
 
@@ -31,7 +31,7 @@ ax.set_title("Basic Strip Plot with Median")
 # Horizontal strip plot
 # ~~~~~~~~~~~~~~~~~~~~~
 # Swap x and y for horizontal orientation.
-cns.figure(100, 120)
+cns.figure(120, 100)
 ax = cns.stripplot(data=tips, x="total_bill", y="day", size=2)
 ax.set_title("Horizontal Strip Plot")
 
@@ -40,7 +40,7 @@ ax.set_title("Horizontal Strip Plot")
 # Strip plot without median line
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Set ``showmedian=False`` for points only.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stripplot(data=tips, x="day", y="total_bill", size=2, showmedian=False)
 ax.set_title("Strip Plot without Median")
 
@@ -49,7 +49,7 @@ ax.set_title("Strip Plot without Median")
 # Strip plot with mean marker
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``showmeans=True`` to show mean instead of median.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stripplot(
     data=tips, x="day", y="total_bill", size=2, showmedian=False, showmeans=True
 )
@@ -60,7 +60,7 @@ ax.set_title("Strip Plot with Mean Marker")
 # Strip plot with both median and mean
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Show both summary statistics.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stripplot(
     data=tips, x="day", y="total_bill", size=2, showmedian=True, showmeans=True
 )
@@ -71,7 +71,7 @@ ax.set_title("Strip Plot with Median and Mean")
 # Strip plot with sample counts
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``addcount=True`` to display sample sizes.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stripplot(data=tips, x="day", y="total_bill", size=2, addcount=True)
 ax.set_title("Strip Plot with Sample Counts")
 
@@ -80,7 +80,7 @@ ax.set_title("Strip Plot with Sample Counts")
 # Grouped strip plot with hue
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``hue`` for color-coded subgroups.
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.stripplot(data=tips, x="day", y="total_bill", size=2, hue="sex")
 cns.take_legend_out()
 ax.set_title("Grouped Strip Plot")
@@ -90,7 +90,7 @@ ax.set_title("Grouped Strip Plot")
 # Strip plot with dodging
 # ~~~~~~~~~~~~~~~~~~~~~~~
 # Points are automatically dodged when using hue.
-cns.figure(180, 100)
+cns.figure(100, 180)
 ax = cns.stripplot(data=tips, x="day", y="total_bill", size=3, hue="smoker", dodge=True)
 cns.take_legend_out()
 ax.set_title("Strip Plot with Dodging")
@@ -102,11 +102,11 @@ ax.set_title("Strip Plot with Dodging")
 # Adjust point size for visibility.
 mp = cns.multipanel(max_width=330)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 120, 80)
 cns.stripplot(data=iris, x="species", y="sepal_width", size=1)
 mp.get_axes("A").set_title("size=1 (small)")
 
-mp.panel("B", 80, 120, margin_right=0)
+mp.panel("B", 120, 80, margin_right=0)
 cns.stripplot(data=iris, x="species", y="sepal_width", size=5)
 mp.get_axes("B").set_title("size=5 (large)")
 
@@ -115,7 +115,7 @@ mp.get_axes("B").set_title("size=5 (large)")
 # Strip plot with custom palette
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use built-in color palettes.
-cns.figure(120, 100, "Tableau")
+cns.figure(100, 120, "Tableau")
 ax = cns.stripplot(data=tips, x="day", y="total_bill", size=2)
 ax.set_title("Tableau Palette")
 
@@ -126,11 +126,11 @@ ax.set_title("Tableau Palette")
 # Control the amount of horizontal jitter with the ``jitter`` parameter.
 mp = cns.multipanel(max_width=350)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 120, 80)
 cns.stripplot(data=tips, x="day", y="total_bill", size=2, jitter=0.1)
 mp.get_axes("A").set_title("jitter=0.1 (tight)")
 
-mp.panel("B", 80, 120)
+mp.panel("B", 120, 80)
 cns.stripplot(data=tips, x="day", y="total_bill", size=2, jitter=0.4)
 mp.get_axes("B").set_title("jitter=0.4 (spread)")
 
@@ -141,11 +141,11 @@ mp.get_axes("B").set_title("jitter=0.4 (spread)")
 # Adjust transparency for overlapping points.
 mp = cns.multipanel(max_width=330)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 120, 80)
 cns.stripplot(data=tips, x="day", y="total_bill", size=4, alpha=1.0)
 mp.get_axes("A").set_title("alpha=1.0 (opaque)")
 
-mp.panel("B", 80, 120, margin_right=0)
+mp.panel("B", 120, 80, margin_right=0)
 cns.stripplot(data=tips, x="day", y="total_bill", size=4, alpha=0.3)
 mp.get_axes("B").set_title("alpha=0.3 (transparent)")
 
@@ -154,7 +154,7 @@ mp.get_axes("B").set_title("alpha=0.3 (transparent)")
 # Strip plot with custom order
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Specify category order with the ``order`` parameter.
-cns.figure(120, 100)
+cns.figure(100, 120)
 ax = cns.stripplot(
     data=tips,
     x="day",
@@ -176,7 +176,7 @@ iris_melted = iris.melt(
     value_name="value",
 )
 
-cns.figure(120, 200)
+cns.figure(200, 120)
 ax = cns.stripplot(
     data=iris_melted,
     x="measurement",

--- a/examples/survivalplot.py
+++ b/examples/survivalplot.py
@@ -38,7 +38,7 @@ plt.title("Kaplan-Meier Survival Curves")
 # Survival plot with legend outside
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Move legend to avoid overlapping curves.
-cns.figure(180, 150)
+cns.figure(150, 180)
 cns.survivalplot(
     data=waltons, duration="T", event="E", hue="group", hue_order=["miR-137", "control"]
 )
@@ -129,7 +129,7 @@ clinical_df = pd.DataFrame(survival_data)
 # Survival plot with three groups
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare multiple treatment arms.
-cns.figure(180, 150)
+cns.figure(150, 180)
 cns.survivalplot(
     data=clinical_df,
     duration="time",
@@ -146,7 +146,7 @@ plt.xlabel("Time (Months)")
 # Cumulative incidence with three groups
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Show cumulative events for multiple groups.
-cns.figure(180, 150)
+cns.figure(150, 180)
 ax = cns.cumulativeincidenceplot(
     data=clinical_df,
     duration="time",
@@ -167,7 +167,7 @@ plt.title("Cumulative Incidence - Three Arms")
 # Compare survival vs cumulative incidence.
 mp = cns.multipanel(max_width=450)
 
-mp.panel("A", 120, 160)
+mp.panel("A", 160, 120)
 cns.survivalplot(
     data=waltons,
     duration="T",
@@ -177,7 +177,7 @@ cns.survivalplot(
 mp.get_axes("A").legend().remove()
 mp.get_axes("A").set_title("Survival Probability")
 
-mp.panel("B", 120, 160)
+mp.panel("B", 160, 120)
 cns.cumulativeincidenceplot(
     data=waltons,
     duration="T",
@@ -229,7 +229,7 @@ plt.xlabel("Time (Months)")
 # Cumulative incidence with custom x-axis ticks
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Control the time axis display.
-cns.figure(180, 150)
+cns.figure(150, 180)
 ax = cns.cumulativeincidenceplot(
     data=waltons,
     duration="T",

--- a/examples/vennplot.py
+++ b/examples/vennplot.py
@@ -50,7 +50,7 @@ upregulated_genes = {"TP53", "BRCA1", "MYC", "EGFR", "KRAS", "PIK3CA", "PTEN"}
 mutated_genes = {"TP53", "KRAS", "PIK3CA", "APC", "BRAF", "NRAS"}
 methylated_genes = {"BRCA1", "CDKN2A", "MLH1", "TP53", "MGMT"}
 
-cns.figure(120, 100)
+cns.figure(100, 120)
 cns.vennplot(
     [upregulated_genes, mutated_genes, methylated_genes],
     ["Upregulated", "Mutated", "Methylated"],
@@ -66,7 +66,7 @@ condition_a_degs = set(["gene" + str(i) for i in range(1, 51)])  # 50 genes
 condition_b_degs = set(["gene" + str(i) for i in range(30, 80)])  # 50 genes
 condition_c_degs = set(["gene" + str(i) for i in range(45, 95)])  # 50 genes
 
-cns.figure(120, 100)
+cns.figure(100, 120)
 cns.vennplot(
     [condition_a_degs, condition_b_degs, condition_c_degs],
     ["Condition A", "Condition B", "Condition C"],
@@ -105,7 +105,7 @@ high_coverage = {"S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8"}
 low_duplication = {"S1", "S3", "S4", "S6", "S7", "S9", "S10"}
 clean_data = {"S1", "S2", "S4", "S5", "S7", "S8", "S10", "S11"}
 
-cns.figure(120, 100)
+cns.figure(100, 120)
 cns.vennplot(
     [high_coverage, low_duplication, clean_data], ["High Cov", "Low Dup", "Clean"]
 )
@@ -132,7 +132,7 @@ apoptosis_genes = {"BAX", "BCL2", "CASP3", "CASP9", "CYCS", "TP53", "BID"}
 cell_cycle_genes = {"CDK1", "CDK2", "CCNA", "CCNB", "TP53", "RB1", "E2F1"}
 dna_repair_genes = {"BRCA1", "BRCA2", "ATM", "ATR", "TP53", "RAD51", "CHEK2"}
 
-cns.figure(120, 100)
+cns.figure(100, 120)
 cns.vennplot(
     [apoptosis_genes, cell_cycle_genes, dna_repair_genes],
     ["Apoptosis", "Cell Cycle", "DNA Repair"],

--- a/examples/violinplot.py
+++ b/examples/violinplot.py
@@ -23,7 +23,7 @@ iris = cns.datasets.load_dataset("iris")
 # Basic violin plot
 # ~~~~~~~~~~~~~~~~~
 # Simple violin plot with embedded box plot (default).
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.violinplot(data=tips, x="day", y="total_bill")
 ax.set_title("Basic Violin Plot")
 
@@ -32,7 +32,7 @@ ax.set_title("Basic Violin Plot")
 # Violin plot with statistical testing
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``pairs="all"`` for Mann-Whitney U tests between all groups.
-cns.figure(150, 100, "Tableau")
+cns.figure(100, 150, "Tableau")
 ax = cns.violinplot(data=tips, x="day", y="total_bill", pairs="all")
 ax.set_title("Violin Plot with All Pairwise Comparisons")
 
@@ -41,7 +41,7 @@ ax.set_title("Violin Plot with All Pairwise Comparisons")
 # Violin plot with specific pair comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Test only selected pairs.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.violinplot(
     data=iris,
     x="species",
@@ -55,7 +55,7 @@ ax.set_title("Selected Pair Comparisons")
 # Violin plot without embedded box plot
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Set ``add_box=False`` for cleaner violin shapes.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.violinplot(data=tips, x="day", y="total_bill", add_box=False)
 ax.set_title("Violin Plot without Box")
 
@@ -66,11 +66,11 @@ ax.set_title("Violin Plot without Box")
 # Adjust violin body width with the ``width`` parameter.
 mp = cns.multipanel(max_width=330)
 
-mp.panel("A", 80, 120)
+mp.panel("A", 120, 80)
 cns.violinplot(data=tips, x="day", y="total_bill", width=0.4)
 mp.get_axes("A").set_title("width=0.4 (narrow)")
 
-mp.panel("B", 80, 120, margin_right=0)
+mp.panel("B", 120, 80, margin_right=0)
 cns.violinplot(data=tips, x="day", y="total_bill", width=0.9)
 mp.get_axes("B").set_title("width=0.9 (wide)")
 
@@ -79,7 +79,7 @@ mp.get_axes("B").set_title("width=0.9 (wide)")
 # Grouped violin plot with hue
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``hue`` for side-by-side violins within each category.
-cns.figure(120, 180)
+cns.figure(180, 120)
 ax = cns.violinplot(
     data=tips,
     x="day",
@@ -96,7 +96,7 @@ ax.set_title("Grouped Violin Plot")
 # ~~~~~~~~~~~~~~~~~
 # Use ``split=True`` to show two hue levels as halves of the same violin.
 # This is useful for direct comparison of two groups.
-cns.figure(150, 100)
+cns.figure(100, 150)
 ax = cns.violinplot(
     data=tips,
     x="day",
@@ -116,15 +116,15 @@ ax.set_title("Split Violin Plot")
 # Options: "box" (default), "quart", "point", "stick", None
 mp = cns.multipanel(max_width=450)
 
-mp.panel("A", 80, 110)
+mp.panel("A", 110, 80)
 cns.violinplot(data=tips, x="day", y="total_bill", inner="quart", add_box=False)
 mp.get_axes("A").set_title("inner='quart'")
 
-mp.panel("B", 80, 110)
+mp.panel("B", 110, 80)
 cns.violinplot(data=tips, x="day", y="total_bill", inner="point", add_box=False)
 mp.get_axes("B").set_title("inner='point'")
 
-mp.panel("C", 80, 110)
+mp.panel("C", 110, 80)
 cns.violinplot(data=tips, x="day", y="total_bill", inner="stick", add_box=False)
 mp.get_axes("C").set_title("inner='stick'")
 
@@ -133,7 +133,7 @@ mp.get_axes("C").set_title("inner='stick'")
 # Horizontal violin plot
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Swap x and y for horizontal orientation.
-cns.figure(100, 150)
+cns.figure(150, 100)
 ax = cns.violinplot(
     data=iris,
     x="sepal_width",
@@ -147,7 +147,7 @@ ax.set_title("Horizontal Violin Plot")
 # Violin plot with custom palette
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use built-in palettes or custom colors.
-cns.figure(150, 100, "Bold")
+cns.figure(100, 150, "Bold")
 ax = cns.violinplot(data=tips, x="day", y="total_bill")
 ax.set_title("Bold Palette")
 
@@ -179,7 +179,7 @@ ax.set_title("Setosa Measurements Distribution")
 # Violin plot with grouped comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Statistical testing across hue groups.
-cns.figure(120, 150)
+cns.figure(150, 120)
 ax = cns.violinplot(
     data=tips,
     x="day",

--- a/examples/volcanoplot.py
+++ b/examples/volcanoplot.py
@@ -134,7 +134,7 @@ cns.volcanoplot(
 # Wide volcano plot
 # ~~~~~~~~~~~~~~~~~
 # Emphasize fold change axis.
-cns.figure(280, 180)
+cns.figure(180, 280)
 cns.volcanoplot(
     de,
     x="log2FoldChange",
@@ -148,7 +148,7 @@ cns.volcanoplot(
 # Tall volcano plot
 # ~~~~~~~~~~~~~~~~~
 # Emphasize significance axis.
-cns.figure(180, 250)
+cns.figure(250, 180)
 cns.volcanoplot(
     de,
     x="log2FoldChange",

--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -876,8 +876,8 @@ class multipanel:
     def panel(
         self,
         label: str | None = None,
-        height: int | float | None = None,
         width: int | float | None = None,
+        height: int | float | None = None,
         pad_left: int | float | None = None,
         pad_top: int | float | None = None,
         *,
@@ -897,10 +897,10 @@ class multipanel:
         label : str or None, optional
             Panel label (e.g., "A", "B", "C"). If None, uses automatic
             sequential labeling (A, B, C, ...).
-        height : int, optional
-            Axes height in pixels. If None, uses cns.settings.panel_height.
         width : int, optional
             Axes width in pixels. If None, uses cns.settings.panel_width.
+        height : int, optional
+            Axes height in pixels. If None, uses cns.settings.panel_height.
         pad_left : int, optional
             Extra horizontal gap in pixels between the panel label and the
             leftmost visible left-side axis decoration. The layout reserves the
@@ -986,10 +986,10 @@ class multipanel:
             color_cycle = settings.palette_qual
         if color_map is None:
             color_map = settings.palette_seq
-        if height is None:
-            height = settings.panel_height
         if width is None:
             width = settings.panel_width
+        if height is None:
+            height = settings.panel_height
         if pad_left is None:
             pad_left = settings.panel_pad_left
         if pad_top is None:

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -173,7 +173,7 @@ def _capture_detached_axes_layout(
     return new_layouts
 
 
-def figure(height=None, width=None, color_cycle=None, color_map=None):
+def figure(width=None, height=None, color_cycle=None, color_map=None):
     """
     Initialize a new figure with custom size and styling.
 
@@ -182,10 +182,10 @@ def figure(height=None, width=None, color_cycle=None, color_map=None):
 
     Parameters
     ----------
-    height : int, default: 150
-        Height of the figure in pixels.
     width : int, default: 150
         Width of the figure in pixels.
+    height : int, default: 150
+        Height of the figure in pixels.
     color_cycle : str, default: None
         Name of the qualitative color palette to use for the color cycle.
         If None, uses cns.settings.palette_qual.
@@ -216,18 +216,18 @@ def figure(height=None, width=None, color_cycle=None, color_map=None):
     Examples
     --------
     >>> import cnsplots as cns
-    >>> cns.figure(height=200, width=300)
+    >>> cns.figure(width=300, height=200)
     >>> cns.boxplot(data=df, x="group", y="value")
     >>> cns.savefig("plot.pdf")
 
     >>> # With custom color scheme
-    >>> cns.figure(height=150, width=150, color_cycle="Set2", color_map="parula")
+    >>> cns.figure(width=150, height=150, color_cycle="Set2", color_map="parula")
     >>> cns.heatmapplot(adata)
     """
-    if height is None:
-        height = settings.figure_height
     if width is None:
         width = settings.figure_width
+    if height is None:
+        height = settings.figure_height
     if color_cycle is None:
         color_cycle = settings.palette_qual
     if color_map is None:

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -51,7 +51,7 @@ def placeholderplot(description: str) -> Axes:
     Examples
     --------
     >>> import cnsplots as cns
-    >>> cns.figure(100, 200)
+    >>> cns.figure(200, 100)
     >>> ax = cns.placeholderplot("A description to be centered in the panel")
     >>> ax.set_title("Placeholder")
     """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -933,11 +933,11 @@ def test_savefig_default_bounds_match_jpg_pdf_and_svg(
     try:
         mp = cns.multipanel(max_width=220, title="Figure 1", loc="left")
 
-        mp.panel("A", 90, 70, color_cycle=[cns.VIOLET])
+        mp.panel("A", 70, 90, color_cycle=[cns.VIOLET])
         ax = cns.boxplot(data=categorical_df, x="group", y="value")
         ax.set_title("Boxplot")
 
-        mp.panel("B", 90, 70, color_cycle="BlueRed")
+        mp.panel("B", 70, 90, color_cycle="BlueRed")
         ax = cns.stripplot(data=categorical_df, x="group", y="value", hue="hue")
         ax.set_title("Stripplot")
 
@@ -1244,7 +1244,7 @@ def test_utils_helpers_and_showcase_data(
 
 
 def test_figure_keeps_fixed_size_with_overflowing_artists() -> None:
-    cns.figure(120, 100)
+    cns.figure(100, 120)
     fig = plt.gcf()
     initial_size = tuple(fig.get_size_inches())
     ax = plt.gca()

--- a/tests/test_methods_and_helpers.py
+++ b/tests/test_methods_and_helpers.py
@@ -180,7 +180,7 @@ def test_sankey_helpers(sankey_df: pd.DataFrame) -> None:
 
 
 def test_phylo_helper_functions(phylo_adata: ad.AnnData) -> None:
-    cns.figure(150, 120)
+    cns.figure(120, 150)
     _phylo.phyloplot(phylo_adata)
     assert len(plt.gcf().axes) == 5
 

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -604,7 +604,7 @@ def test_heatmap_and_dotplot(
 
 def test_dotplot_respects_multipanel_bounds(dotplot_df: pd.DataFrame) -> None:
     mp = cns.multipanel(max_width=180)
-    host_ax = mp.panel("A", height=80, width=80, pad_left=5, pad_top=5)
+    host_ax = mp.panel("A", width=80, height=80, pad_left=5, pad_top=5)
     host_box = host_ax.get_position().frozen()
 
     dp = cns.dotplot(
@@ -643,7 +643,7 @@ def test_dotplot_respects_multipanel_bounds(dotplot_df: pd.DataFrame) -> None:
 
 def test_dotplot_tracks_multipanel_relayout(dotplot_df: pd.DataFrame) -> None:
     mp = cns.multipanel(max_width=220)
-    host_ax = mp.panel("A", height=80, width=80, pad_left=5, pad_top=5)
+    host_ax = mp.panel("A", width=80, height=80, pad_left=5, pad_top=5)
     initial_host_box = host_ax.get_position().frozen()
 
     dp = cns.dotplot(
@@ -662,7 +662,7 @@ def test_dotplot_tracks_multipanel_relayout(dotplot_df: pd.DataFrame) -> None:
     assert dp.ax_heatmap is not None
 
     mp.newline()
-    mp.panel("B", height=200, width=100)
+    mp.panel("B", width=100, height=200)
 
     resized_host_box = host_ax.get_position().frozen()
     heatmap_box = dp.ax_heatmap.get_position().frozen()
@@ -673,7 +673,7 @@ def test_dotplot_tracks_multipanel_relayout(dotplot_df: pd.DataFrame) -> None:
 
 def test_heatmapplot_tracks_multipanel_relayout(heatmap_adata: ad.AnnData) -> None:
     mp = cns.multipanel(max_width=220)
-    host_ax = mp.panel("A", height=80, width=80, pad_left=5, pad_top=5)
+    host_ax = mp.panel("A", width=80, height=80, pad_left=5, pad_top=5)
     initial_host_box = host_ax.get_position().frozen()
 
     cmp = cns.heatmapplot(
@@ -685,7 +685,7 @@ def test_heatmapplot_tracks_multipanel_relayout(heatmap_adata: ad.AnnData) -> No
     assert cmp.ax_heatmap is not None
 
     mp.newline()
-    mp.panel("B", height=200, width=100)
+    mp.panel("B", width=100, height=200)
 
     resized_host_box = host_ax.get_position().frozen()
     heatmap_box = cmp.ax_heatmap.get_position().frozen()
@@ -698,11 +698,11 @@ def test_histplot_colorbars_align_in_multipanel() -> None:
     data = _bivariate_hist_df()
     mp = cns.multipanel(max_width=400)
 
-    ax_a = mp.panel("A", 120, 140)
+    ax_a = mp.panel("A", 140, 120)
     cns.histplot(data=data, x="x", y="y", cbar=True, cmap="hot")
     ax_a.set_title("hot colormap")
 
-    ax_b = mp.panel("B", 120, 140)
+    ax_b = mp.panel("B", 140, 120)
     cns.histplot(data=data, x="x", y="y", cbar=True, cmap="BuRd_custom")
     ax_b.set_title("BuRd_custom colormap")
 
@@ -725,7 +725,7 @@ def test_histplot_colorbars_align_in_multipanel() -> None:
 def test_histplot_colorbar_tracks_multipanel_relayout() -> None:
     data = _bivariate_hist_df()
     mp = cns.multipanel(max_width=220)
-    host_ax = mp.panel("A", height=80, width=80, pad_left=5, pad_top=5)
+    host_ax = mp.panel("A", width=80, height=80, pad_left=5, pad_top=5)
     cns.histplot(data=data, x="x", y="y", cbar=True, cmap="hot")
 
     colorbar = host_ax.collections[0].colorbar
@@ -739,7 +739,7 @@ def test_histplot_colorbar_tracks_multipanel_relayout() -> None:
     initial_cbar_box = colorbar.ax.get_position().frozen()
 
     mp.newline()
-    mp.panel("B", height=200, width=100)
+    mp.panel("B", width=100, height=200)
     fig.canvas.draw()
 
     resized_host_box = host_ax.get_position().frozen()
@@ -755,7 +755,7 @@ def test_histplot_colorbar_tracks_multipanel_relayout() -> None:
 def test_histplot_with_explicit_cbar_ax_leaves_it_untouched() -> None:
     data = _bivariate_hist_df()
     mp = cns.multipanel(max_width=220)
-    host_ax = mp.panel("A", height=80, width=80, pad_left=5, pad_top=5)
+    host_ax = mp.panel("A", width=80, height=80, pad_left=5, pad_top=5)
     fig = mp.fig
     assert fig is not None
     cbar_ax = fig.add_axes((0.8, 0.2, 0.05, 0.5))
@@ -772,7 +772,7 @@ def test_histplot_with_explicit_cbar_ax_leaves_it_untouched() -> None:
     )
 
     mp.newline()
-    mp.panel("B", height=200, width=100)
+    mp.panel("B", width=100, height=200)
     fig.canvas.draw()
 
     assert host_ax.collections[0].colorbar is not None
@@ -858,7 +858,7 @@ def test_scanpy_umap_colorbar_tracks_multipanel_relayout(
     sc, blobs = scanpy_blobs
     mp = cns.multipanel(max_width=220)
     cns.setup_scanpy()
-    host_ax = mp.panel("A", height=90, width=90, pad_left=5, pad_top=5)
+    host_ax = mp.panel("A", width=90, height=90, pad_left=5, pad_top=5)
     sc.pl.umap(blobs, color="mitf", size=8, ax=host_ax, show=False, cmap="gnuplot")
 
     colorbar = _linked_colorbar(host_ax)
@@ -876,7 +876,7 @@ def test_scanpy_umap_colorbar_tracks_multipanel_relayout(
     assert cbar_box.x0 >= host_box.x1 - 1e-9
 
     mp.newline()
-    mp.panel("B", height=160, width=100)
+    mp.panel("B", width=100, height=160)
     fig.canvas.draw()
 
     assert _relative_axes_bounds(host_ax, colorbar.ax) == pytest.approx(
@@ -890,7 +890,7 @@ def test_scanpy_categorical_umap_does_not_capture_detached_axes(
     sc, blobs = scanpy_blobs
     mp = cns.multipanel(max_width=220)
     cns.setup_scanpy()
-    host_ax = mp.panel("A", height=90, width=90)
+    host_ax = mp.panel("A", width=90, height=90)
     sc.pl.umap(blobs, color="blobs", size=8, ax=host_ax, show=False)
 
     fig = mp.fig
@@ -903,7 +903,7 @@ def test_scanpy_categorical_umap_does_not_capture_detached_axes(
 
 def test_multipanel_linked_colorbar_tracks_relayout() -> None:
     mp = cns.multipanel(max_width=220)
-    host_ax = mp.panel("A", height=90, width=90)
+    host_ax = mp.panel("A", width=90, height=90)
     fig = mp.fig
     assert fig is not None
 
@@ -911,7 +911,7 @@ def test_multipanel_linked_colorbar_tracks_relayout() -> None:
     colorbar = fig.colorbar(scatter, ax=host_ax)
 
     mp.newline()
-    mp.panel("B", height=160, width=100)
+    mp.panel("B", width=100, height=160)
     fig.canvas.draw()
     rendered_relative_box = _relative_axes_bounds(host_ax, colorbar.ax)
 
@@ -922,7 +922,7 @@ def test_multipanel_linked_colorbar_tracks_relayout() -> None:
     assert cbar_box.x0 >= host_box.x1 - 1e-9
 
     mp.newline()
-    mp.panel("C", height=120, width=80)
+    mp.panel("C", width=80, height=120)
     fig.canvas.draw()
 
     assert _relative_axes_bounds(host_ax, colorbar.ax) == pytest.approx(
@@ -933,7 +933,7 @@ def test_multipanel_linked_colorbar_tracks_relayout() -> None:
 
 def test_multipanel_linked_colorbar_ignores_explicit_cbar_axes() -> None:
     mp = cns.multipanel(max_width=220)
-    host_ax = mp.panel("A", height=90, width=90)
+    host_ax = mp.panel("A", width=90, height=90)
     fig = mp.fig
     assert fig is not None
 
@@ -943,7 +943,7 @@ def test_multipanel_linked_colorbar_ignores_explicit_cbar_axes() -> None:
     initial_cbar_box = colorbar.ax.get_position().frozen()
 
     mp.newline()
-    mp.panel("B", height=160, width=100)
+    mp.panel("B", width=100, height=160)
     fig.canvas.draw()
 
     assert colorbar.ax.get_position().bounds == pytest.approx(initial_cbar_box.bounds)
@@ -977,7 +977,7 @@ def test_gseaplot_colorbar_aligns_with_host_axes_in_multipanel(
     )
 
     mp = cns.multipanel(max_width=240)
-    host_ax = mp.panel("A", height=90, width=100)
+    host_ax = mp.panel("A", width=100, height=90)
     plt.sca(host_ax)
     cns.gseaplot(gsea_plot_df, y="Clean_Term", color="NES", top_term=2)
 
@@ -998,7 +998,7 @@ def test_gseaplot_colorbar_aligns_with_host_axes_in_multipanel(
     assert cbar_box.x0 - host_box.x1 < host_box.width * 0.2
 
     mp.newline()
-    mp.panel("B", height=120, width=100)
+    mp.panel("B", width=100, height=120)
     fig.canvas.draw()
 
     assert _relative_axes_bounds(host_ax, colorbar.ax) == pytest.approx(
@@ -1048,7 +1048,7 @@ def test_genomics_plots(
     with pytest.raises(TypeError, match="Parameter 'n_show' must be an integer"):
         cns.volcanoplot(volcano_df, n_show=True)
 
-    cns.figure(160, 140)
+    cns.figure(140, 160)
     ax5 = cns.gseaplot(gsea_plot_df, y="Clean_Term", color="NES", top_term=3)
     assert ax5.get_xlabel() == "Normalized Enrichment Score (NES)"
     assert [tick.get_text() for tick in ax5.get_yticklabels()] == [

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -421,7 +421,7 @@ def test_line_scatter_reg_and_slope_plots(
 
 def test_placeholderplot_renders_centered_placeholder() -> None:
     with cns.settings.context(title_fontsize=11, title_fontweight="normal"):
-        cns.figure(120, 180)
+        cns.figure(180, 120)
         plt.plot([0, 1], [0, 1])
         ax = cns.placeholderplot("A description to be centered in the panel")
 

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -449,7 +449,7 @@ def test_public_prerank_and_gseaplot_use_real_gseapy_backend() -> None:
     assert nes_by_term["GO_BOTTOM_PATHWAY"] < -1.5
     assert (result["FDR q-val"].astype(float) < 0.25).all()
 
-    cns.figure(160, 140)
+    cns.figure(140, 160)
     ax = cns.gseaplot(result, y="Clean_Term", top_term=2)
     offsets = np.asarray(ax.collections[0].get_offsets(), dtype=float)
     rendered_nes = {
@@ -511,12 +511,21 @@ def test_public_prerank_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
 
+def test_public_figure_uses_width_first_order() -> None:
+    parameters = list(inspect.signature(cns.figure).parameters)
+    assert parameters[:2] == ["width", "height"]
+
+    cns.figure(96, 72)
+
+    assert tuple(plt.gcf().get_size_inches()) == pytest.approx((96 / 72, 72 / 72))
+
+
 def test_public_figure_and_save_alias_contract(output_dir: Path) -> None:
     png_path = output_dir / "nested" / "plot.png"
     pdf_path = output_dir / "nested" / "plot.pdf"
     svg_path = output_dir / "nested" / "plot.svg"
 
-    cns.figure(72, 96)
+    cns.figure(96, 72)
     plt.plot([0, 1], [0, 1])
     plt.title("Contract Export")
 
@@ -611,12 +620,15 @@ def test_public_multipanel_layout_contract(
     categorical_df: pd.DataFrame,
     numeric_df: pd.DataFrame,
 ) -> None:
+    parameters = list(inspect.signature(cns.multipanel.panel).parameters)
+    assert parameters[2:4] == ["width", "height"]
+
     mp = cns.multipanel(max_width=120, title="Overview", loc="left")
 
-    mp.panel("A", width=70, height=60)
+    mp.panel("A", 70, 60)
     ax1 = cns.boxplot(categorical_df, x="group", y="value")
 
-    mp.panel("B", width=70, height=60)
+    mp.panel("B", 70, 60)
     ax2 = cns.scatterplot(numeric_df, x="x", y="y")
 
     fig = plt.gcf()
@@ -627,6 +639,13 @@ def test_public_multipanel_layout_contract(
 
     ax1_bbox = ax1.get_window_extent(renderer=renderer)
     ax2_bbox = ax2.get_window_extent(renderer=renderer)
+    display_scale = fig.dpi / 72
+    assert (ax1_bbox.width, ax1_bbox.height) == pytest.approx(
+        (70 * display_scale, 60 * display_scale)
+    )
+    assert (ax2_bbox.width, ax2_bbox.height) == pytest.approx(
+        (70 * display_scale, 60 * display_scale)
+    )
     title = next(text for text in fig.findobj(Text) if text.get_text() == "Overview")
     title_bbox = title.get_window_extent(renderer=renderer)
 


### PR DESCRIPTION
## What changed

- Reorder `cns.figure` positional dimensions to `(width, height)`.
- Reorder `multipanel.panel` positional dimensions to `(label, width, height)`.
- Migrate repository call sites, tests, examples, and documentation while preserving existing canvas and panel sizes.
- Support both Sphinx 8 and Sphinx 9 document context APIs in the custom autosummary extension.

## How it was tested

- `make test` — 277 tests passed with 100% coverage.
- `make lint` — all lint, formatting, type, and documentation checks passed.
- `cd docs && make html` — documentation built successfully and all 36 gallery examples executed.

## Risks and follow-ups

- This is a breaking change for downstream positional callers, which must swap their width and height arguments. Keyword callers are unaffected.
- No known follow-up work.