### PR TITLE
🐛 Preserve Cox formula coefficients

### DIFF
--- a/examples/forestplot.py
+++ b/examples/forestplot.py
@@ -58,7 +58,6 @@ model = cns.methods.CoxModel(
         "C(Cirrhosis, levels=['no', 'yes'])",
         "C(TNM_staging, levels=['I', 'I-II'])",
         "Predictor + AFP_cat + Cirrhosis + C(TNM_staging, levels=['I', 'I-II'])",
-        "AFP_cat + Predictor + Cirrhosis + C(TNM_staging, levels=['I', 'I-II'])",
     ],
     hue="Group",
 )
@@ -175,7 +174,7 @@ model = cns.methods.CoxModel(
     ],
 )
 model.fit()
-cns.figure(210, 40, ["black"])
+cns.figure(210, 90, ["black"])
 ax = cns.forestplot(model)
 ax.set_title("Multivariate Cox Regression")
 

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -68,8 +68,9 @@ class CoxModel:
 
     Notes
     -----
-    The fit() method performs univariate Cox regression for each variate,
-    optionally stratified by hue groups. Results include:
+    The fit() method fits one Cox regression model for each formula,
+    optionally stratified by hue groups. Every fitted coefficient is retained.
+    Results include:
 
     - exp(coef): Hazard ratio
     - exp(coef) lower 95%, exp(coef) upper 95%: 95% confidence interval
@@ -147,9 +148,10 @@ class CoxModel:
         - hue_group: Group name (or 'All' if no grouping)
         - p: P-value
 
-        The display_label is automatically extracted from formula strings,
-        removing formula syntax (Q(), C(), np.log(), etc.) for cleaner
-        visualization.
+        For formulas with one coefficient, display_label is automatically
+        extracted from the formula string. For formulas with multiple
+        coefficients, it combines the formula and coefficient names so every
+        estimate remains distinct in visualizations.
 
         Examples
         --------
@@ -190,7 +192,11 @@ class CoxModel:
                         event_col=self.event,
                         formula=var,
                     )
-                    summary = cph.summary.iloc[[0]].reset_index()
+                    summary = cph.summary.reset_index()
+                    if summary.empty:
+                        raise ValueError(
+                            f"Formula {var!r} produced no fitted coefficients"
+                        )
                     summary["analysis"] = var
                     summary["hue_group"] = hue_group
                     all_results.append(summary)
@@ -211,8 +217,13 @@ class CoxModel:
         df["exp(coef) lower_err"] = df["exp(coef)"] - df["exp(coef) lower 95%"]
         df["exp(coef) upper_err"] = df["exp(coef) upper 95%"] - df["exp(coef)"]
         df["log10_pvalue"] = -np.log10(df["p"])
+        df["coefficient_count"] = df.groupby("analysis")["covariate"].transform(
+            "nunique"
+        )
 
         def display_label_helper(x):
+            if x["coefficient_count"] > 1:
+                return f"{x['analysis']} ({x['covariate']})"
             analysis_str = (
                 x["analysis"].split(" + ")[0] if "+" in x["analysis"] else x["analysis"]
             )
@@ -227,6 +238,16 @@ class CoxModel:
             return None
 
         df["display_label"] = df.apply(display_label_helper, axis=1)
+        label_counts = (
+            df[["display_label", "analysis", "covariate"]]
+            .drop_duplicates()
+            .groupby("display_label", dropna=False)
+            .size()
+        )
+        duplicate_labels = df["display_label"].map(label_counts).fillna(1).gt(1)
+        df.loc[duplicate_labels, "display_label"] = df.loc[duplicate_labels].apply(
+            lambda x: f"{x['analysis']} ({x['covariate']})", axis=1
+        )
 
         self.results = df[
             [

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -198,6 +198,95 @@ def test_cox_model_warns_for_failed_unstratified_fit(
     assert model.results is None
 
 
+def test_cox_model_retains_all_numeric_formula_coefficients(
+    survival_df: pd.DataFrame,
+) -> None:
+    data = survival_df.assign(
+        x1=survival_df["age"],
+        x2=[0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0],
+    )
+    model = cns.CoxModel(
+        data,
+        duration="time",
+        event="event",
+        variates=["x1 + x2"],
+    )
+
+    model.fit()
+
+    assert model.results is not None
+    results = model.results.sort_values("covariate").reset_index(drop=True)
+    assert results["analysis"].tolist() == ["x1 + x2", "x1 + x2"]
+    assert results["covariate"].tolist() == ["x1", "x2"]
+    assert results["display_label"].tolist() == [
+        "x1 + x2 (x1)",
+        "x1 + x2 (x2)",
+    ]
+
+
+def test_cox_model_retains_all_categorical_formula_coefficients(
+    survival_df: pd.DataFrame,
+) -> None:
+    model = cns.CoxModel(
+        survival_df,
+        duration="time",
+        event="event",
+        variates=["C(stage)"],
+    )
+
+    model.fit()
+
+    assert model.results is not None
+    results = model.results.sort_values("covariate").reset_index(drop=True)
+    assert results["analysis"].tolist() == ["C(stage)", "C(stage)"]
+    assert set(results["covariate"]) == {
+        "C(stage)[T.II]",
+        "C(stage)[T.III]",
+    }
+    assert results["display_label"].is_unique
+
+
+def test_cox_model_disambiguates_shared_single_coefficient_labels(
+    survival_df: pd.DataFrame,
+) -> None:
+    model = cns.CoxModel(
+        survival_df,
+        duration="time",
+        event="event",
+        variates=["age", "np.log(age)"],
+    )
+
+    model.fit()
+
+    assert model.results is not None
+    labels = model.results.set_index("analysis")["display_label"].to_dict()
+    assert labels == {
+        "age": "age (age)",
+        "np.log(age)": "np.log(age) (np.log(age))",
+    }
+
+
+def test_cox_model_rejects_formula_without_coefficients(
+    survival_df: pd.DataFrame,
+) -> None:
+    model = cns.CoxModel(
+        survival_df,
+        duration="time",
+        event="event",
+        variates=["0"],
+    )
+
+    with pytest.warns(RuntimeWarning) as caught:
+        model.fit()
+
+    messages = [str(warning.message) for warning in caught]
+    assert any(
+        "Formula '0' produced no fitted coefficients" in message for message in messages
+    )
+    assert "No successful model fits" in messages
+    assert model.results is None
+
+
 def test_logistic_model_warns_for_failed_unstratified_fit() -> None:
     model = cns.LogisticModel(
         pd.DataFrame({"event": [0, 1] * 5}),


### PR DESCRIPTION
## What changed

- Retain every coefficient fitted by multi-term and categorical Cox formulas.
- Preserve formula and coefficient identity while keeping forest-plot labels distinct.
- Update regression coverage and the affected gallery examples.

## How it was tested

- make test — 281 tests passed with 100% coverage.
- make lint — all hooks passed.

## Risks and follow-ups

- Multi-coefficient formulas now return additional result rows by design, which may affect consumers that assumed one row per formula.
- No follow-up work is currently required.