### PR TITLE
🐛 Make survival inference order-invariant

### DIFF
--- a/examples/survivalplot.py
+++ b/examples/survivalplot.py
@@ -5,8 +5,8 @@ Survival Analysis
 Create Kaplan-Meier survival curves and cumulative incidence plots.
 
 Survival plots are essential for time-to-event analysis in clinical and
-biological research. cnsplots provides automatic statistical testing
-(log-rank test) and hazard ratio calculation.
+biological research. cnsplots provides automatic omnibus log-rank testing and
+optional, explicitly selected pairwise hazard-ratio inference.
 """
 
 # %%
@@ -128,7 +128,8 @@ clinical_df = pd.DataFrame(survival_data)
 # %%
 # Survival plot with three groups
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Compare multiple treatment arms.
+# Compare multiple treatment arms with an omnibus test and an explicitly
+# requested Cox contrast. Pair tuples are (reference, comparison).
 cns.figure(150, 180)
 cns.survivalplot(
     data=clinical_df,
@@ -136,6 +137,7 @@ cns.survivalplot(
     event="event",
     hue="group",
     hue_order=["Control", "Treatment A", "Treatment B"],
+    pairs=[("Control", "Treatment B")],
 )
 cns.take_legend_out()
 plt.title("Three-Arm Clinical Trial")

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -112,13 +112,16 @@ def survivalplot(
     hue: str,
     hue_order: list[str] | None = None,
     time_label: str = "Time",
+    *,
+    overall_test: Literal["logrank", "trend"] = "logrank",
+    pairs: list[tuple[str, str]] | None = None,
 ) -> Axes:
     """
     Create a Kaplan-Meier survival plot with statistical comparisons.
 
     This function generates Kaplan-Meier survival curves comparing survival
-    probabilities across groups, with automatic statistical testing and
-    hazard ratio calculation.
+    probabilities across groups, with an overall statistical test and optional
+    pairwise Cox proportional hazards inference.
 
     Parameters
     ----------
@@ -134,6 +137,18 @@ def survivalplot(
         Order of groups from hue to display and compare.
     time_label : str, default: "Time"
         Label for the time axis, including units when applicable.
+    overall_test : {'logrank', 'trend'}, default: 'logrank'
+        Test used for the overall p-value. ``'logrank'`` performs a categorical
+        omnibus log-rank test. ``'trend'`` performs a one-degree-of-freedom Cox
+        trend test using equally spaced scores in ``hue_order`` and requires a
+        complete, explicitly supplied ``hue_order``.
+    pairs : list of tuple of str, optional
+        Pairwise Cox contrasts written as ``(reference, comparison)``. Each
+        contrast reports the hazard ratio for comparison versus reference, its
+        95% confidence interval, and an unadjusted two-sided Cox Wald p-value.
+        When omitted, the sole contrast is reported automatically for two groups;
+        no contrast is inferred for three or more groups. Pass an empty list to
+        suppress pairwise inference.
 
     Returns
     -------
@@ -155,6 +170,7 @@ def survivalplot(
     ...     hue="treatment",
     ...     hue_order=["control", "drug_a", "drug_b"],
     ...     time_label="Time (months)",
+    ...     pairs=[("control", "drug_b")],
     ... )
     >>> ax.set_title("Overall Survival by Treatment")
     """
@@ -176,9 +192,49 @@ def survivalplot(
     from lifelines.statistics import multivariate_logrank_test
 
     data = data.copy()
+    observed_groups = list(data[hue].unique())
+    has_explicit_order = (
+        hue_order is not None
+        and len(hue_order) == len(observed_groups)
+        and set(hue_order) == set(observed_groups)
+    )
+    if overall_test not in {"logrank", "trend"}:
+        raise ValueError(
+            "[survivalplot] Parameter 'overall_test' must be one of "
+            "'logrank' or 'trend'."
+        )
+    if overall_test == "trend" and not has_explicit_order:
+        raise ValueError(
+            "[survivalplot] The trend test requires a complete explicit 'hue_order' "
+            "because category order defines the trend scores."
+        )
+    if not has_explicit_order:
+        hue_order = observed_groups
+    assert hue_order is not None
+
+    resolved_pairs = (
+        [(hue_order[0], hue_order[1])]
+        if pairs is None and len(hue_order) == 2
+        else ([] if pairs is None else pairs)
+    )
+    for pair in resolved_pairs:
+        if not isinstance(pair, tuple) or len(pair) != 2:
+            raise ValueError(
+                "[survivalplot] Each item in 'pairs' must contain exactly two groups "
+                "as a (reference, comparison) tuple."
+            )
+        if pair[0] == pair[1]:
+            raise ValueError(
+                "[survivalplot] Pairwise contrasts must contain two distinct groups."
+            )
+        missing_groups = [group for group in pair if group not in observed_groups]
+        if missing_groups:
+            raise ValueError(
+                "[survivalplot] Pairwise contrast contains group(s) not present in "
+                f"'{hue}': {missing_groups}."
+            )
+
     ax: Any = None
-    if hue_order is None or set(data[hue].unique()) != set(hue_order):
-        hue_order = list(data[hue].unique())
     data[hue] = pd.Categorical(data[hue], categories=hue_order, ordered=True)
     data = data.sort_values(hue)
     kmf = ll.KaplanMeierFitter()
@@ -203,29 +259,36 @@ def survivalplot(
     ax.set_xlabel(time_label)
     ax.set_ylabel("Survival probability")
 
-    df = data[[duration, hue, event]].copy()
-    df[hue] = df[hue].cat.codes
-
-    if len(hue_order) == 2:
+    if overall_test == "logrank":
         try:
-            logrank_test = multivariate_logrank_test(df[duration], df[hue], df[event])
-            p = num2tex.num2tex(logrank_test.p_value, precision=2)
-            logger.info(
-                "P-value was determined by two-sided multivariate log-rank test."
+            logrank_result = multivariate_logrank_test(
+                data[duration], data[hue], data[event]
             )
+            overall_p = num2tex.num2tex(logrank_result.p_value, precision=2)
+            overall_label = "Omnibus log-rank"
+            logger.info("P-value was determined by two-sided omnibus log-rank test.")
         except Exception as e:
             raise RuntimeError(
                 "[survivalplot] Log-rank test failed. This may indicate insufficient data "
                 f"or invalid event/duration values. Details: {e}"
             ) from e
     else:
+        trend_data = pd.DataFrame(
+            {
+                "_duration": data[duration].to_numpy(),
+                "_event": data[event].to_numpy(),
+                "_group_score": data[hue].cat.codes.to_numpy(),
+            }
+        )
         try:
             cph = ll.CoxPHFitter()
-            cph.fit(df, duration_col=duration, event_col=event)
-            trend_test = cph.log_likelihood_ratio_test()
-            p = num2tex.num2tex(trend_test.p_value, precision=2)
+            cph.fit(trend_data, duration_col="_duration", event_col="_event")
+            trend_result = cph.log_likelihood_ratio_test()
+            overall_p = num2tex.num2tex(trend_result.p_value, precision=2)
+            overall_label = "Cox trend"
             logger.info(
-                "P-value was determined by two-sided multivariate log-rank test for trend."
+                "P-value was determined by a one-degree-of-freedom Cox proportional "
+                "hazards trend test using hue_order scores."
             )
         except Exception as e:
             raise RuntimeError(
@@ -233,26 +296,40 @@ def survivalplot(
                 f"insufficient data or model convergence issues. Details: {e}"
             ) from e
 
-    df = data[[duration, hue, event]].copy()
-    df = df[df[hue].isin([hue_order[0], hue_order[-1]])]
-    df[hue] = pd.Categorical(
-        df[hue], categories=[hue_order[0], hue_order[-1]], ordered=True
-    )
-    df[hue] = df[hue].cat.codes
-    try:
-        cph = ll.CoxPHFitter()
-        cph.fit(df, duration_col=duration, event_col=event)
-        hazard_ratio = cph.hazard_ratios_.iloc[0]
-        ci1 = cph.summary["exp(coef) lower 95%"].iloc[0]
-        ci2 = cph.summary["exp(coef) upper 95%"].iloc[0]
-    except Exception as e:
-        raise RuntimeError(
-            "[survivalplot] Could not compute hazard ratios. This may indicate "
-            f"insufficient data or model convergence issues. Details: {e}"
-        ) from e
-    ax.text(
-        0, 0, f"HR = {hazard_ratio:.2f} ({ci1:.2f}-{ci2:.2f})\nP = " + rf"${p:.2g}$"
-    )
+    annotation_lines = [f"{overall_label} P = " + rf"${overall_p:.2g}$"]
+    for reference, comparison in resolved_pairs:
+        pair_data = data[data[hue].isin([reference, comparison])]
+        cox_data = pd.DataFrame(
+            {
+                "_duration": pair_data[duration].to_numpy(),
+                "_event": pair_data[event].to_numpy(),
+                "_comparison": (pair_data[hue] == comparison).astype(int).to_numpy(),
+            }
+        )
+        try:
+            cph = ll.CoxPHFitter()
+            cph.fit(cox_data, duration_col="_duration", event_col="_event")
+            summary = cph.summary.loc["_comparison"]
+            hazard_ratio = summary["exp(coef)"]
+            ci1 = summary["exp(coef) lower 95%"]
+            ci2 = summary["exp(coef) upper 95%"]
+            pair_p = num2tex.num2tex(summary["p"], precision=2)
+        except Exception as e:
+            raise RuntimeError(
+                "[survivalplot] Could not compute hazard ratios for contrast "
+                f"{comparison!r} vs {reference!r}. This may indicate insufficient "
+                f"data or model convergence issues. Details: {e}"
+            ) from e
+        annotation_lines.append(
+            f"{comparison} vs {reference}: HR = {hazard_ratio:.2f} "
+            f"(95% CI {ci1:.2f}-{ci2:.2f}), Cox P = " + rf"${pair_p:.2g}$"
+        )
+    if resolved_pairs:
+        logger.info(
+            "Pairwise hazard ratios and unadjusted two-sided P-values were determined "
+            "by Cox proportional hazards models."
+        )
+    ax.text(0, 0, "\n".join(annotation_lines))
 
     if ax.get_legend() is not None:
         for handle in ax.get_legend().legend_handles:

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -1100,6 +1100,8 @@ def test_plot_internal_coverage(
             "time",
             "event",
             "group",
+            hue_order=["A", "B", "C"],
+            overall_test="trend",
         )
     with pytest.raises(RuntimeError, match="Could not compute hazard ratios"):
         cns.survivalplot(survival_df, "time", "event", "group")

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -175,15 +175,20 @@ def test_survival_plots(
         control_y,
         [1, 5 / 6, 2 / 3, 2 / 3, 4 / 9, 4 / 9, 0],
     )
-    assert ax.texts[0].get_text() == "HR = 0.68 (0.15-3.06)\nP = $0.6$"
-    assert "multivariate log-rank test" in caplog.text
+    assert ax.texts[0].get_text() == (
+        "Omnibus log-rank P = $0.6$\n"
+        "Control vs Treatment: HR = 0.68 (95% CI 0.15-3.06), Cox P = $0.62$"
+    )
+    assert "omnibus log-rank test" in caplog.text
 
     cns.figure(120, 120)
     caplog.clear()
     with caplog.at_level(logging.INFO, logger="cnsplots"):
         ax2 = cns.survivalplot(survival_three_group_df, "time", "event", "group")
     assert ax2.get_xlabel() == "Time"
-    assert "trend" in caplog.text
+    assert ax2.texts[0].get_text() == "Omnibus log-rank P = $0.36$"
+    assert "omnibus log-rank test" in caplog.text
+    assert "trend" not in caplog.text
 
     cns.figure(120, 120)
     caplog.clear()

--- a/tests/test_survival_inference.py
+++ b/tests/test_survival_inference.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+def _annotation(ax: plt.Axes) -> str:
+    return ax.texts[0].get_text()
+
+
+def test_survivalplot_omnibus_test_is_category_order_invariant(
+    survival_three_group_df: pd.DataFrame,
+) -> None:
+    annotations = []
+    for order in (["Low", "Mid", "High"], ["Low", "High", "Mid"]):
+        plt.figure()
+        ax = cns.survivalplot(
+            survival_three_group_df,
+            "time",
+            "event",
+            "group",
+            hue_order=order,
+        )
+        annotations.append(_annotation(ax))
+
+    assert annotations == ["Omnibus log-rank P = $0.36$"] * 2
+
+
+def test_survivalplot_trend_test_is_explicitly_ordered(
+    survival_three_group_df: pd.DataFrame,
+) -> None:
+    annotations = []
+    for order in (["Low", "Mid", "High"], ["Low", "High", "Mid"]):
+        plt.figure()
+        ax = cns.survivalplot(
+            survival_three_group_df,
+            "time",
+            "event",
+            "group",
+            hue_order=order,
+            overall_test="trend",
+        )
+        annotations.append(_annotation(ax))
+
+    assert annotations == ["Cox trend P = $0.16$", "Cox trend P = $0.57$"]
+
+
+@pytest.mark.parametrize("hue_order", [None, ["Low", "High"]])
+def test_survivalplot_trend_requires_complete_explicit_order(
+    survival_three_group_df: pd.DataFrame,
+    hue_order: list[str] | None,
+) -> None:
+    with pytest.raises(ValueError, match="complete explicit 'hue_order'"):
+        cns.survivalplot(
+            survival_three_group_df,
+            "time",
+            "event",
+            "group",
+            hue_order=hue_order,
+            overall_test="trend",
+        )
+
+
+@pytest.mark.parametrize(
+    ("pair", "expected"),
+    [
+        (
+            ("Low", "High"),
+            "High vs Low: HR = 0.38 (95% CI 0.08-1.75), Cox P = $0.21$",
+        ),
+        (
+            ("High", "Low"),
+            "Low vs High: HR = 2.66 (95% CI 0.57-12.43), Cox P = $0.21$",
+        ),
+    ],
+)
+def test_survivalplot_reports_named_directional_pairwise_inference(
+    survival_three_group_df: pd.DataFrame,
+    pair: tuple[str, str],
+    expected: str,
+) -> None:
+    annotations = []
+    for order in (["Low", "Mid", "High"], ["Low", "High", "Mid"]):
+        plt.figure()
+        ax = cns.survivalplot(
+            survival_three_group_df,
+            "time",
+            "event",
+            "group",
+            hue_order=order,
+            pairs=[pair],
+        )
+        annotations.append(_annotation(ax).splitlines())
+
+    assert annotations == [
+        ["Omnibus log-rank P = $0.36$", expected],
+        ["Omnibus log-rank P = $0.36$", expected],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("pairs", "message"),
+    [
+        (["Low"], "exactly two groups"),
+        ([("Low", "Low")], "two distinct groups"),
+        ([("Low", "missing")], "not present in 'group'"),
+    ],
+)
+def test_survivalplot_validates_pairwise_contrasts(
+    survival_three_group_df: pd.DataFrame,
+    pairs: list[object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        cns.survivalplot(
+            survival_three_group_df,
+            "time",
+            "event",
+            "group",
+            pairs=pairs,  # type: ignore[arg-type]
+        )
+
+
+def test_survivalplot_rejects_unknown_overall_test(
+    survival_three_group_df: pd.DataFrame,
+) -> None:
+    with pytest.raises(ValueError, match="'overall_test' must be one of"):
+        cns.survivalplot(
+            survival_three_group_df,
+            "time",
+            "event",
+            "group",
+            overall_test="score",  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## What changed

- use an omnibus multigroup log-rank test by default in `survivalplot()`
- make the ordered Cox trend test opt-in through `overall_test="trend"`
- require explicit named pairwise contrasts for multigroup hazard ratios and report each contrast with its own Cox inference
- retain the automatic sole contrast for two-group plots with an explicit direction label
- document the new inference behavior and add category-order regression coverage

## Testing

- `make test` — 291 passed with 100% coverage
- `make lint` — passed

## Risks and follow-ups

- multigroup default p-values intentionally change from a one-degree-of-freedom trend hypothesis to the omnibus hypothesis
- implicit first-versus-last hazard ratios are no longer shown for three or more groups
- p-values for multiple requested pairwise Cox contrasts are unadjusted, as documented