### PR TITLE
🐛 Correct cumulative incidence Gray test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "adjustText",
     "anndata",
     "biopython",
+    "comprisk>=0.7,<0.8",
     "gseapy",
     "lifelines>=0.30,<0.31",
     "lxml",

--- a/src/cnsplots/helpers/_cmprsk.py
+++ b/src/cnsplots/helpers/_cmprsk.py
@@ -6,7 +6,6 @@ if TYPE_CHECKING:
     from pandas import Series
 
 import pandas as pd
-from lifelines.statistics import multivariate_logrank_test
 
 from cnsplots._validation import (
     validate_categorical_has_levels,
@@ -22,25 +21,15 @@ def cuminc(
     events: Series,
     group: Series,
     event_of_interest: int = 1,
-    competing_event: int = 2,
 ) -> float:
     """
-    Approximates Gray's Test (cmprsk::cuminc) using a Subdistribution Hazard
-    Log-Rank Test in pure Python.
-
-    Method:
-    1. Identifies the Competing Events.
-    2. "Immortalizes" them: In the subdistribution framework, subjects who
-       experience a competing event remain in the risk set for the event of interest
-       (effectively censored at infinity).
-    3. Runs a standard Log-Rank test on this modified risk set.
+    Calculate Gray's K-sample test p-value for cumulative incidence functions.
 
     Parameters:
     - durations: Sequence of time-to-event.
-    - events: Sequence of event codes (0=censored, 1=interest, 2=competing).
+    - events: Sequence of event codes (0=censored; all other codes are events).
     - group: Sequence of group labels.
     - event_of_interest: The code for the primary event (default 1).
-    - competing_event: The code for the competing event (default 2).
 
     Returns:
     - p_value: The p-value testing the null hypothesis that CIFs are identical.
@@ -57,37 +46,14 @@ def cuminc(
     validate_column_type(df, "E", ["numeric"], "cuminc")
     validate_categorical_has_levels(df, "group", min_levels=2, function_name="cuminc")
 
-    # 2. Pre-process for Subdistribution Hazard (Fine-Gray approach)
-    # The trick: Subjects with the *competing* event are treated as if
-    # they are still in the risk set (censored at a time later than the max time).
+    from comprisk import gray_test
 
-    # Find the maximum time in the dataset to shift competing events beyond it
-    max_time = df["T"].max() + 1.0
-
-    # Create mask for competing events
-    mask_competing = df["E"] == competing_event
-
-    # Create mask for the event of interest
-    mask_interest = df["E"] == event_of_interest
-
-    # Apply the transformation:
-    # - Event of Interest: Stays as Event (1) at Time T
-    # - Censored: Stays as Censored (0) at Time T
-    # - Competing Event: Becomes Censored (0) at Time "Infinity" (max_time)
-
-    df["T_mod"] = df["T"]
-    df["E_mod"] = 0  # Default to censored
-
-    # Set event of interest
-    df.loc[mask_interest, "E_mod"] = 1
-
-    # For competing events, shift time to 'infinity' so they stay in risk set
-    df.loc[mask_competing, "T_mod"] = max_time
-
-    # 3. Run Multivariate Log-Rank Test on the modified data
-    # This compares the subdistribution hazards across groups
-    result = multivariate_logrank_test(
-        event_durations=df["T_mod"], event_observed=df["E_mod"], groups=df["group"]
+    result = gray_test(
+        time=df["T"],
+        event=df["E"],
+        group=df["group"],
+        cause=event_of_interest,
+        rho=0.0,
     )
 
-    return result.p_value
+    return float(result.pvalue)

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -359,7 +359,7 @@ def cumulativeincidenceplot(
     Create a cumulative incidence plot for competing risks analysis.
 
     This function generates cumulative incidence curves using the Aalen-Johansen
-    estimator for competing risks data, with automatic statistical testing and
+    estimator for competing risks data, with an automatic Gray's K-sample test and
     optional at-risk table.
 
     Parameters
@@ -376,7 +376,7 @@ def cumulativeincidenceplot(
     hue_order : list, optional
         Order of groups from hue to display and compare.
     pvalue_position : tuple of float, default: (0, 0.5)
-        (x, y) coordinates for placing the p-value text annotation.
+        (x, y) coordinates for placing the Gray's test p-value annotation.
     show_risk_table : bool, default: False
         Whether to display a risk table below the plot.
     risk_table_rows : tuple of str, default: ('At risk',)
@@ -527,12 +527,11 @@ def cumulativeincidenceplot(
             )
             ax.set_xlim(new_xlim)
     if data[hue].nunique() > 1:
-        gray_events = data[event].where(data[event] <= 1, 2)
         pvalue = helper_cmprsk.cuminc(
-            data[duration], gray_events, group=data[hue].cat.codes
+            data[duration], data[event], group=data[hue].cat.codes
         )
         p = num2tex.num2tex(pvalue, precision=2)
-        logger.info("P-value was determined by two-sided Gray's test.")
+        logger.info("P-value was determined by Gray's K-sample test.")
         ax.text(pvalue_position[0], pvalue_position[1], "P = " + rf"${p:.2g}$")
 
     if show_risk_table:

--- a/tests/test_methods_and_helpers.py
+++ b/tests/test_methods_and_helpers.py
@@ -18,13 +18,56 @@ from cnsplots import _utils
 from cnsplots.helpers import _cmprsk, _heatmap as helper_heatmap, _phylo, _sankey
 
 
-def test_competing_risk_helper(competing_risk_df: pd.DataFrame) -> None:
+@pytest.mark.parametrize(
+    "competing_codes",
+    [(2, 2, 2, 2), (2, 3, 2, 3), (3, 3, 3, 3)],
+)
+def test_competing_risk_helper_matches_cmprsk_reference(
+    competing_risk_df: pd.DataFrame,
+    competing_codes: tuple[int, ...],
+) -> None:
+    data = competing_risk_df.copy()
+    data.loc[data["event"] == 2, "event"] = competing_codes
+
+    pvalue = _cmprsk.cuminc(
+        data["time"],
+        data["event"],
+        data["group"],
+    )
+
+    # cmprsk 2.2-12: cuminc(time, event, group)$Tests["1", "pv"]
+    assert pvalue == pytest.approx(0.87651762813141, rel=1e-12)
+
+
+def test_competing_risk_helper_matches_three_group_cmprsk_reference() -> None:
+    durations = pd.Series(
+        [1, 2, 3, 4, 5, 6, 7, 8]
+        + [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5]
+        + [0.5, 1.8, 3.2, 4.8, 5.2, 6.8, 7.2, 9]
+    )
+    events = pd.Series(
+        [1, 2, 0, 1, 3, 0, 1, 2] + [2, 1, 0, 2, 1, 3, 0, 1] + [3, 0, 1, 2, 0, 1, 2, 1]
+    )
+    groups = pd.Series(["A"] * 8 + ["B"] * 8 + ["C"] * 8)
+
+    pvalue = _cmprsk.cuminc(durations, events, groups)
+
+    # cmprsk 2.2-12: cuminc(time, event, group)$Tests["1", "pv"]
+    assert pvalue == pytest.approx(0.7367051945773576, rel=1e-12)
+
+
+def test_competing_risk_helper_supports_an_alternate_event_of_interest(
+    competing_risk_df: pd.DataFrame,
+) -> None:
     pvalue = _cmprsk.cuminc(
         competing_risk_df["time"],
         competing_risk_df["event"],
         competing_risk_df["group"],
+        event_of_interest=2,
     )
-    assert 0 <= pvalue <= 1
+
+    # cmprsk 2.2-12: cuminc(time, event, group)$Tests["2", "pv"]
+    assert pvalue == pytest.approx(0.6230363296121225, rel=1e-12)
 
 
 def test_competing_risk_helper_validates_inputs() -> None:

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -221,7 +221,8 @@ def test_survival_plots(
     ]
     assert risk_table_labels[0].split() == ["At", "risk", "A", "6", "B", "6"]
     assert risk_table_labels[-1].split() == ["0", "0"]
-    assert "Gray's test" in caplog.text
+    assert ax3.texts[0].get_text() == "P = $0.88$"
+    assert "Gray's K-sample test" in caplog.text
 
     cns.figure(120, 120)
     single_group = competing_risk_df[competing_risk_df["group"] == "A"].copy()

--- a/tests/test_survival_hardening.py
+++ b/tests/test_survival_hardening.py
@@ -146,6 +146,7 @@ def test_cumulativeincidenceplot_accepts_multiple_competing_event_codes(
     ax = cns.cumulativeincidenceplot(data, "time", "event", "group")
 
     assert ax.get_xlabel() == "Time"
+    assert ax.texts[0].get_text() == "P = $0.88$"
 
 
 def test_cumulativeincidenceplot_ties_are_deterministic_without_rng_side_effects() -> (

--- a/uv.lock
+++ b/uv.lock
@@ -486,6 +486,7 @@ dependencies = [
     { name = "anndata", version = "0.11.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "anndata", version = "0.12.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "biopython" },
+    { name = "comprisk" },
     { name = "gseapy" },
     { name = "lifelines", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "lifelines", version = "0.30.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -542,6 +543,7 @@ requires-dist = [
     { name = "anndata" },
     { name = "biopython" },
     { name = "bump-my-version", marker = "extra == 'dev'" },
+    { name = "comprisk", specifier = ">=0.7,<0.8" },
     { name = "fastcluster", marker = "extra == 'dev'" },
     { name = "furo", marker = "extra == 'dev'" },
     { name = "glasbey", marker = "extra == 'dev'" },
@@ -609,6 +611,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "comprisk"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numba" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/05/55906f8f7459f4e3a3c108a9296abb6c2384f9d7a88278d0c8d040bbe3b1/comprisk-0.7.0.tar.gz", hash = "sha256:95d40b913ade87f32da273703c8b118b27f457a0e11d8bb89b2bc7c8c5c70709", size = 322459, upload-time = "2026-06-22T13:18:08.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/77/a2cba01fc8525fa7e24ed005b8fa7129a8a472ec8a6e2ccde0a49fb6829d/comprisk-0.7.0-py3-none-any.whl", hash = "sha256:cc616c8591b762a80bc3becd89c38e42a46f0fb42a133efdb06a83efb3fd15d3", size = 147303, upload-time = "2026-06-22T13:18:05.82Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Replaced the transformed ordinary log-rank approximation with the native-Python Gray K-sample test from comprisk.
- Passed original competing-event codes so every non-target positive code is handled correctly.
- Updated the plot documentation and logging to identify the test accurately.
- Added known-answer coverage from R cmprsk 2.2-12 for two groups, three groups, mixed competing codes, and an alternate target cause.

## How it was tested

- `make test` — 295 tests passed with 100% coverage.
- `make lint` — all checks passed.
- Gray statistics and p-values matched R cmprsk 2.2-12 to floating-point precision.

## Risks and follow-ups

- Adds comprisk 0.7 as a runtime dependency. It is pure Python and does not install or invoke R or rpy2.
- comprisk is pre-1.0, so the dependency is constrained to the 0.7 release series and protected by R-reference regression tests.