### PR TITLE
💥 Standardize plotting parameter names

### DIFF
--- a/examples/barplot.py
+++ b/examples/barplot.py
@@ -109,7 +109,7 @@ cns.barplot(data=tips, x="day", y="total_bill", palette=cols)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Add significance annotations for all pairwise comparisons.
 cns.figure(100, 150, "Tableau")
-cns.barplot(data=tips, x="day", y="total_bill", pairs="all", addtip=True)
+cns.barplot(data=tips, x="day", y="total_bill", pairs="all", add_tip=True)
 
 
 # %%
@@ -122,7 +122,7 @@ cns.barplot(
     x="day",
     y="total_bill",
     pairs=[("Thur", "Fri"), ("Sat", "Sun")],
-    addtip=True,
+    add_tip=True,
 )
 
 
@@ -206,18 +206,18 @@ ax.spines["left"].set_visible(False)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare measurements across species.
 cns.figure(100, 150, "Bold")
-ax = cns.barplot(data=iris, x="species", y="sepal_width", pairs="all", addtip=True)
+ax = cns.barplot(data=iris, x="species", y="sepal_width", pairs="all", add_tip=True)
 ax.set_xticklabels(
     ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor"
 )
 
 
 # %%
-# Barplot with sample counts
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Display number of samples above bars.
+# Barplot with value labels
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# Display the aggregated value above each bar.
 cns.figure(150, 150)
-cns.barplot(data=iris, x="species", y="sepal_length", addtip=True)
+cns.barplot(data=iris, x="species", y="sepal_length", add_tip=True)
 
 
 # %%

--- a/examples/boxplot.py
+++ b/examples/boxplot.py
@@ -92,7 +92,7 @@ for index in range(tips["day"].nunique()):
 # Boxplot with statistical comparisons (all pairs)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use ``pairs="all"`` to perform Mann-Whitney U tests between all groups.
-# The ``addcount=True`` parameter adds sample sizes below each box.
+# The ``add_count=True`` parameter adds sample sizes below each box.
 with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
     cns.figure(100, 150)
     ax = cns.boxplot(
@@ -100,7 +100,7 @@ with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
         x="species",
         y="sepal_width",
         pairs="all",
-        addcount=True,
+        add_count=True,
     )
 ax.set_title("All Pairwise Comparisons\nwith Sample Counts")
 

--- a/examples/donutplot.py
+++ b/examples/donutplot.py
@@ -53,7 +53,7 @@ ax.set_title("Customers by Sex")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Control the order of categories.
 cns.figure(100, 100)
-ax = cns.donutplot(tips, "day", hue_order=["Thur", "Fri", "Sat", "Sun"])
+ax = cns.donutplot(tips, "day", order=["Thur", "Fri", "Sat", "Sun"])
 ax.set_title("Custom Order")
 
 

--- a/examples/lollipopplot.py
+++ b/examples/lollipopplot.py
@@ -93,7 +93,7 @@ cns.lollipopplot(
 # ~~~~~~~~~~~~~~~~~
 # Display the mean value at each dot.
 cns.figure(100, 150, "Tableau")
-cns.lollipopplot(data=tips, x="day", y="total_bill", addtip=True)
+cns.lollipopplot(data=tips, x="day", y="total_bill", add_tip=True)
 
 
 # %%
@@ -145,7 +145,7 @@ cns.take_legend_out()
 # Compare measurements across species with value labels.
 cns.figure(100, 150, "Bold")
 ax = cns.lollipopplot(
-    data=iris, x="species", y="sepal_width", addtip=True, errorbar="se"
+    data=iris, x="species", y="sepal_width", add_tip=True, errorbar="se"
 )
 ax.set_xticklabels(
     ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor"
@@ -189,6 +189,6 @@ cns.take_legend_out()
 # Use median instead of mean for robust estimation.
 cns.figure(100, 150)
 ax = cns.lollipopplot(
-    data=tips, x="day", y="total_bill", estimator="median", addtip=True
+    data=tips, x="day", y="total_bill", estimator="median", add_tip=True
 )
 ax.set_title("Median Total Bill")

--- a/examples/pieplot.py
+++ b/examples/pieplot.py
@@ -53,7 +53,7 @@ ax.set_title("Customers by Sex")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Control the order of categories.
 cns.figure(100, 100)
-ax = cns.pieplot(tips, "day", hue_order=["Thur", "Fri", "Sat", "Sun"])
+ax = cns.pieplot(tips, "day", order=["Thur", "Fri", "Sat", "Sun"])
 ax.set_title("Custom Order")
 
 
@@ -91,7 +91,7 @@ contrast_data = pd.DataFrame(
 )
 
 cns.figure(100, 100, ["#1F2937", "#F3F4F6"])
-ax = cns.pieplot(contrast_data, "region", hue_order=["Dark Region", "Light Region"])
+ax = cns.pieplot(contrast_data, "region", order=["Dark Region", "Light Region"])
 ax.set_title("Contrast-Aware Labels")
 
 

--- a/examples/stackplot.py
+++ b/examples/stackplot.py
@@ -24,10 +24,10 @@ tips = cns.datasets.load_dataset("tips")
 # Basic stacked bar plot (normalized)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Shows proportions that sum to 100% within each bar.
-# Use ``addcount=True`` to display total counts in the tick labels.
+# Use ``add_count=True`` to display total counts in the tick labels.
 cns.figure(100, 120)
 ax = cns.stackplot(
-    data=tips, x="sex", stack="day", width=0.4, normalize=True, addcount=True
+    data=tips, x="sex", stack="day", width=0.4, normalize=True, add_count=True
 )
 ax.set_title("Basic Stacked Plot")
 
@@ -99,7 +99,7 @@ ax = cns.stackplot(
     stack="sex",
     normalize=True,
     pairs=[("Thur", "Fri"), ("Fri", "Sat")],
-    bar_order=["Fri", "Sat", "Sun", "Thur"],
+    order=["Fri", "Sat", "Sun", "Thur"],
 )
 ax.set_title("Horizontal Stacked Bar")
 
@@ -107,14 +107,14 @@ ax.set_title("Horizontal Stacked Bar")
 # %%
 # Stacked bar plot with custom bar order
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``bar_order`` to specify the order of bars on the axis.
+# Use ``order`` to specify the order of bars on the axis.
 cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips,
     x="day",
     stack="sex",
     normalize=True,
-    bar_order=["Sun", "Sat", "Fri", "Thur"],
+    order=["Sun", "Sat", "Fri", "Thur"],
 )
 ax.set_title("Custom Bar Order")
 
@@ -163,7 +163,7 @@ mp.get_axes("B").set_title("BlueRed")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Stack plots work with multiple categories in the stack variable.
 cns.figure(100, 150, "Ecotyper1")
-ax = cns.stackplot(data=tips, x="sex", stack="time", normalize=True, addcount=True)
+ax = cns.stackplot(data=tips, x="sex", stack="time", normalize=True, add_count=True)
 ax.set_title("Multiple Stack Categories")
 
 
@@ -212,7 +212,7 @@ ax = cns.stackplot(
     y="day",
     stack="sex",
     normalize=True,
-    addcount=True,
+    add_count=True,
     width=0.6,
 )
 ax.set_title("Horizontal with Labels")
@@ -232,6 +232,6 @@ mp.get_axes("A").set_ylabel("Count")
 mp.newline()
 
 mp.panel("B", 130, 80, margin_top=10)
-cns.stackplot(data=tips, x="day", stack="sex", normalize=True, addcount=True)
+cns.stackplot(data=tips, x="day", stack="sex", normalize=True, add_count=True)
 mp.get_axes("B").set_title("Normalized Proportions")
 mp.get_axes("B").set_ylabel("Proportion")

--- a/examples/stripplot.py
+++ b/examples/stripplot.py
@@ -70,9 +70,9 @@ ax.set_title("Strip Plot with Median and Mean")
 # %%
 # Strip plot with sample counts
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``addcount=True`` to display sample sizes.
+# Use ``add_count=True`` to display sample sizes.
 cns.figure(100, 120)
-ax = cns.stripplot(data=tips, x="day", y="total_bill", size=2, addcount=True)
+ax = cns.stripplot(data=tips, x="day", y="total_bill", size=2, add_count=True)
 ax.set_title("Strip Plot with Sample Counts")
 
 
@@ -205,7 +205,7 @@ ax = cns.stripplot(
     size=3,
     showmedian=True,
     showmeans=True,
-    addcount=True,
+    add_count=True,
     order=["Thur", "Fri", "Sat", "Sun"],
     alpha=0.6,
 )

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -641,7 +641,7 @@ def apply_unicode_font(ax: Axes | None = None, font: str = "DejaVu Sans") -> Non
             text_obj.set_fontfamily(font)
 
 
-def _addcount_helper(data, attr, ax, axis="x"):
+def _add_count_helper(data, attr, ax, axis="x"):
     counts = data[attr].astype(str).value_counts()
     if axis == "x":
         tick_labels = ax.get_xticklabels()

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib.axes import Axes
+from matplotlib.container import BarContainer
 from matplotlib.patches import Patch
 from scipy import stats
 
@@ -128,7 +129,7 @@ def _draw_lollipop_series(
     markersize: float,
     marker: str,
     errors: pd.Series | None,
-    addtip: bool,
+    add_tip: bool,
     tip_offset: float,
     label: Any = None,
 ) -> None:
@@ -175,7 +176,7 @@ def _draw_lollipop_series(
                 capsize=2,
             )
 
-    if addtip:
+    if add_tip:
         for position, value in zip(positions, values):
             if pd.isna(value):
                 continue
@@ -200,7 +201,11 @@ def barplot(
     x: str,
     y: str,
     pairs: list[tuple[str, str]] | None = None,
-    addtip: bool = False,
+    add_tip: bool = False,
+    *,
+    hue: str | None = None,
+    order: list[str] | None = None,
+    hue_order: list[str] | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -221,8 +226,14 @@ def barplot(
     pairs : list of tuple of str, optional
         List of pairs of category names from x for pairwise statistical comparisons
         using Welch's t-test.
-    addtip : bool, default: False
+    add_tip : bool, default: False
         Whether to add text labels showing the mean value above each bar.
+    hue : str, optional
+        Column name for grouping data into separate bars.
+    order : list of str, optional
+        Order of categories along the categorical axis.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Additional keyword arguments passed to `seaborn.barplot`.
 
@@ -245,7 +256,7 @@ def barplot(
     ...     x="treatment",
     ...     y="response",
     ...     pairs=[("control", "drug_a"), ("control", "drug_b")],
-    ...     addtip=True,
+    ...     add_tip=True,
     ... )
     >>> ax.set_title("Treatment Response")
 
@@ -255,8 +266,15 @@ def barplot(
     """
     # Validate inputs
     validate_dataframe(data, "data", "barplot")
-    validate_columns_exist(data, [x, y], "barplot")
+    columns = [x, y] if hue is None else [x, y, hue]
+    validate_columns_exist(data, columns, "barplot")
     validate_dataframe_not_empty(data, "barplot")
+
+    if "addtip" in kwargs:
+        raise TypeError(
+            "barplot() got an unexpected keyword argument 'addtip'; "
+            "use 'add_tip' instead"
+        )
 
     args = {
         "edgecolor": None,
@@ -276,21 +294,32 @@ def barplot(
             group_col,
         )
         show_legend = True
-    plotting = {"data": data, "x": x, "y": y, "palette": palette}
+    plotting = {
+        "data": data,
+        "x": x,
+        "y": y,
+        "hue": hue,
+        "order": order,
+        "hue_order": hue_order,
+        "palette": palette,
+    }
     plotting.update(args)
     plotting.update(kwargs)
     ax = sns.barplot(**plotting)
-    if addtip:
-        groupedvalues = data.groupby(x)[[y]].mean().reset_index()
-        for _, row in groupedvalues.iterrows():
-            ax.text(
-                row.name,
-                row[y] + 0.05,
-                round(row[y], 2),
+    if add_tip:
+        for container in (
+            item for item in ax.containers if isinstance(item, BarContainer)
+        ):
+            labels = [
+                "" if pd.isna(value) else str(round(value, 2))
+                for value in container.datavalues
+            ]
+            ax.bar_label(
+                container,
+                labels=labels,
+                padding=2,
                 color="black",
-                ha="center",
-                rotation=0,
-                size=_legend_fontsize(),
+                fontsize=_legend_fontsize(),
             )
     if pairs is not None:
         utils._p_value_helper("t-test_welch", data, ax, plotting, pairs)
@@ -313,7 +342,7 @@ def lollipopplot(
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
     pairs: list[LollipopPair] | None = None,
-    addtip: bool = False,
+    add_tip: bool = False,
     estimator: str = "mean",
     errorbar: str | None = None,
     markersize: float = 20,
@@ -348,7 +377,7 @@ def lollipopplot(
     pairs : list of tuple of str, optional
         List of pairs of category names for pairwise statistical comparisons
         using Welch's t-test.
-    addtip : bool, default: False
+    add_tip : bool, default: False
         Whether to add text labels showing the aggregated value at each dot.
     estimator : {'mean', 'median'}, default: 'mean'
         The aggregation function to compute for each category.
@@ -475,7 +504,7 @@ def lollipopplot(
             markersize=markersize,
             marker=marker,
             errors=errors,
-            addtip=addtip,
+            add_tip=add_tip,
             tip_offset=(means.max() - baseline) * 0.02,
         )
     else:
@@ -514,7 +543,7 @@ def lollipopplot(
                 markersize=markersize,
                 marker=marker,
                 errors=errors,
-                addtip=addtip,
+                add_tip=add_tip,
                 tip_offset=means.max() * 0.02,
                 label=hue_val,
             )
@@ -573,12 +602,12 @@ def stackplot(
     y: str | None = None,
     *,
     stack: str,
-    bar_order: list[str] | None = None,
+    order: list[str] | None = None,
     stack_order: list[str] | None = None,
     width: float = 0.5,
     normalize: bool = True,
     pairs: list[tuple[str, str]] | None = None,
-    addcount: bool = False,
+    add_count: bool = False,
     n_factor: int | float = 1,
 ) -> Axes:
     """
@@ -603,7 +632,7 @@ def stackplot(
         be provided.
     stack : str
         Column name for the categorical variable determining stack segments.
-    bar_order : list, optional
+    order : list, optional
         Order of categories from the selected bar variable to display.
     stack_order : list, optional
         Order of categories from ``stack`` for stacking.
@@ -614,7 +643,7 @@ def stackplot(
     pairs : list of tuple of str, optional
         List of pairs of bar-category names for pairwise statistical comparisons
         from the selected bar variable.
-    addcount : bool, default: False
+    add_count : bool, default: False
         Whether to append total counts to the category tick labels in the
         format ``n=...``.
     n_factor : int or float, default: 1
@@ -670,7 +699,7 @@ def stackplot(
         value_label = "Frequency"
     else:
         value_label = "Count"
-    df = df.reindex(index=bar_order)
+    df = df.reindex(index=order)
     df = df / n_factor
     ax = plt.gca()
     if y is not None:
@@ -682,14 +711,14 @@ def stackplot(
         ax.set_ylabel(value_label)
         ax.set_xlabel("")
     utils.take_legend_out()
-    if addcount:
+    if add_count:
         count_axis = "y" if y is not None else "x"
-        utils._addcount_helper(data, bar, ax, axis=count_axis)
+        utils._add_count_helper(data, bar, ax, axis=count_axis)
     if pairs is not None:
         if y is not None:
-            plotting = {"data": data2, "x": "count", "y": bar, "order": bar_order}
+            plotting = {"data": data2, "x": "count", "y": bar, "order": order}
         else:
-            plotting = {"data": data2, "x": bar, "y": "count", "order": bar_order}
+            plotting = {"data": data2, "x": bar, "y": "count", "order": order}
         if contingency.shape[1] == 2:
             utils._p_value_helper(
                 "fisher-exact", data2, ax, plotting, pairs, contingency
@@ -709,7 +738,11 @@ def stripplot(
     size: float = 2,
     showmedian: bool = True,
     showmeans: bool = False,
-    addcount: bool = False,
+    add_count: bool = False,
+    *,
+    hue: str | None = None,
+    order: list[str] | None = None,
+    hue_order: list[str] | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -732,8 +765,14 @@ def stripplot(
         Whether to overlay a horizontal line at the median for each category.
     showmeans : bool, default: False
         Whether to overlay a marker at the mean for each category.
-    addcount : bool, default: False
+    add_count : bool, default: False
         Whether to add sample size (n) labels above each category.
+    hue : str, optional
+        Column name for grouping points within each category.
+    order : list of str, optional
+        Order of categories along the categorical axis.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Additional keyword arguments passed to `seaborn.stripplot`.
 
@@ -752,7 +791,7 @@ def stripplot(
     --------
     >>> import cnsplots as cns
     >>> ax = cns.stripplot(
-    ...     data=df, x="treatment", y="response", showmedian=True, addcount=True
+    ...     data=df, x="treatment", y="response", showmedian=True, add_count=True
     ... )
     >>> ax.set_title("Treatment Response")
 
@@ -764,14 +803,31 @@ def stripplot(
     """
     # Validate inputs
     validate_dataframe(data, "data", "stripplot")
-    validate_columns_exist(data, [x, y], "stripplot")
+    columns = [x, y] if hue is None else [x, y, hue]
+    validate_columns_exist(data, columns, "stripplot")
     validate_dataframe_not_empty(data, "stripplot")
 
-    ax = sns.stripplot(data=data, x=x, y=y, size=size, **kwargs)
+    if "addcount" in kwargs:
+        raise TypeError(
+            "stripplot() got an unexpected keyword argument 'addcount'; "
+            "use 'add_count' instead"
+        )
+
+    ax = sns.stripplot(
+        data=data,
+        x=x,
+        y=y,
+        hue=hue,
+        order=order,
+        hue_order=hue_order,
+        size=size,
+        **kwargs,
+    )
     sns.boxplot(
         data=data,
         x=x,
         y=y,
+        order=order,
         medianprops={"visible": showmedian, "color": "black", "lw": 1},
         meanprops={
             "markerfacecolor": "white",
@@ -788,8 +844,8 @@ def stripplot(
         ax=ax,
         showmeans=showmeans,
     )
-    if addcount:
-        utils._addcount_helper(data, x, ax)
+    if add_count:
+        utils._add_count_helper(data, x, ax)
 
     _resize_legend_markers(ax.get_legend(), size**2, marker_size=size * 2)
 
@@ -800,7 +856,7 @@ def pieplot(
     data: pd.DataFrame,
     x: str,
     legend: str = "bottom",
-    hue_order: list[str] | None = None,
+    order: list[str] | None = None,
 ) -> Axes:
     """
     Create a pie chart showing categorical proportions.
@@ -813,7 +869,7 @@ def pieplot(
         Column name for the categorical variable to visualize.
     legend : {'right', 'left', 'top', 'bottom'}, default: 'bottom'
         Position of the legend relative to the pie chart.
-    hue_order : list, optional
+    order : list, optional
         Order of categories to display in the pie chart.
 
     Returns
@@ -834,7 +890,7 @@ def pieplot(
     >>> ax.set_title("Cell Type Distribution")
 
     >>> # Specify category order
-    >>> ax = cns.pieplot(data=df, x="response", hue_order=["CR", "PR", "SD", "PD"])
+    >>> ax = cns.pieplot(data=df, x="response", order=["CR", "PR", "SD", "PD"])
     """
     # Validate inputs
     validate_dataframe(data, "data", "pieplot")
@@ -842,10 +898,10 @@ def pieplot(
     validate_dataframe_not_empty(data, "pieplot")
 
     df = data[x].value_counts()
-    if hue_order is None:
-        hue_order = df.index
+    if order is None:
+        order = df.index
     ax = plt.gca()
-    ax = df.reindex(index=hue_order).plot.pie(
+    ax = df.reindex(index=order).plot.pie(
         shadow=False,
         autopct="%1.0f%%",
         explode=[0] * df.shape[0],
@@ -874,7 +930,7 @@ def donutplot(
     data: pd.DataFrame,
     x: str,
     legend: str = "bottom",
-    hue_order: list[str] | None = None,
+    order: list[str] | None = None,
 ) -> Axes:
     """
     Create a donut chart showing categorical proportions.
@@ -887,7 +943,7 @@ def donutplot(
         Column name for the categorical variable to visualize.
     legend : {'right', 'left', 'top', 'bottom'}, default: 'bottom'
         Position of the legend relative to the pie chart.
-    hue_order : list, optional
+    order : list, optional
         Order of categories to display in the donut chart.
 
     Returns
@@ -908,7 +964,7 @@ def donutplot(
     >>> ax.set_title("Tissue Type Distribution")
 
     >>> # Specify category order
-    >>> ax = cns.donutplot(data=df, x="grade", hue_order=["I", "II", "III", "IV"])
+    >>> ax = cns.donutplot(data=df, x="grade", order=["I", "II", "III", "IV"])
     """
     # Validate inputs
     validate_dataframe(data, "data", "donutplot")
@@ -916,10 +972,10 @@ def donutplot(
     validate_dataframe_not_empty(data, "donutplot")
 
     df = data[x].value_counts()
-    if hue_order is None:
-        hue_order = df.index
+    if order is None:
+        order = df.index
     ax = plt.gca()
-    ax = df.reindex(index=hue_order).plot.pie(
+    ax = df.reindex(index=order).plot.pie(
         labeldistance=None,
         ax=ax,
         ylabel="",

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -32,8 +32,12 @@ def boxplot(
     y: str,
     pairs: list[tuple[str, str]] | None = None,
     showoutliers: bool = False,
-    addcount: bool = False,
+    add_count: bool = False,
     whis: float | tuple[float, float] = 1.5,
+    *,
+    hue: str | None = None,
+    order: list[str] | None = None,
+    hue_order: list[str] | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -56,11 +60,17 @@ def boxplot(
         using Mann-Whitney U test.
     showoutliers : bool, default: False
         Whether to display outlier points beyond the whiskers.
-    addcount : bool, default: False
+    add_count : bool, default: False
         Whether to add sample size (n) labels above each box.
     whis : float or tuple of float, default: 1.5
         The proportion of the IQR past the low and high quartiles to extend the
         plot whiskers.
+    hue : str, optional
+        Column name for grouping boxes within each category.
+    order : list of str, optional
+        Order of categories along the categorical axis.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Additional keyword arguments passed to `seaborn.boxplot`.
 
@@ -89,8 +99,15 @@ def boxplot(
     """
     # Validate inputs
     validate_dataframe(data, "data", "boxplot")
-    validate_columns_exist(data, [x, y], "boxplot")
+    columns = [x, y] if hue is None else [x, y, hue]
+    validate_columns_exist(data, columns, "boxplot")
     validate_dataframe_not_empty(data, "boxplot")
+
+    if "addcount" in kwargs:
+        raise TypeError(
+            "boxplot() got an unexpected keyword argument 'addcount'; "
+            "use 'add_count' instead"
+        )
 
     args = {
         "showfliers": showoutliers,
@@ -111,7 +128,14 @@ def boxplot(
         },
         "width": 0.5,
     }
-    plotting: dict[str, Any] = {"data": data, "x": x, "y": y}
+    plotting: dict[str, Any] = {
+        "data": data,
+        "x": x,
+        "y": y,
+        "hue": hue,
+        "order": order,
+        "hue_order": hue_order,
+    }
     plotting.update(args)
     plotting.update(kwargs)
     ax = sns.boxplot(**plotting)
@@ -156,8 +180,8 @@ def boxplot(
     if pairs is not None:
         utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
 
-    if addcount:
-        utils._addcount_helper(data, x, ax)
+    if add_count:
+        utils._add_count_helper(data, x, ax)
 
     return ax
 
@@ -169,7 +193,11 @@ def violinplot(
     pairs: list[tuple[str, str]] | None = None,
     width: float = 0.6,
     add_box: bool = True,
-    addcount: bool = False,
+    add_count: bool = False,
+    *,
+    hue: str | None = None,
+    order: list[str] | None = None,
+    hue_order: list[str] | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -193,8 +221,14 @@ def violinplot(
         Width of each violin body.
     add_box : bool, default: True
         Whether to overlay a narrow box plot inside each violin.
-    addcount : bool, default: False
+    add_count : bool, default: False
         Whether to add sample size (n) labels above each violin.
+    hue : str, optional
+        Column name for grouping violins within each category.
+    order : list of str, optional
+        Order of categories along the categorical axis.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Additional keyword arguments passed to `seaborn.violinplot`.
 
@@ -223,8 +257,15 @@ def violinplot(
     """
     # Validate inputs
     validate_dataframe(data, "data", "violinplot")
-    validate_columns_exist(data, [x, y], "violinplot")
+    columns = [x, y] if hue is None else [x, y, hue]
+    validate_columns_exist(data, columns, "violinplot")
     validate_dataframe_not_empty(data, "violinplot")
+
+    if "addcount" in kwargs:
+        raise TypeError(
+            "violinplot() got an unexpected keyword argument 'addcount'; "
+            "use 'add_count' instead"
+        )
 
     args = {
         "showfliers": False,
@@ -245,7 +286,14 @@ def violinplot(
         "width": 0.2,
         "color": "white",
     }
-    plotting: dict[str, Any] = {"data": data, "x": x, "y": y}
+    plotting: dict[str, Any] = {
+        "data": data,
+        "x": x,
+        "y": y,
+        "hue": hue,
+        "order": order,
+        "hue_order": hue_order,
+    }
     plotting.update(kwargs)
     ax = sns.violinplot(linewidth=0.001, width=width, **plotting)
     plotting.update(args)
@@ -257,13 +305,20 @@ def violinplot(
     if pairs is not None:
         utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
 
-    if addcount:
-        utils._addcount_helper(data, x, ax)
+    if add_count:
+        utils._add_count_helper(data, x, ax)
 
     return ax
 
 
-def distplot(data: pd.DataFrame, x: str, **kwargs: Any) -> Axes:
+def distplot(
+    data: pd.DataFrame,
+    x: str,
+    *,
+    hue: str | None = None,
+    hue_order: list[str] | None = None,
+    **kwargs: Any,
+) -> Axes:
     """
     Create a distribution plot combining histogram and kernel density estimate.
 
@@ -276,6 +331,10 @@ def distplot(data: pd.DataFrame, x: str, **kwargs: Any) -> Axes:
         The input DataFrame containing the data to be plotted.
     x : str
         Column name for the continuous variable to plot.
+    hue : str, optional
+        Column name for grouping distributions.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Additional keyword arguments passed to `seaborn.histplot`.
 
@@ -302,16 +361,31 @@ def distplot(data: pd.DataFrame, x: str, **kwargs: Any) -> Axes:
     """
     # Validate inputs
     validate_dataframe(data, "data", "distplot")
-    validate_column_exists(data, x, "x", "distplot")
+    columns = [x] if hue is None else [x, hue]
+    validate_columns_exist(data, columns, "distplot")
     validate_dataframe_not_empty(data, "distplot")
 
     args = {"kde": True, "edgecolor": None}
     args.update(kwargs)
-    ax = sns.histplot(data=data, x=x, **args)
+    ax = sns.histplot(
+        data=data,
+        x=x,
+        hue=hue,
+        hue_order=hue_order,
+        **args,
+    )
     return ax
 
 
-def kdeplot(data: pd.DataFrame, x: str, add_mode: bool = True, **kwargs: Any) -> Axes:
+def kdeplot(
+    data: pd.DataFrame,
+    x: str,
+    add_mode: bool = True,
+    *,
+    hue: str | None = None,
+    hue_order: list[str] | None = None,
+    **kwargs: Any,
+) -> Axes:
     """
     Create a kernel density estimate plot with optional mode annotation.
 
@@ -327,6 +401,10 @@ def kdeplot(data: pd.DataFrame, x: str, add_mode: bool = True, **kwargs: Any) ->
         Column name for the continuous variable to plot.
     add_mode : bool, default: True
         Whether to add a vertical dashed line at the mode (peak) of the distribution.
+    hue : str, optional
+        Column name for grouping density estimates.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Additional keyword arguments passed to `seaborn.kdeplot`.
 
@@ -353,19 +431,24 @@ def kdeplot(data: pd.DataFrame, x: str, add_mode: bool = True, **kwargs: Any) ->
     """
     # Validate inputs
     validate_dataframe(data, "data", "kdeplot")
-    columns_to_check = [x]
-    if "hue" in kwargs:
-        columns_to_check.append(kwargs["hue"])
+    columns_to_check = [x] if hue is None else [x, hue]
     validate_columns_exist(data, columns_to_check, "kdeplot")
     validate_dataframe_not_empty(data, "kdeplot")
 
     linewidth = kwargs.pop("linewidth", 1)
-    ax = sns.kdeplot(data=data, x=x, linewidth=linewidth, **kwargs)
+    ax = sns.kdeplot(
+        data=data,
+        x=x,
+        hue=hue,
+        hue_order=hue_order,
+        linewidth=linewidth,
+        **kwargs,
+    )
     ax = plt.gca()
     modes = []
-    if "hue" in kwargs:
-        if data[kwargs["hue"]].nunique() == 2:
-            grouped = data.groupby(kwargs["hue"])
+    if hue is not None:
+        if data[hue].nunique() == 2:
+            grouped = data.groupby(hue)
             args = [group_df[x].values for _, group_df in grouped]
             p_value = sp.stats.ks_2samp(*args)
             ax = plt.gca()
@@ -421,7 +504,12 @@ def kdeplot(data: pd.DataFrame, x: str, add_mode: bool = True, **kwargs: Any) ->
     return ax
 
 
-def histplot(**kwargs: Any) -> Axes:
+def histplot(
+    *,
+    hue: str | None = None,
+    hue_order: list[str] | None = None,
+    **kwargs: Any,
+) -> Axes:
     """
     Create a histogram plot (wrapper around seaborn.histplot).
 
@@ -430,6 +518,10 @@ def histplot(**kwargs: Any) -> Axes:
 
     Parameters
     ----------
+    hue : str, optional
+        Column name for grouping histograms.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Keyword arguments passed directly to `seaborn.histplot`.
 
@@ -463,6 +555,8 @@ def histplot(**kwargs: Any) -> Axes:
             columns_to_check.append(kwargs["x"])
         if "y" in kwargs:
             columns_to_check.append(kwargs["y"])
+        if hue is not None:
+            columns_to_check.append(hue)
         if columns_to_check:
             validate_columns_exist(data, columns_to_check, "histplot")
 
@@ -471,7 +565,7 @@ def histplot(**kwargs: Any) -> Axes:
     existing_axes = list(host_ax.figure.axes) if track_detached_axes else []
 
     kwargs.setdefault("edgecolor", None)
-    ax = sns.histplot(**kwargs)
+    ax = sns.histplot(hue=hue, hue_order=hue_order, **kwargs)
     if track_detached_axes:
         utils._capture_detached_axes_layout(ax, existing_axes)
     return ax

--- a/src/cnsplots/plots/_regression.py
+++ b/src/cnsplots/plots/_regression.py
@@ -49,6 +49,8 @@ def regplot(
     hue: str | None = None,
     s: float = 3,
     color: ColorType = "black",
+    *,
+    hue_order: list[str] | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -77,6 +79,8 @@ def regplot(
         a legend is added, while a single overall regression line and correlation
         statistic are shown. If *hue* is also specified, *hue* takes precedence
         and *color* is ignored.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Additional keyword arguments passed to `seaborn.regplot`.
 
@@ -127,9 +131,9 @@ def regplot(
     if hue is not None:
         plot_data = finite_data.loc[finite_data[hue].notna()]
         _validate_pearson_sample_size(plot_data)
+        hue_levels = list(plot_data[hue].unique()) if hue_order is None else hue_order
         hue_subsets = [
-            (hue_val, plot_data[plot_data[hue] == hue_val])
-            for hue_val in plot_data[hue].unique()
+            (hue_val, plot_data[plot_data[hue] == hue_val]) for hue_val in hue_levels
         ]
         for hue_val, subset in hue_subsets:
             _validate_pearson_sample_size(subset, group=hue_val)
@@ -219,7 +223,14 @@ def regplot(
 
 
 def scatterplot(
-    data: pd.DataFrame, x: str, y: str, s: float = 7, **kwargs: Any
+    data: pd.DataFrame,
+    x: str,
+    y: str,
+    s: float = 7,
+    *,
+    hue: str | None = None,
+    hue_order: list[str] | None = None,
+    **kwargs: Any,
 ) -> Axes:
     """
     Create a scatter plot with automatic legend size correction.
@@ -234,6 +245,10 @@ def scatterplot(
         Column name for the y-axis variable.
     s : float, default: 7
         Size of scatter plot markers.
+    hue : str, optional
+        Column name for grouping points by color.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Additional keyword arguments passed to `seaborn.scatterplot`.
 
@@ -262,22 +277,41 @@ def scatterplot(
     """
     # Validate inputs
     validate_dataframe(data, "data", "scatterplot")
-    validate_columns_exist(data, [x, y], "scatterplot")
+    columns = [x, y] if hue is None else [x, y, hue]
+    validate_columns_exist(data, columns, "scatterplot")
     validate_dataframe_not_empty(data, "scatterplot")
 
-    ax = sns.scatterplot(data=data, x=x, y=y, s=s, edgecolor=None, **kwargs)
+    ax = sns.scatterplot(
+        data=data,
+        x=x,
+        y=y,
+        hue=hue,
+        hue_order=hue_order,
+        s=s,
+        edgecolor=None,
+        **kwargs,
+    )
 
     _resize_legend_markers(ax.get_legend(), s)
 
     return ax
 
 
-def lineplot(**kwargs: Any) -> Axes:
+def lineplot(
+    *,
+    hue: str | None = None,
+    hue_order: list[str] | None = None,
+    **kwargs: Any,
+) -> Axes:
     """
     Create a line plot (wrapper around seaborn.lineplot).
 
     Parameters
     ----------
+    hue : str, optional
+        Column name for grouping lines by color.
+    hue_order : list of str, optional
+        Order of hue levels.
     **kwargs
         Keyword arguments passed directly to `seaborn.lineplot`.
 
@@ -313,14 +347,24 @@ def lineplot(**kwargs: Any) -> Axes:
             columns_to_check.append(kwargs["x"])
         if "y" in kwargs:
             columns_to_check.append(kwargs["y"])
+        if hue is not None:
+            columns_to_check.append(hue)
         if columns_to_check:
             validate_columns_exist(data, columns_to_check, "lineplot")
 
-    ax = sns.lineplot(**kwargs)
+    ax = sns.lineplot(hue=hue, hue_order=hue_order, **kwargs)
     return ax
 
 
-def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str, pair: str) -> Axes:
+def slopeplot(
+    data: pd.DataFrame,
+    x: str,
+    y: str,
+    hue: str,
+    pair: str,
+    *,
+    hue_order: list[str] | None = None,
+) -> Axes:
     """
     Create a slope plot showing paired changes between two conditions.
 
@@ -338,6 +382,8 @@ def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str, pair: str) -> Axes:
         Column containing the subject or observation identifier used to pair values
         across the two conditions. Each pair must belong to one ``x`` group and have
         exactly one value per condition.
+    hue_order : list of str, optional
+        Order of the two hue levels from left to right within each x group.
 
     Returns
     -------
@@ -378,12 +424,20 @@ def slopeplot(data: pd.DataFrame, x: str, y: str, hue: str, pair: str) -> Axes:
     validate_dataframe_not_empty(data, "slopeplot")
     validate_no_nulls(data, [x, y, hue, pair], "slopeplot")
 
-    hues = data[hue].unique()
-    if len(hues) != 2:
+    observed_hues = list(data[hue].unique())
+    if len(observed_hues) != 2:
         raise ValueError(
             f"[slopeplot] Column '{hue}' must have exactly 2 unique values, "
-            f"found {len(hues)}: {list(hues)}"
+            f"found {len(observed_hues)}: {observed_hues}"
         )
+    if hue_order is not None and (
+        len(hue_order) != 2 or set(hue_order) != set(observed_hues)
+    ):
+        raise ValueError(
+            "[slopeplot] 'hue_order' must contain both observed hue levels exactly "
+            "once."
+        )
+    hues = observed_hues if hue_order is None else hue_order
 
     pair_count = len(data[[pair]].drop_duplicates())
     pair_x_keys = list(dict.fromkeys((pair, x)))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1094,10 +1094,10 @@ def test_utils_helpers_and_showcase_data(
     fig4, ax4 = plt.subplots()
     sns = pytest.importorskip("seaborn")
     sns.boxplot(data=categorical_df, x="group", y="value", ax=ax4)
-    _utils._addcount_helper(categorical_df, "group", ax4)
+    _utils._add_count_helper(categorical_df, "group", ax4)
     assert "(n=" in ax4.get_xticklabels()[0].get_text()
     with pytest.raises(ValueError, match="axis must be 'x' or 'y'"):
-        _utils._addcount_helper(categorical_df, "group", ax4, axis="z")
+        _utils._add_count_helper(categorical_df, "group", ax4, axis="z")
 
     class DummyResult:
         test_short_name = "T"

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -754,11 +754,11 @@ def test_plot_internal_coverage(
 ) -> None:
     with pytest.raises(ValueError, match="errorbar must be one of"):
         cns.lollipopplot(
-            categorical_df, x="group", y="value", addtip=True, errorbar="bad"
+            categorical_df, x="group", y="value", add_tip=True, errorbar="bad"
         )
 
     cns.figure(120, 120)
-    lollipop_ax = cns.lollipopplot(categorical_df, x="group", y="value", addtip=True)
+    lollipop_ax = cns.lollipopplot(categorical_df, x="group", y="value", add_tip=True)
     lollipop_points = [
         collection
         for collection in lollipop_ax.collections
@@ -807,7 +807,7 @@ def test_plot_internal_coverage(
         x="num",
         y="cat",
         hue="hue",
-        addtip=True,
+        add_tip=True,
         errorbar="se",
     )
     horizontal_lollipop_points = [
@@ -839,8 +839,8 @@ def test_plot_internal_coverage(
         y="treatment",
         stack="response",
         normalize=True,
-        addcount=True,
-        bar_order=["C", "B", "A"],
+        add_count=True,
+        order=["C", "B", "A"],
     )
     stack_widths = []
     for patch in stack_ax.patches:

--- a/tests/test_plot_behavior_regressions.py
+++ b/tests/test_plot_behavior_regressions.py
@@ -139,10 +139,38 @@ def test_lollipop_ignores_missing_order_categories_for_errors_and_tips() -> None
         y="value",
         order=["A", "B", "missing"],
         errorbar="se",
-        addtip=True,
+        add_tip=True,
     )
 
     assert [text.get_text() for text in ax.texts] == ["0.50", "2.50"]
+
+
+def test_barplot_labels_each_hue_bar_and_skips_missing_order_levels() -> None:
+    data = pd.DataFrame(
+        {
+            "category": ["A", "A", "A", "A", "B", "B", "B", "B"],
+            "value": [1.0, 3.0, 2.0, 4.0, 5.0, 7.0, 6.0, 8.0],
+            "hue": ["H1", "H1", "H2", "H2"] * 2,
+        }
+    )
+
+    cns.figure(120, 120)
+    ax = cns.barplot(
+        data,
+        x="category",
+        y="value",
+        hue="hue",
+        order=["A", "B", "missing"],
+        hue_order=["H2", "H1"],
+        add_tip=True,
+    )
+
+    assert [text.get_text() for text in ax.texts if text.get_text()] == [
+        "3.0",
+        "7.0",
+        "2.0",
+        "6.0",
+    ]
 
 
 def test_lollipop_rejects_ambiguous_palette_column_combinations() -> None:
@@ -298,9 +326,9 @@ def test_stackplot_y_axis_preserves_bar_and_stack_semantics(
         data,
         y="patient",
         stack="mutation",
-        addcount=True,
+        add_count=True,
         pairs=[("P2", "P1")],
-        bar_order=["P2", "P1"],
+        order=["P2", "P1"],
         stack_order=["M3", "M2", "M1"],
     )
 

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -47,7 +47,7 @@ def test_boxplot_and_violinplot(
             x="group",
             y="value",
             pairs=[("A", "B")],
-            addcount=True,
+            add_count=True,
             showoutliers=True,
             whis=(0, 100),
         )
@@ -77,7 +77,7 @@ def test_boxplot_and_violinplot(
         y="value",
         pairs=[("A", "B")],
         add_box=True,
-        addcount=True,
+        add_count=True,
         hue="hue",
         split=True,
         inner="quart",
@@ -106,7 +106,7 @@ def test_barplot_and_lollipopplot(
         x="group",
         y="value",
         pairs=[("A", "B")],
-        addtip=True,
+        add_tip=True,
         palette="palette_group",
     )
     legend = ax.get_legend()
@@ -125,7 +125,7 @@ def test_barplot_and_lollipopplot(
         y="value",
         hue="hue",
         pairs=[(("A", "H1"), ("A", "H2"))],
-        addtip=True,
+        add_tip=True,
         errorbar="ci",
         palette="Set1",
     )
@@ -138,7 +138,7 @@ def test_barplot_and_lollipopplot(
         y="cat",
         color="black",
         errorbar="sd",
-        addtip=True,
+        add_tip=True,
         estimator="median",
     )
     assert ax3.get_yticklabels()[0].get_text()
@@ -160,12 +160,12 @@ def test_categorical_annotations_use_legend_fontsize(
 ) -> None:
     with cns.settings.context(legend_fontsize=13):
         cns.figure(120, 120)
-        bar_ax = cns.barplot(categorical_df, x="group", y="value", addtip=True)
+        bar_ax = cns.barplot(categorical_df, x="group", y="value", add_tip=True)
         assert {text.get_fontsize() for text in bar_ax.texts} == {13}
 
         cns.figure(120, 120)
         lollipop_ax = cns.lollipopplot(
-            categorical_df, x="group", y="value", addtip=True
+            categorical_df, x="group", y="value", add_tip=True
         )
         assert {text.get_fontsize() for text in lollipop_ax.texts} == {13}
 
@@ -203,9 +203,9 @@ def test_stack_strip_pie_and_donut_plots(
         x="treatment",
         stack="response",
         normalize=True,
-        addcount=True,
+        add_count=True,
         pairs=[("A", "B")],
-        bar_order=["A", "B", "C"],
+        order=["A", "B", "C"],
         stack_order=["Yes", "No"],
     )
     assert ax.get_ylabel() == "Frequency"
@@ -226,7 +226,7 @@ def test_stack_strip_pie_and_donut_plots(
         stack="response",
         normalize=False,
         pairs=[("A", "B")],
-        bar_order=["A", "B", "C"],
+        order=["A", "B", "C"],
         stack_order=["No", "Yes"],
     )
     assert ax2.get_xlabel() == "Count"
@@ -240,7 +240,7 @@ def test_stack_strip_pie_and_donut_plots(
         y="treatment",
         stack="response",
         normalize=False,
-        addcount=True,
+        add_count=True,
     )
     assert {tick.get_text() for tick in ax2b.get_yticklabels()} == {
         "A\n(n=4)",
@@ -256,14 +256,12 @@ def test_stack_strip_pie_and_donut_plots(
         y="value",
         hue="hue",
         showmeans=True,
-        addcount=True,
+        add_count=True,
     )
     assert ax3.get_legend() is not None
 
     cns.figure(120, 120)
-    ax4 = cns.pieplot(
-        categorical_df, x="group", legend="left", hue_order=["C", "B", "A"]
-    )
+    ax4 = cns.pieplot(categorical_df, x="group", legend="left", order=["C", "B", "A"])
     assert ax4.get_legend() is not None
     pie_wedges = [patch for patch in ax4.patches if isinstance(patch, Wedge)]
     np.testing.assert_allclose(
@@ -271,9 +269,7 @@ def test_stack_strip_pie_and_donut_plots(
     )
 
     cns.figure(120, 120)
-    ax5 = cns.donutplot(
-        categorical_df, x="group", legend="top", hue_order=["A", "B", "C"]
-    )
+    ax5 = cns.donutplot(categorical_df, x="group", legend="top", order=["A", "B", "C"])
     assert ax5.get_legend() is not None
     assert any(text.get_text() == "group" for text in ax5.texts)
     donut_wedges = [patch for patch in ax5.patches if isinstance(patch, Wedge)]
@@ -320,6 +316,78 @@ def test_distribution_wrappers(
     assert ax6 is plt.gca()
 
 
+@pytest.mark.parametrize(
+    "plot_name",
+    [
+        "barplot",
+        "boxplot",
+        "violinplot",
+        "stripplot",
+        "distplot",
+        "kdeplot",
+        "histplot",
+        "scatterplot",
+        "lineplot",
+    ],
+)
+def test_seaborn_wrappers_respect_explicit_hue_order(plot_name: str) -> None:
+    data = pd.DataFrame(
+        {
+            "category": ["A", "A", "B", "B", "C", "C"] * 2,
+            "hue": ["H1"] * 6 + ["H2"] * 6,
+            "time": [0, 1, 2, 0, 1, 2] * 2,
+            "value": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0] + [0.5, 1.5, 2.5, 3.5, 4.5, 5.5],
+        }
+    )
+    data["other"] = data["value"] * 2
+    hue_order = ["H2", "H1"]
+
+    if plot_name in {"barplot", "boxplot", "violinplot", "stripplot"}:
+        kwargs: dict[str, Any] = {
+            "data": data,
+            "x": "category",
+            "y": "value",
+            "order": ["C", "B", "A"],
+        }
+    elif plot_name in {"distplot", "kdeplot", "histplot"}:
+        kwargs = {"data": data, "x": "value"}
+    elif plot_name == "scatterplot":
+        kwargs = {"data": data, "x": "value", "y": "other"}
+    else:
+        kwargs = {"data": data, "x": "time", "y": "value"}
+
+    cns.figure(120, 120)
+    ax = getattr(cns, plot_name)(
+        **kwargs,
+        hue="hue",
+        hue_order=hue_order,
+    )
+
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.get_texts()][:2] == hue_order
+    if "order" in kwargs:
+        assert [tick.get_text() for tick in ax.get_xticklabels()] == kwargs["order"]
+
+
+@pytest.mark.parametrize("plot_name", ["pieplot", "donutplot"])
+def test_circular_plots_respect_category_order(plot_name: str) -> None:
+    data = pd.DataFrame({"group": ["A"] + ["B"] * 2 + ["C"] * 3})
+    order = ["A", "C", "B"]
+
+    cns.figure(120, 120)
+    ax = getattr(cns, plot_name)(data, x="group", order=order)
+
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.get_texts()] == order
+    wedges = [patch for patch in ax.patches if isinstance(patch, Wedge)]
+    np.testing.assert_allclose(
+        [patch.theta2 - patch.theta1 for patch in wedges],
+        [60.0, 180.0, 120.0],
+    )
+
+
 def test_distribution_annotations_use_legend_fontsize(
     numeric_df: pd.DataFrame,
     categorical_df: pd.DataFrame,
@@ -362,7 +430,7 @@ def test_pieplot_uses_contrast_text_color() -> None:
 
     cns.figure(120, 120)
     with plt.rc_context({"axes.prop_cycle": cycler(color=["#111111", "#eeeeee"])}):
-        ax = cns.pieplot(data, x="group", hue_order=["dark", "light"])
+        ax = cns.pieplot(data, x="group", order=["dark", "light"])
 
     percent_texts = [text for text in ax.texts if text.get_text().endswith("%")]
     assert [text.get_color() for text in percent_texts] == ["white", "black"]
@@ -370,7 +438,7 @@ def test_pieplot_uses_contrast_text_color() -> None:
     with cns.settings.context(annotation_auto_contrast=False):
         cns.figure(120, 120)
         with plt.rc_context({"axes.prop_cycle": cycler(color=["#111111", "#eeeeee"])}):
-            ax = cns.pieplot(data, x="group", hue_order=["dark", "light"])
+            ax = cns.pieplot(data, x="group", order=["dark", "light"])
 
     percent_texts = [text for text in ax.texts if text.get_text().endswith("%")]
     assert [text.get_color() for text in percent_texts] == ["white", "white"]

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -10,7 +10,7 @@ import types
 from collections.abc import Mapping, Sequence
 from importlib.metadata import version
 from pathlib import Path
-from typing import cast, get_type_hints
+from typing import Any, cast, get_type_hints
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -196,8 +196,79 @@ def test_public_stackplot_signature_contract() -> None:
     assert parameters["stack"].kind is inspect.Parameter.KEYWORD_ONLY
     assert parameters["stack"].default is inspect.Parameter.empty
     assert "horizontal" not in parameters
-    assert "addcount" in parameters
-    assert "addtip" not in parameters
+    assert "add_count" in parameters
+    assert "add_tip" not in parameters
+
+
+@pytest.mark.parametrize(
+    ("plot_name", "canonical_names", "removed_names"),
+    [
+        ("barplot", {"add_tip", "hue", "order", "hue_order"}, {"addtip"}),
+        (
+            "boxplot",
+            {"add_count", "hue", "order", "hue_order"},
+            {"addcount"},
+        ),
+        (
+            "violinplot",
+            {"add_box", "add_count", "hue", "order", "hue_order"},
+            {"addcount"},
+        ),
+        (
+            "lollipopplot",
+            {"add_tip", "hue", "order", "hue_order"},
+            {"addtip"},
+        ),
+        (
+            "stackplot",
+            {"add_count", "order", "stack_order"},
+            {"addcount", "bar_order"},
+        ),
+        (
+            "stripplot",
+            {"add_count", "hue", "order", "hue_order"},
+            {"addcount"},
+        ),
+        ("pieplot", {"order"}, {"hue_order"}),
+        ("donutplot", {"order"}, {"hue_order"}),
+        ("distplot", {"hue", "hue_order"}, set()),
+        ("kdeplot", {"hue", "hue_order"}, set()),
+        ("histplot", {"hue", "hue_order"}, set()),
+        ("scatterplot", {"hue", "hue_order"}, set()),
+        ("lineplot", {"hue", "hue_order"}, set()),
+        ("regplot", {"hue", "hue_order"}, set()),
+        ("slopeplot", {"hue", "hue_order"}, set()),
+    ],
+)
+def test_public_plot_naming_contract(
+    plot_name: str,
+    canonical_names: set[str],
+    removed_names: set[str],
+) -> None:
+    parameters = inspect.signature(getattr(cns, plot_name)).parameters
+
+    assert canonical_names <= set(parameters)
+    assert removed_names.isdisjoint(parameters)
+
+
+def test_removed_plot_keywords_name_their_replacements(
+    categorical_df: pd.DataFrame,
+) -> None:
+    calls = [
+        (cns.barplot, "addtip", "add_tip"),
+        (cns.boxplot, "addcount", "add_count"),
+        (cns.violinplot, "addcount", "add_count"),
+        (cns.stripplot, "addcount", "add_count"),
+    ]
+
+    for plotter, removed, replacement in calls:
+        with pytest.raises(TypeError, match=replacement):
+            cast(Any, plotter)(
+                categorical_df,
+                x="group",
+                y="value",
+                **{removed: True},
+            )
 
 
 def test_public_validation_contract(heatmap_adata: object) -> None:

--- a/tests/test_regression_plot_defects.py
+++ b/tests/test_regression_plot_defects.py
@@ -78,6 +78,64 @@ def test_slopeplot_aligns_values_by_pair_key() -> None:
     assert paired_values == [(1.0, 2.0), (10.0, 20.0)]
 
 
+def test_regplot_and_slopeplot_respect_hue_order() -> None:
+    regression_data = pd.DataFrame(
+        {
+            "x": [0.0, 1.0, 0.0, 1.0],
+            "y": [0.0, 1.0, 1.0, 2.0],
+            "condition": ["before", "before", "after", "after"],
+        }
+    )
+    hue_order = ["after", "before"]
+
+    cns.figure(120, 120)
+    regression_ax = cns.regplot(
+        regression_data,
+        x="x",
+        y="y",
+        hue="condition",
+        hue_order=hue_order,
+    )
+    regression_legend = regression_ax.get_legend()
+    assert regression_legend is not None
+    assert [text.get_text() for text in regression_legend.get_texts()] == hue_order
+
+    slope_data = regression_data.assign(site="A", subject=["one", "two"] * 2)
+    cns.figure(120, 120)
+    slope_ax = cns.slopeplot(
+        slope_data,
+        x="site",
+        y="y",
+        hue="condition",
+        pair="subject",
+        hue_order=hue_order,
+    )
+    slope_legend = slope_ax.get_legend()
+    assert slope_legend is not None
+    assert [text.get_text() for text in slope_legend.get_texts()] == hue_order
+
+
+def test_slopeplot_rejects_incomplete_hue_order() -> None:
+    data = pd.DataFrame(
+        {
+            "site": ["A"] * 4,
+            "subject": ["one", "two"] * 2,
+            "condition": ["before", "before", "after", "after"],
+            "value": [1.0, 10.0, 2.0, 20.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="hue_order.*both observed"):
+        cns.slopeplot(
+            data,
+            x="site",
+            y="value",
+            hue="condition",
+            pair="subject",
+            hue_order=["before", "missing"],
+        )
+
+
 @pytest.mark.parametrize(
     "conditions",
     [


### PR DESCRIPTION
## What changed

- Standardize add_* parameter names and category ordering across plotting functions.
- Expose hue and hue_order as explicit parameters across seaborn-backed wrappers.
- Add hue ordering to regression and slope plots, correct grouped bar labels, and update examples and API contract tests.

## Tested

- make test: 326 passed with 100% coverage.
- make lint: all checks passed.

## Risks and follow-ups

- Breaking API change: callers must migrate addtip to add_tip, addcount to add_count, stackplot bar_order to order, and pieplot or donutplot hue_order to order.
- No additional follow-up identified.