### PR TITLE
✨ Add axes-aware plot composition

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,13 @@ import cnsplots as cns
 
 ## Plotting Functions
 
+Every plotting function accepts a keyword-only `ax` argument for composition
+inside an existing Matplotlib layout. Most return the target
+`matplotlib.axes.Axes`; `heatmapplot`, `dotplot`, `upsetplot`, and `vennplot`
+instead preserve their backend-native results: `ClusterMapPlotterNew`,
+`DotClustermapPlotterNew`, a dictionary of panel axes, and a matplotlib-venn
+diagram object, respectively.
+
 ### Distribution & Comparison Plots
 
 ```{eval-rst}

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -94,6 +94,12 @@ plt.tight_layout()
 cns.savefig("subplots.svg")
 ```
 
+All plotting functions accept `ax` as a keyword-only argument, so they can be
+composed into an existing Matplotlib layout. Most return the target
+`matplotlib.axes.Axes`. `heatmapplot`, `dotplot`, `upsetplot`, and `vennplot`
+retain their backend-native return objects so callers can access their
+multi-panel layout or diagram elements.
+
 ## Saving Figures
 
 For publication, save figures in vector formats:

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -147,6 +147,108 @@ def _chain_axes_sync_hook(
     return sync
 
 
+class _HostRelativeAxesLocator:
+    """Locate an axes within a live host while exposing its SubplotSpec."""
+
+    def __init__(
+        self,
+        host_ax: Axes,
+        layout: tuple[float, float, float, float],
+        *,
+        use_original_position: bool = True,
+    ) -> None:
+        self._host_ax = host_ax
+        self._layout = layout
+        self._use_original_position = use_original_position
+
+    def get_subplotspec(self):
+        return self._host_ax.get_subplotspec()
+
+    def __call__(self, _ax: Any, _renderer: Any) -> mtransforms.Bbox:
+        host_pos = self._host_ax.get_position(
+            original=self._use_original_position
+        ).frozen()
+        x0, y0, width, height = self._layout
+        return mtransforms.Bbox.from_bounds(
+            host_pos.x0 + host_pos.width * x0,
+            host_pos.y0 + host_pos.height * y0,
+            host_pos.width * width,
+            host_pos.height * height,
+        )
+
+
+def _anchor_axes_to_host(
+    host_ax: Axes,
+    axes: Sequence[Axes],
+    *,
+    use_original_position: bool = True,
+) -> None:
+    """Keep helper axes at fixed positions relative to a live host axes."""
+    host_pos = host_ax.get_position(original=use_original_position).frozen()
+    if host_pos.width <= 0 or host_pos.height <= 0:
+        return
+
+    child_axes = [
+        child_ax
+        for child_ax in axes
+        if child_ax is not host_ax and child_ax.figure is host_ax.figure
+    ]
+    if not child_axes:
+        return
+
+    child_positions = [
+        child_ax.get_position(original=True).frozen() for child_ax in child_axes
+    ]
+    source_pos = mtransforms.Bbox.union(child_positions)
+    if source_pos.width <= 0 or source_pos.height <= 0:
+        source_pos = host_pos
+
+    host_spec = host_ax.get_subplotspec()
+    layouts = []
+    for child_ax, child_pos in zip(child_axes, child_positions):
+        layout = (
+            float((child_pos.x0 - source_pos.x0) / source_pos.width),
+            float((child_pos.y0 - source_pos.y0) / source_pos.height),
+            float(child_pos.width / source_pos.width),
+            float(child_pos.height / source_pos.height),
+        )
+        locator = _HostRelativeAxesLocator(
+            host_ax,
+            layout,
+            use_original_position=use_original_position,
+        )
+        existing_locator = child_ax.get_axes_locator()
+
+        if host_spec is None:
+            setattr(child_ax, "_subplotspec", None)
+            child_ax.set_in_layout(False)
+        else:
+            child_ax.set_subplotspec(host_spec)
+            child_ax.set_in_layout(True)
+
+        if (
+            existing_locator is not None
+            and type(existing_locator).__name__ == "_ColorbarAxesLocator"
+        ):
+            setattr(existing_locator, "_orig_locator", locator)
+            installed_locator = existing_locator
+        else:
+            installed_locator = locator
+        child_ax.set_axes_locator(installed_locator)
+        layouts.append((child_ax, installed_locator))
+
+    def _sync_axes() -> None:
+        for child_ax, locator in layouts:
+            if child_ax.figure is not host_ax.figure:
+                continue
+            locate = cast(Callable[[Any, Any], mtransforms.Bbox], locator)
+            child_ax.set_position(locate(child_ax, None), which="active")
+            child_ax.set_in_layout(host_spec is not None)
+
+    _chain_axes_sync_hook(host_ax, _sync_axes)
+    _sync_axes()
+
+
 def _capture_detached_axes_layout(
     host_ax: Axes,
     existing_axes: Sequence[Axes] | None = None,
@@ -375,7 +477,11 @@ def _get_export_bbox_inches(fig) -> mtransforms.Bbox | None:
         fig.set_canvas(original_canvas)
 
 
-def take_legend_out(title: str | None = None) -> None:
+def take_legend_out(
+    title: str | None = None,
+    *,
+    ax: Axes | None = None,
+) -> None:
     """
     Move the legend outside the plot area to the upper-left of the right margin.
 
@@ -387,6 +493,8 @@ def take_legend_out(title: str | None = None) -> None:
     title : str, optional
         Title for the legend. If None, uses the existing legend title from
         the current axes.
+    ax : matplotlib.axes.Axes, optional
+        Axes whose legend should be moved. Defaults to the current Axes.
 
     Returns
     -------
@@ -418,7 +526,8 @@ def take_legend_out(title: str | None = None) -> None:
     >>> cns.barplot(data=df, x="treatment", y="response", hue="batch")
     >>> cns.take_legend_out(title="Batch")
     """
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     legend = ax.get_legend()
     handles = None
     labels = None
@@ -429,7 +538,7 @@ def take_legend_out(title: str | None = None) -> None:
             title = legend.get_title().get_text()
     if title is None:
         title = ""
-    plt.legend(
+    ax.legend(
         handles=handles,
         labels=labels,
         bbox_to_anchor=settings.legend_out_bbox_to_anchor,

--- a/src/cnsplots/helpers/_heatmap.py
+++ b/src/cnsplots/helpers/_heatmap.py
@@ -362,10 +362,12 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
         ylabel_bbox_kws: dict[str, Any] | None = None,
         legend_delta_x: float | None = None,
         verbose: int = 1,
+        ax: Axes | None = None,
         **kwargs: Any,
     ) -> None:
         self.data = data
         self.legend_gap = legend_gap
+        self._host_ax = ax
         super().__init__(
             data=data,
             z_score=z_score,
@@ -432,6 +434,22 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
         )
         if not plot:
             self.post_processing()
+
+    def plot(
+        self,
+        ax: Axes | None = None,
+        subplot_spec: Any = None,
+        row_order: Any = None,
+        col_order: Any = None,
+    ) -> Axes:
+        if ax is None:
+            ax = self._host_ax
+        return super().plot(
+            ax=ax,
+            subplot_spec=subplot_spec,
+            row_order=row_order,
+            col_order=col_order,
+        )
 
     def _define_axes(self, subplot_spec: Any = None) -> None:
         if not _define_axes_within_current_bounds(self, subplot_spec):
@@ -530,6 +548,31 @@ class DotClustermapPlotterNew(DotClustermapPlotter):
     dot_legend: mlegend.Legend | None
     cbar_ax: Axes | None
     legend_ax: Axes | None
+
+    def __init__(
+        self,
+        *args: Any,
+        ax: Axes | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._host_ax = ax
+        super().__init__(*args, **kwargs)
+
+    def plot(
+        self,
+        ax: Axes | None = None,
+        subplot_spec: Any = None,
+        row_order: Any = None,
+        col_order: Any = None,
+    ) -> Axes:
+        if ax is None:
+            ax = self._host_ax
+        return super().plot(
+            ax=ax,
+            subplot_spec=subplot_spec,
+            row_order=row_order,
+            col_order=col_order,
+        )
 
     def _define_axes(self, subplot_spec: Any = None) -> None:
         if not _define_axes_within_current_bounds(self, subplot_spec):

--- a/src/cnsplots/helpers/_phylo.py
+++ b/src/cnsplots/helpers/_phylo.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from cnsplots._validation import (
     validate_adata_layer,
@@ -24,7 +25,7 @@ from cnsplots._validation import (
 )
 
 
-def phyloplot(adata: AnnData) -> None:
+def phyloplot(adata: AnnData, *, ax: Axes | None = None) -> Axes:
     import io
 
     import Bio.Phylo
@@ -40,20 +41,15 @@ def phyloplot(adata: AnnData) -> None:
     ]
     adata = cast(Any, adata)[cell_ids].copy()
 
-    fig = plt.gcf()
-    axes = fig.subplots(
-        nrows=1,
-        ncols=5,
-        sharey=True,
-        width_ratios=[0.2, 0.6, 0.05, 0.05, 0.1],
-        squeeze=False,
-        gridspec_kw=dict(hspace=0, wspace=0.1),
-    )[0]
-    tree_ax = cast(matplotlib.axes.Axes, axes[0])
-    heatmap_ax = cast(matplotlib.axes.Axes, axes[1])
-    group_ax_1 = cast(matplotlib.axes.Axes, axes[2])
-    group_ax_2 = cast(matplotlib.axes.Axes, axes[3])
-    legend_ax = cast(matplotlib.axes.Axes, axes[4])
+    if ax is None:
+        ax = plt.gca()
+    heatmap_ax = ax
+    divider = make_axes_locatable(heatmap_ax)
+    tree_ax = divider.append_axes("left", size="33.333%", pad=0.01, sharey=ax)
+    group_ax_1 = divider.append_axes("right", size="8.333%", pad=0.01, sharey=ax)
+    group_ax_2 = divider.append_axes("right", size="8.333%", pad=0.01, sharey=ax)
+    legend_ax = divider.append_axes("right", size="16.667%", pad=0.01)
+    axes = [tree_ax, heatmap_ax, group_ax_1, group_ax_2, legend_ax]
     for ax in axes:
         ax.set_axis_off()
     with plt.rc_context({"lines.linewidth": 0.5}):
@@ -85,6 +81,7 @@ def phyloplot(adata: AnnData) -> None:
         rasterized=True,
         palette="Set2",
     )
+    return heatmap_ax
 
 
 def _heatmap(

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -206,6 +206,7 @@ def barplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -234,6 +235,8 @@ def barplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `seaborn.barplot`.
 
@@ -305,7 +308,9 @@ def barplot(
     }
     plotting.update(args)
     plotting.update(kwargs)
-    ax = sns.barplot(**plotting)
+    if ax is None:
+        ax = plt.gca()
+    ax = sns.barplot(ax=ax, **plotting)
     if add_tip:
         for container in (
             item for item in ax.containers if isinstance(item, BarContainer)
@@ -352,6 +357,8 @@ def lollipopplot(
     color: str | None = None,
     palette: Any = None,
     baseline: float = 0,
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a lollipop plot showing values across categories.
@@ -402,6 +409,8 @@ def lollipopplot(
         or a column name in data for palette-as-column mapping.
     baseline : float, default: 0
         Value at which the stems originate.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
 
     Returns
     -------
@@ -458,7 +467,8 @@ def lollipopplot(
     categories = order if order is not None else list(data[cat_col].unique())
     cat_positions = np.arange(len(categories))
 
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
 
     # Resolve palette and legend
     show_legend = False
@@ -609,6 +619,7 @@ def stackplot(
     pairs: list[tuple[str, str]] | None = None,
     add_count: bool = False,
     n_factor: int | float = 1,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a stacked bar plot showing categorical distributions.
@@ -648,6 +659,8 @@ def stackplot(
         format ``n=...``.
     n_factor : int or float, default: 1
         Scaling factor to divide all values.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
 
     Returns
     -------
@@ -701,7 +714,8 @@ def stackplot(
         value_label = "Count"
     df = df.reindex(index=order)
     df = df / n_factor
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     if y is not None:
         ax = df.plot.barh(stacked=True, width=width, ax=ax, rot=0)
         ax.set_ylabel("")
@@ -710,7 +724,7 @@ def stackplot(
         ax = df.plot.bar(stacked=True, width=width, ax=ax, rot=0)
         ax.set_ylabel(value_label)
         ax.set_xlabel("")
-    utils.take_legend_out()
+    utils.take_legend_out(ax=ax)
     if add_count:
         count_axis = "y" if y is not None else "x"
         utils._add_count_helper(data, bar, ax, axis=count_axis)
@@ -743,6 +757,7 @@ def stripplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -773,6 +788,8 @@ def stripplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `seaborn.stripplot`.
 
@@ -813,6 +830,8 @@ def stripplot(
             "use 'add_count' instead"
         )
 
+    if ax is None:
+        ax = plt.gca()
     ax = sns.stripplot(
         data=data,
         x=x,
@@ -821,6 +840,7 @@ def stripplot(
         order=order,
         hue_order=hue_order,
         size=size,
+        ax=ax,
         **kwargs,
     )
     sns.boxplot(
@@ -857,6 +877,8 @@ def pieplot(
     x: str,
     legend: str = "bottom",
     order: list[str] | None = None,
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a pie chart showing categorical proportions.
@@ -871,6 +893,8 @@ def pieplot(
         Position of the legend relative to the pie chart.
     order : list, optional
         Order of categories to display in the pie chart.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
 
     Returns
     -------
@@ -900,7 +924,8 @@ def pieplot(
     df = data[x].value_counts()
     if order is None:
         order = df.index
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     ax = df.reindex(index=order).plot.pie(
         shadow=False,
         autopct="%1.0f%%",
@@ -931,6 +956,8 @@ def donutplot(
     x: str,
     legend: str = "bottom",
     order: list[str] | None = None,
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a donut chart showing categorical proportions.
@@ -945,6 +972,8 @@ def donutplot(
         Position of the legend relative to the pie chart.
     order : list, optional
         Order of categories to display in the donut chart.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
 
     Returns
     -------
@@ -974,7 +1003,8 @@ def donutplot(
     df = data[x].value_counts()
     if order is None:
         order = df.index
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     ax = df.reindex(index=order).plot.pie(
         labeldistance=None,
         ax=ax,
@@ -982,7 +1012,7 @@ def donutplot(
         legend=True,
         wedgeprops={"edgecolor": "black", "linewidth": 0.3, "width": 0.4},
     )
-    plt.annotate(x, (0, 0), size=_legend_fontsize(), ha="center", va="center")
+    ax.annotate(x, (0, 0), size=_legend_fontsize(), ha="center", va="center")
     utils._remove_edge_from_legend_items(ax)
     legend_positions = {
         "right": {"loc": "upper left", "bbox_to_anchor": (1, 1.02)},

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -38,6 +38,7 @@ def boxplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -71,6 +72,8 @@ def boxplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `seaborn.boxplot`.
 
@@ -138,7 +141,9 @@ def boxplot(
     }
     plotting.update(args)
     plotting.update(kwargs)
-    ax = sns.boxplot(**plotting)
+    if ax is None:
+        ax = plt.gca()
+    ax = sns.boxplot(ax=ax, **plotting)
 
     box_patches = [
         patch for patch in ax.patches if isinstance(patch, mpl.patches.PathPatch)
@@ -198,6 +203,7 @@ def violinplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -229,6 +235,8 @@ def violinplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `seaborn.violinplot`.
 
@@ -295,13 +303,15 @@ def violinplot(
         "hue_order": hue_order,
     }
     plotting.update(kwargs)
-    ax = sns.violinplot(linewidth=0.001, width=width, **plotting)
+    if ax is None:
+        ax = plt.gca()
+    ax = sns.violinplot(ax=ax, linewidth=0.001, width=width, **plotting)
     plotting.update(args)
     plotting.update(kwargs)
     # Remove violin-only arguments that boxplot doesn't support
     boxplot_kwargs = {k: v for k, v in plotting.items() if k not in ("split", "inner")}
     if add_box:
-        sns.boxplot(**boxplot_kwargs)
+        sns.boxplot(ax=ax, **boxplot_kwargs)
     if pairs is not None:
         utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
 
@@ -317,6 +327,7 @@ def distplot(
     *,
     hue: str | None = None,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -335,6 +346,8 @@ def distplot(
         Column name for grouping distributions.
     hue_order : list of str, optional
         Order of hue levels.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `seaborn.histplot`.
 
@@ -367,11 +380,14 @@ def distplot(
 
     args = {"kde": True, "edgecolor": None}
     args.update(kwargs)
+    if ax is None:
+        ax = plt.gca()
     ax = sns.histplot(
         data=data,
         x=x,
         hue=hue,
         hue_order=hue_order,
+        ax=ax,
         **args,
     )
     return ax
@@ -384,6 +400,7 @@ def kdeplot(
     *,
     hue: str | None = None,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -405,6 +422,8 @@ def kdeplot(
         Column name for grouping density estimates.
     hue_order : list of str, optional
         Order of hue levels.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `seaborn.kdeplot`.
 
@@ -436,22 +455,23 @@ def kdeplot(
     validate_dataframe_not_empty(data, "kdeplot")
 
     linewidth = kwargs.pop("linewidth", 1)
+    if ax is None:
+        ax = plt.gca()
     ax = sns.kdeplot(
         data=data,
         x=x,
         hue=hue,
         hue_order=hue_order,
         linewidth=linewidth,
+        ax=ax,
         **kwargs,
     )
-    ax = plt.gca()
     modes = []
     if hue is not None:
         if data[hue].nunique() == 2:
             grouped = data.groupby(hue)
             args = [group_df[x].values for _, group_df in grouped]
             p_value = sp.stats.ks_2samp(*args)
-            ax = plt.gca()
             x_lim = ax.get_xlim()
             y_lim = ax.get_ylim()
             ax.text(
@@ -505,9 +525,40 @@ def kdeplot(
 
 
 def histplot(
+    data: pd.DataFrame | None = None,
     *,
-    hue: str | None = None,
-    hue_order: list[str] | None = None,
+    x: Any = None,
+    y: Any = None,
+    hue: Any = None,
+    weights: Any = None,
+    stat: str = "count",
+    bins: Any = "auto",
+    binwidth: float | None = None,
+    binrange: tuple[float, float] | None = None,
+    discrete: bool | None = None,
+    cumulative: bool = False,
+    common_bins: bool = True,
+    common_norm: bool = True,
+    multiple: str = "layer",
+    element: str = "bars",
+    fill: bool = True,
+    shrink: float = 1,
+    kde: bool = False,
+    kde_kws: dict[str, Any] | None = None,
+    line_kws: dict[str, Any] | None = None,
+    thresh: float | None = 0,
+    pthresh: float | None = None,
+    pmax: float | None = None,
+    cbar: bool = False,
+    cbar_ax: Axes | None = None,
+    cbar_kws: dict[str, Any] | None = None,
+    palette: Any = None,
+    hue_order: list[Any] | None = None,
+    hue_norm: Any = None,
+    color: Any = None,
+    log_scale: Any = None,
+    legend: bool = True,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -518,10 +569,38 @@ def histplot(
 
     Parameters
     ----------
-    hue : str, optional
-        Column name for grouping histograms.
-    hue_order : list of str, optional
-        Order of hue levels.
+    data : pd.DataFrame, optional
+        Input data in long or wide form.
+    x, y, hue, weights : str or vector, optional
+        Variables that define positions, grouping, and observation weights.
+    stat : str, default: "count"
+        Aggregate statistic shown by each bin.
+    bins, binwidth, binrange, discrete
+        Parameters controlling how histogram bins are defined.
+    cumulative, common_bins, common_norm : bool
+        Parameters controlling cumulative and shared histogram calculations.
+    multiple, element, fill, shrink
+        Parameters controlling how histogram marks are drawn.
+    kde : bool, default: False
+        Whether to add a kernel density estimate.
+    kde_kws, line_kws : dict, optional
+        Additional keyword arguments for the KDE and its line artists.
+    thresh, pthresh, pmax : float, optional
+        Thresholds used when drawing a bivariate histogram.
+    cbar : bool, default: False
+        Whether to add a colorbar for a bivariate histogram.
+    cbar_ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the colorbar.
+    cbar_kws : dict, optional
+        Additional keyword arguments for the colorbar.
+    palette, hue_order, hue_norm, color
+        Parameters controlling color mapping.
+    log_scale : bool, number, or pair, optional
+        Log scaling configuration for the plot axes.
+    legend : bool, default: True
+        Whether to draw a legend.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Keyword arguments passed directly to `seaborn.histplot`.
 
@@ -546,32 +625,69 @@ def histplot(
     >>> ax = cns.histplot(data=df, x="expression", kde=True, hue="treatment")
     >>> ax.set_xlabel("Gene Expression")
     """
-    # Validate inputs if provided in kwargs
-    if "data" in kwargs:
-        validate_dataframe(kwargs["data"], "data", "histplot")
-        data = kwargs["data"]
-        columns_to_check = []
-        if "x" in kwargs:
-            columns_to_check.append(kwargs["x"])
-        if "y" in kwargs:
-            columns_to_check.append(kwargs["y"])
-        if hue is not None:
-            columns_to_check.append(hue)
+    if data is not None:
+        validate_dataframe(data, "data", "histplot")
+        columns_to_check = [
+            value for value in (x, y, hue, weights) if isinstance(value, str)
+        ]
         if columns_to_check:
             validate_columns_exist(data, columns_to_check, "histplot")
 
-    track_detached_axes = bool(kwargs.get("cbar")) and kwargs.get("cbar_ax") is None
-    host_ax = kwargs.get("ax", plt.gca())
-    existing_axes = list(host_ax.figure.axes) if track_detached_axes else []
+    if ax is None:
+        ax = plt.gca()
+    track_detached_axes = cbar and cbar_ax is None
+    existing_axes = list(ax.figure.axes) if track_detached_axes else []
 
     kwargs.setdefault("edgecolor", None)
-    ax = sns.histplot(hue=hue, hue_order=hue_order, **kwargs)
+    ax = sns.histplot(
+        data=data,
+        x=x,
+        y=y,
+        hue=hue,
+        weights=weights,
+        stat=stat,
+        bins=bins,
+        binwidth=binwidth,
+        binrange=binrange,
+        discrete=discrete,
+        cumulative=cumulative,
+        common_bins=common_bins,
+        common_norm=common_norm,
+        multiple=multiple,
+        element=element,
+        fill=fill,
+        shrink=shrink,
+        kde=kde,
+        kde_kws=kde_kws,
+        line_kws=line_kws,
+        thresh=thresh,
+        pthresh=pthresh,
+        pmax=pmax,
+        cbar=cbar,
+        cbar_ax=cbar_ax,
+        cbar_kws=cbar_kws,
+        palette=palette,
+        hue_order=hue_order,
+        hue_norm=hue_norm,
+        color=color,
+        log_scale=log_scale,
+        legend=legend,
+        ax=ax,
+        **kwargs,
+    )
     if track_detached_axes:
         utils._capture_detached_axes_layout(ax, existing_axes)
     return ax
 
 
-def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes:
+def ridgeplot(
+    data: pd.DataFrame,
+    x: str,
+    y: str,
+    cmap: str = "viridis",
+    *,
+    ax: Axes | None = None,
+) -> Axes:
     """
     Create a ridge plot (joyplot) showing distributions across categories.
 
@@ -589,6 +705,8 @@ def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes
     cmap : str, optional
         Name of a matplotlib colormap to use for coloring the ridges.
         Default is ``"viridis"``.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
 
     Returns
     -------
@@ -604,11 +722,11 @@ def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes
     Examples
     --------
     >>> import cnsplots as cns
-    >>> axes = cns.ridgeplot(data=df, x="expression", y="tissue_type")
-    >>> axes[-1].set_xlabel("Gene Expression")
+    >>> ax = cns.ridgeplot(data=df, x="expression", y="tissue_type")
+    >>> ax.set_xlabel("Gene Expression")
 
     >>> # Time series data with a custom colormap
-    >>> axes = cns.ridgeplot(data=df, x="temperature", y="month", cmap="plasma")
+    >>> ax = cns.ridgeplot(data=df, x="temperature", y="month", cmap="plasma")
     """
     # Validate inputs
     validate_dataframe(data, "data", "ridgeplot")
@@ -634,7 +752,8 @@ def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes
 
     n = len(categories)
     colors = utils._get_hex_colors_from_colorbar(cmap, n)
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
 
     from scipy.stats import gaussian_kde
 
@@ -674,7 +793,13 @@ def ridgeplot(data: pd.DataFrame, x: str, y: str, cmap: str = "viridis") -> Axes
     return ax
 
 
-def qqplot(data: pd.DataFrame, x: str, **kwargs: Any) -> Axes:
+def qqplot(
+    data: pd.DataFrame,
+    x: str,
+    *,
+    ax: Axes | None = None,
+    **kwargs: Any,
+) -> Axes:
     """
     Create a quantile-quantile (Q-Q) plot to assess normality.
 
@@ -687,6 +812,8 @@ def qqplot(data: pd.DataFrame, x: str, **kwargs: Any) -> Axes:
         The input DataFrame containing the data to plot.
     x : str
         Column name for the variable to test for normality.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `statsmodels.api.qqplot`.
 
@@ -717,7 +844,8 @@ def qqplot(data: pd.DataFrame, x: str, **kwargs: Any) -> Axes:
 
     import statsmodels.api as sm
 
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     sm.qqplot(
         data[x],
         ax=ax,

--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -34,6 +34,8 @@ def volcanoplot(
     symbol: str = "symbol",
     show_list: list[str] | None = None,
     n_show: int = 10,
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a volcano plot for differential expression analysis.
@@ -58,6 +60,8 @@ def volcanoplot(
         Number of top upregulated and downregulated genes to label automatically
         when ``show_list`` is ``None``. If ``show_list`` is provided, it takes
         precedence and ``n_show`` is ignored.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes.
 
     Returns
     -------
@@ -124,6 +128,8 @@ def volcanoplot(
 
     blue = utils.get_hexcolors_from_apalette([0], "BlueRed")[0]
     red = utils.get_hexcolors_from_apalette([1], "BlueRed")[0]
+    if ax is None:
+        ax = plt.gca()
     ax = sns.scatterplot(
         data=de,
         x=x,
@@ -134,13 +140,14 @@ def volcanoplot(
         edgecolor=None,
         palette={"Down": blue, "NS": "grey", "Up": red, "p_adj < 0.05": "black"},
         rasterized=True,
+        ax=ax,
     )
 
     annotations = []
     for mode, color in [("Up", red), ("Down", blue)]:
         for _, (x0, y0, t) in de.loc[de[hue] == mode, [x, y, symbol]].iterrows():
             annotations.append(
-                plt.annotate(
+                ax.annotate(
                     t,
                     (x0, y0),
                     color=color,
@@ -149,14 +156,16 @@ def volcanoplot(
                 )
             )
     at.adjust_text(
-        annotations, arrowprops={"arrowstyle": "-", "color": "black", "lw": 0.5}
+        annotations,
+        arrowprops={"arrowstyle": "-", "color": "black", "lw": 0.5},
+        ax=ax,
     )
 
     ax.spines["right"].set_visible(True)
     ax.spines["top"].set_visible(True)
     ax.set_xlabel("log2(fold change)")
     ax.set_ylabel("\u2013log10(adjusted p-value)")
-    plt.plot(
+    ax.plot(
         [0, 0],
         [0, max(de[y])],
         color="black",
@@ -164,7 +173,7 @@ def volcanoplot(
         linewidth=0.8,
         dashes=(8, 5),
     )
-    utils.take_legend_out()
+    utils.take_legend_out(ax=ax)
     _resize_legend_markers(ax.get_legend(), 20)
 
     return ax
@@ -179,6 +188,8 @@ def gseaplot(
     top_term: int = 20,
     size: float = 1.8,
     significance_column: str = "FDR q-val",
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a Gene Set Enrichment Analysis (GSEA) dot plot.
@@ -207,6 +218,8 @@ def gseaplot(
     significance_column : str, default: 'FDR q-val'
         Column containing significance values used to filter gene sets by
         ``cutoff``. This is independent of the ``color`` encoding.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes.
 
     Returns
     -------
@@ -246,7 +259,8 @@ def gseaplot(
     plot_data = data.loc[data[significance_column] <= cutoff].copy()
     resolved_cmap = utils.palettes(cmap) if cmap in _CNS_CONTINUOUS_CMAPS else cmap
 
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     gp.dotplot(
         plot_data,
         cmap=cast(Any, resolved_cmap),
@@ -258,7 +272,7 @@ def gseaplot(
         top_term=top_term,
         size=size,
     )
-    fig = plt.gcf()
+    fig = ax.figure
     cbar_ax = fig.axes[-1]
     cbar_ax.yaxis.set_label_position("left")
     cbar_ax.yaxis.labelpad = 1
@@ -278,5 +292,5 @@ def gseaplot(
         markerscale=1.5,
     )
     setup_ax(ax, colorbar_label="")
-    plt.xlabel("Normalized Enrichment Score (NES)")
+    ax.set_xlabel("Normalized Enrichment Score (NES)")
     return ax

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -14,6 +14,7 @@ import seaborn as sns
 from anndata import AnnData
 from anndata.abc import CSCDataset, CSRDataset
 from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from natsort import natsort_keygen
 from scipy import sparse
 from scipy.stats import fisher_exact
@@ -108,6 +109,8 @@ def heatmapplot(
     yticklabels_fontsize: int = 7,
     xlabel_labelpad: float = 5,
     ylabel_labelpad: float = 3,
+    *,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> ClusterMapPlotterNew:
     """
@@ -164,6 +167,8 @@ def heatmapplot(
         Padding between the x-axis label and the tick labels.
     ylabel_labelpad : float, default: 3
         Padding between the y-axis label and the tick labels.
+    ax : matplotlib.axes.Axes, optional
+        Host axes for the heatmap layout. If None, uses the current axes.
     **kwargs
         Additional keyword arguments passed to `ClusterMapPlotterNew`.
 
@@ -305,37 +310,52 @@ def heatmapplot(
         col_split_val = adata.var[col_split]
 
     df = _anndata_to_heatmap_dataframe(adata, layer)
-    cmp = helper_heatmap.ClusterMapPlotterNew(
-        data=df,
-        left_annotation=left_annotation,
-        top_annotation=top_annotation,
-        row_cluster=row_cluster,
-        col_cluster=col_cluster,
-        row_split=row_split_val,
-        col_split=col_split_val,
-        cmap=cmap,
-        rasterized=rasterized,
-        label=label,
-        xlabel=xlabel,
-        ylabel=ylabel,
-        legend_hpad=legend_hpad,
-        legend_vpad=legend_vpad,
-        row_dendrogram_size=10,
-        col_dendrogram_size=10,
-        linewidth=linewidth,
-        xticklabels_kws={
-            "labelrotation": xticklabels_rotation,
-            "labelsize": xticklabels_fontsize,
-        },
-        yticklabels_kws={"labelsize": yticklabels_fontsize},
-        ylabel_kws={"labelpad": ylabel_labelpad},
-        xlabel_kws={"labelpad": xlabel_labelpad},
-        verbose=0,
-        row_names_side="left" if left_annotation is None else "right",
-        xticklabels=True,
-        yticklabels=True,
-        **kwargs,
+    host_ax = ax
+    fig = None if host_ax is None else host_ax.figure
+    layout_fig = (
+        None if host_ax is None else cast(Figure, host_ax.get_figure(root=True))
     )
+    layout_engine = None if layout_fig is None else layout_fig.get_layout_engine()
+    existing_axes = set() if fig is None else set(fig.axes)
+    if layout_fig is not None:
+        layout_fig.set_layout_engine("none")
+    try:
+        cmp = helper_heatmap.ClusterMapPlotterNew(
+            data=df,
+            left_annotation=left_annotation,
+            top_annotation=top_annotation,
+            row_cluster=row_cluster,
+            col_cluster=col_cluster,
+            row_split=row_split_val,
+            col_split=col_split_val,
+            cmap=cmap,
+            rasterized=rasterized,
+            label=label,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            legend_hpad=legend_hpad,
+            legend_vpad=legend_vpad,
+            row_dendrogram_size=10,
+            col_dendrogram_size=10,
+            linewidth=linewidth,
+            xticklabels_kws={
+                "labelrotation": xticklabels_rotation,
+                "labelsize": xticklabels_fontsize,
+            },
+            yticklabels_kws={"labelsize": yticklabels_fontsize},
+            ylabel_kws={"labelpad": ylabel_labelpad},
+            xlabel_kws={"labelpad": xlabel_labelpad},
+            verbose=0,
+            ax=ax,
+            row_names_side="left" if left_annotation is None else "right",
+            xticklabels=True,
+            yticklabels=True,
+            **kwargs,
+        )
+
+    finally:
+        if layout_fig is not None:
+            layout_fig.set_layout_engine(layout_engine)
 
     plt.setp(
         cmp.heatmap_axes[-1, 0].get_xticklabels(), rotation_mode="anchor", ha="right"
@@ -346,8 +366,14 @@ def heatmapplot(
     for s in ["top", "bottom", "left", "right"]:
         cmp.ax_heatmap.spines[s].set_linewidth(settings.axes_linewidth)
 
+    cmp.cbars = getattr(cmp, "cbars", [])
     _style_plotter_colorbars(cmp.cbars)
     helper_heatmap._capture_detached_colorbar_layout(cmp)
+    if fig is not None and host_ax is not None:
+        utils._anchor_axes_to_host(
+            host_ax,
+            [plot_ax for plot_ax in fig.axes if plot_ax not in existing_axes],
+        )
     return cmp
 
 
@@ -364,6 +390,8 @@ def dotplot(
     xticklabels_rotation: int = 45,
     xticklabels_fontsize: int = 7,
     yticklabels_fontsize: int = 7,
+    *,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> DotClustermapPlotterNew:
     """
@@ -399,12 +427,14 @@ def dotplot(
         Font size for x-axis tick labels.
     yticklabels_fontsize : int, default: 7
         Font size for y-axis tick labels.
+    ax : matplotlib.axes.Axes, optional
+        Host axes for the dot plot layout. If None, uses the current axes.
     **kwargs
         Additional keyword arguments passed to `DotClustermapPlotter`.
 
     Returns
     -------
-    DotClustermapPlotter
+    DotClustermapPlotterNew
         The dot plot plotter object containing axes and layout information.
 
     See Also
@@ -466,12 +496,26 @@ def dotplot(
         },
         "yticklabels_kws": {"labelsize": yticklabels_fontsize},
         "dot_legend_kws": {"frameon": False},
+        "ax": ax,
     }
     if value is not None:
         plotter_kwargs["value"] = value
     plotter_kwargs.update(kwargs)
     plotter_kwargs.setdefault("plot_legend", plotter_kwargs.get("legend", True))
-    cmp = helper_heatmap.DotClustermapPlotterNew(**plotter_kwargs)
+    host_ax = ax
+    fig = None if host_ax is None else host_ax.figure
+    layout_fig = (
+        None if host_ax is None else cast(Figure, host_ax.get_figure(root=True))
+    )
+    layout_engine = None if layout_fig is None else layout_fig.get_layout_engine()
+    existing_axes = set() if fig is None else set(fig.axes)
+    if layout_fig is not None:
+        layout_fig.set_layout_engine("none")
+    try:
+        cmp = helper_heatmap.DotClustermapPlotterNew(**plotter_kwargs)
+    finally:
+        if layout_fig is not None:
+            layout_fig.set_layout_engine(layout_engine)
     cmp.cbars = getattr(cmp, "cbars", [])
 
     hm_ax = cmp.heatmap_axes[-1, 0]
@@ -511,6 +555,11 @@ def dotplot(
         cmp.ax_heatmap.spines[s].set_linewidth(settings.axes_linewidth)
 
     _style_plotter_colorbars(cmp.cbars)
+    if fig is not None and host_ax is not None:
+        utils._anchor_axes_to_host(
+            host_ax,
+            [plot_ax for plot_ax in fig.axes if plot_ax not in existing_axes],
+        )
     return cmp
 
 
@@ -552,6 +601,8 @@ def confusionplot(
     cmap: Any = "Blues",
     pvalue_x_pad: float = 0.25,
     pvalue_y_pad: float = 1.5,
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a confusion matrix heatmap with optional classification metrics.
@@ -591,6 +642,9 @@ def confusionplot(
     pvalue_y_pad : float, default: 1.5
         Vertical padding for positioning the statistics text below the plot.
         Larger values move the statistics block farther down.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes. The optional statistics
+        overlay is anchored to this axes.
 
     Returns
     -------
@@ -643,8 +697,9 @@ def confusionplot(
         )
 
     # Plot
-    ax = plt.gca()
-    fig = plt.gcf()
+    if ax is None:
+        ax = plt.gca()
+    fig = ax.figure
     im = ax.imshow(cm_df.values, interpolation="nearest", cmap=cmap)
     ax.set_xlabel(x)
     ax.set_ylabel(y)
@@ -739,6 +794,7 @@ def confusionplot(
         # Overlay the stats block
         pos = ax.get_position()
         ax2 = fig.add_axes((pos.x0, pos.y0, pos.width, pos.height), frameon=False)
+        utils._anchor_axes_to_host(ax, [ax2], use_original_position=False)
         ax2.tick_params(
             labelcolor="none", top=False, bottom=False, left=False, right=False
         )

--- a/src/cnsplots/plots/_regression.py
+++ b/src/cnsplots/plots/_regression.py
@@ -51,6 +51,7 @@ def regplot(
     color: ColorType = "black",
     *,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -81,6 +82,8 @@ def regplot(
         and *color* is ignored.
     hue_order : list of str, optional
         Order of hue levels.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `seaborn.regplot`.
 
@@ -119,7 +122,8 @@ def regplot(
     validate_column_type(data, x, ["numeric"], "regplot")
     validate_column_type(data, y, ["numeric"], "regplot")
 
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     args = {
         "line_kws": {"lw": 1.2},
         "scatter_kws": {"s": s, "alpha": 1, "edgecolor": None},
@@ -230,6 +234,7 @@ def scatterplot(
     *,
     hue: str | None = None,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -249,6 +254,8 @@ def scatterplot(
         Column name for grouping points by color.
     hue_order : list of str, optional
         Order of hue levels.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Additional keyword arguments passed to `seaborn.scatterplot`.
 
@@ -281,6 +288,8 @@ def scatterplot(
     validate_columns_exist(data, columns, "scatterplot")
     validate_dataframe_not_empty(data, "scatterplot")
 
+    if ax is None:
+        ax = plt.gca()
     ax = sns.scatterplot(
         data=data,
         x=x,
@@ -289,6 +298,7 @@ def scatterplot(
         hue_order=hue_order,
         s=s,
         edgecolor=None,
+        ax=ax,
         **kwargs,
     )
 
@@ -298,9 +308,35 @@ def scatterplot(
 
 
 def lineplot(
+    data: pd.DataFrame | None = None,
     *,
-    hue: str | None = None,
-    hue_order: list[str] | None = None,
+    x: Any = None,
+    y: Any = None,
+    hue: Any = None,
+    size: Any = None,
+    style: Any = None,
+    units: Any = None,
+    weights: Any = None,
+    palette: Any = None,
+    hue_order: list[Any] | None = None,
+    hue_norm: Any = None,
+    sizes: Any = None,
+    size_order: list[Any] | None = None,
+    size_norm: Any = None,
+    dashes: Any = True,
+    markers: Any = None,
+    style_order: list[Any] | None = None,
+    estimator: Any = "mean",
+    errorbar: Any = ("ci", 95),
+    n_boot: int = 1000,
+    seed: Any = None,
+    orient: str = "x",
+    sort: bool = True,
+    err_style: str = "band",
+    err_kws: dict[str, Any] | None = None,
+    legend: Any = "auto",
+    ci: Any = "deprecated",
+    ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
     """
@@ -308,10 +344,38 @@ def lineplot(
 
     Parameters
     ----------
-    hue : str, optional
-        Column name for grouping lines by color.
-    hue_order : list of str, optional
-        Order of hue levels.
+    data : pd.DataFrame, optional
+        Input data in long or wide form.
+    x, y, hue, size, style, units, weights : str or vector, optional
+        Variables that define positions, grouping, and observation units or weights.
+    palette, hue_order, hue_norm
+        Parameters controlling hue color mapping.
+    sizes, size_order, size_norm
+        Parameters controlling line-width mapping.
+    dashes, markers, style_order
+        Parameters controlling line-style and marker mapping.
+    estimator : str, callable, or None, default: "mean"
+        Method used to aggregate repeated observations.
+    errorbar
+        Error-bar method and confidence level.
+    n_boot : int, default: 1000
+        Number of bootstrap samples used for uncertainty estimates.
+    seed : int, random generator, or None
+        Seed or generator for reproducible bootstrapping.
+    orient : {"x", "y"}, default: "x"
+        Axis along which observations are sorted and aggregated.
+    sort : bool, default: True
+        Whether to sort observations by the orient variable.
+    err_style : {"band", "bars"}, default: "band"
+        Visual representation used for uncertainty.
+    err_kws : dict, optional
+        Additional keyword arguments for uncertainty artists.
+    legend : "auto", "brief", "full", or bool, default: "auto"
+        How to draw semantic variable legends.
+    ci
+        Deprecated compatibility parameter forwarded to Seaborn.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
         Keyword arguments passed directly to `seaborn.lineplot`.
 
@@ -338,21 +402,49 @@ def lineplot(
     ... )
     >>> ax.set_ylabel("Gene Expression")
     """
-    # Validate inputs if provided in kwargs
-    if "data" in kwargs:
-        validate_dataframe(kwargs["data"], "data", "lineplot")
-        data = kwargs["data"]
-        columns_to_check = []
-        if "x" in kwargs:
-            columns_to_check.append(kwargs["x"])
-        if "y" in kwargs:
-            columns_to_check.append(kwargs["y"])
-        if hue is not None:
-            columns_to_check.append(hue)
+    if data is not None:
+        validate_dataframe(data, "data", "lineplot")
+        columns_to_check = [
+            value
+            for value in (x, y, hue, size, style, units, weights)
+            if isinstance(value, str)
+        ]
         if columns_to_check:
             validate_columns_exist(data, columns_to_check, "lineplot")
 
-    ax = sns.lineplot(hue=hue, hue_order=hue_order, **kwargs)
+    if ax is None:
+        ax = plt.gca()
+    ax = sns.lineplot(
+        data=data,
+        x=x,
+        y=y,
+        hue=hue,
+        size=size,
+        style=style,
+        units=units,
+        weights=weights,
+        palette=palette,
+        hue_order=hue_order,
+        hue_norm=hue_norm,
+        sizes=sizes,
+        size_order=size_order,
+        size_norm=size_norm,
+        dashes=dashes,
+        markers=markers,
+        style_order=style_order,
+        estimator=estimator,
+        errorbar=errorbar,
+        n_boot=n_boot,
+        seed=seed,
+        orient=orient,
+        sort=sort,
+        err_style=err_style,
+        err_kws=err_kws,
+        legend=legend,
+        ci=ci,
+        ax=ax,
+        **kwargs,
+    )
     return ax
 
 
@@ -364,6 +456,7 @@ def slopeplot(
     pair: str,
     *,
     hue_order: list[str] | None = None,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a slope plot showing paired changes between two conditions.
@@ -384,6 +477,8 @@ def slopeplot(
         exactly one value per condition.
     hue_order : list of str, optional
         Order of the two hue levels from left to right within each x group.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw the plot. Defaults to the current Axes.
 
     Returns
     -------
@@ -460,7 +555,8 @@ def slopeplot(
     set1 = _get_brewer_map("Set1", "qualitative", 9)
     red, blue = set1.hex_colors[:2]
 
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
 
     sites: list[str] = []
     i = 1.0

--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -11,7 +11,9 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
+from matplotlib.axes import Axes
 from matplotlib.figure import Figure
+from matplotlib_venn._common import VennDiagram
 
 import cnsplots._utils as utils
 from cnsplots._setup import setup_ax
@@ -67,9 +69,10 @@ def _import_upsetplot_module() -> Any:
 def upsetplot(
     sets: Mapping[str, AbstractSet[Any] | list[Any]],
     *,
+    ax: Axes | None = None,
     fig: Figure | None = None,
     **kwargs: Any,
-) -> dict:
+) -> dict[str, Axes | None]:
     """
     Create an UpSet plot for visualizing set intersections.
 
@@ -80,6 +83,9 @@ def upsetplot(
     ----------
     sets : dict
         Dictionary mapping set names (str) to sets or array-like collections.
+    ax : matplotlib.axes.Axes or None, optional
+        Host axes to embed the UpSet layout within. ``element_size`` is not
+        supported when embedding because the host axes fixes the available size.
     fig : matplotlib.figure.Figure or None, optional
         Figure to draw the UpSet plot into. Defaults to a new figure.
     **kwargs
@@ -115,6 +121,12 @@ def upsetplot(
         )
     if not sets:
         raise ValueError("[upsetplot] Parameter 'sets' cannot be empty")
+    if ax is not None and fig is not None:
+        raise ValueError("[upsetplot] Pass either 'ax' or 'fig', not both")
+    if ax is not None and kwargs.get("element_size") is not None:
+        raise ValueError(
+            "[upsetplot] Parameter 'element_size' cannot be used together with 'ax'"
+        )
 
     usp = _import_upsetplot_module()
 
@@ -130,17 +142,48 @@ def upsetplot(
     # Set defaults for compact, publication-style UpSet plots while allowing
     # callers to override them when a different layout is needed.
     kwargs.setdefault("subset_size", "count")
-    kwargs.setdefault("element_size", 17)
     kwargs.setdefault("show_counts", "{:,}")
-    upset = usp.UpSet(data, **kwargs)
-    axes = upset.plot(fig=fig)
-    plt.grid(False)
-    for ax in axes.values():
-        if ax is not None:
-            ax.set_facecolor("none")
-    plot_fig = next((ax.figure for ax in axes.values() if ax is not None), None)
-    if plot_fig is not None and np.allclose(
-        plot_fig.patch.get_facecolor(), (1.0, 1.0, 1.0, 1.0)
+    if ax is None:
+        kwargs.setdefault("element_size", 17)
+        upset = usp.UpSet(data, **kwargs)
+        axes = upset.plot(fig=fig)
+    else:
+        kwargs.setdefault("element_size", None)
+
+        class _EmbeddedUpSet(usp.UpSet):
+            def _sync_to_host(self) -> None:
+                pos = ax.get_position()
+                self._host_gridspec.update(
+                    left=pos.x0,
+                    right=pos.x1,
+                    top=pos.y1,
+                    bottom=pos.y0,
+                )
+
+            def make_grid(self, fig: Figure | None = None) -> dict[str, Any]:
+                specs = super().make_grid(fig)
+                self._host_gridspec = specs["gs"]
+                self._sync_to_host()
+                return specs
+
+        upset = _EmbeddedUpSet(data, **kwargs)
+        axes = upset.plot(fig=ax.figure)
+        ax.set_axis_off()
+        utils._chain_axes_sync_hook(ax, upset._sync_to_host)
+
+    for plot_ax in axes.values():
+        if plot_ax is not None:
+            grid = getattr(plot_ax, "grid", None)
+            if callable(grid):
+                grid(False)
+            plot_ax.set_facecolor("none")
+    plot_fig = next(
+        (plot_ax.figure for plot_ax in axes.values() if plot_ax is not None), None
+    )
+    if (
+        ax is None
+        and plot_fig is not None
+        and np.allclose(plot_fig.patch.get_facecolor(), (1.0, 1.0, 1.0, 1.0))
     ):
         plot_fig.patch.set_facecolor("none")
         plot_fig.patch.set_alpha(0)
@@ -164,10 +207,21 @@ def upsetplot(
         new_pos = [pos_mat.x0 + dx, pos_mat.y0, pos_mat.width, pos_mat.height]
         ax_tot.set_position(new_pos)
 
+    if ax is not None:
+        utils._anchor_axes_to_host(
+            ax,
+            [plot_ax for plot_ax in axes.values() if plot_ax is not None],
+        )
+
     return axes
 
 
-def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
+def vennplot(
+    lists: list[set],
+    labels: tuple[str, ...] | list[str],
+    *,
+    ax: Axes | None = None,
+) -> VennDiagram:
     """
     Create a Venn diagram for 2 or 3 sets.
 
@@ -180,10 +234,12 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
         List of 2 or 3 sets or array-like collections to compare.
     labels : tuple or list of str
         Labels for each set, in the same order as lists.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes.
 
     Returns
     -------
-    matplotlib_venn.VennDiagram
+    VennDiagram
         The Venn diagram object containing the plot elements.
 
     See Also
@@ -219,6 +275,8 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
 
     import matplotlib_venn as venn
 
+    if ax is None:
+        ax = plt.gca()
     lists = [s if isinstance(s, AbstractSet) else set(s) for s in lists]
     if len(lists) == 2:
         areas = ["10", "01", "11"]
@@ -226,20 +284,20 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
         colors = tuple(sns.color_palette(n_colors=2))
         subsets = (lists[0], lists[1])
         label_tuple = (labels[0], labels[1])
-        ax = venn.venn2(subsets, label_tuple, set_colors=colors, alpha=0.8)
+        diagram = venn.venn2(subsets, label_tuple, set_colors=colors, alpha=0.8, ax=ax)
     else:
         areas = ["100", "010", "001", "110", "101", "011", "111"]
         names = ["A", "B", "C"]
         colors = tuple(sns.color_palette(n_colors=3))
         subsets = (lists[0], lists[1], lists[2])
         label_tuple = (labels[0], labels[1], labels[2])
-        ax = venn.venn3(subsets, label_tuple, set_colors=colors, alpha=0.8)
+        diagram = venn.venn3(subsets, label_tuple, set_colors=colors, alpha=0.8, ax=ax)
     legend_fontsize = _legend_fontsize()
     for area in areas:
         try:
-            label = ax.get_label_by_id(area)
+            label = diagram.get_label_by_id(area)
             label.set_fontsize(legend_fontsize)
-            patch = ax.get_patch_by_id(area)
+            patch = diagram.get_patch_by_id(area)
             patch.set_edgecolor("black")
             patch.set_linewidth(0.5)
             get_facecolor = getattr(patch, "get_facecolor", None)
@@ -248,6 +306,6 @@ def vennplot(lists: list[set], labels: tuple[str, ...] | list[str]) -> Any:
         except AttributeError:
             pass
     for area in names:
-        ax.get_label_by_id(area).set_fontsize(legend_fontsize)
+        diagram.get_label_by_id(area).set_fontsize(legend_fontsize)
 
-    return ax
+    return diagram

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import matplotlib.gridspec as grid_spec
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -8,6 +7,7 @@ import seaborn as sns
 from anndata import AnnData
 from matplotlib.axes import Axes
 from matplotlib.patches import Circle, FancyBboxPatch, Polygon
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 from sklearn.metrics import auc, roc_curve
 
 import cnsplots.helpers._sankey as helper_sankey
@@ -21,7 +21,7 @@ from cnsplots._validation import (
 )
 
 
-def placeholderplot(description: str) -> Axes:
+def placeholderplot(description: str, *, ax: Axes | None = None) -> Axes:
     """
     Create a stylized placeholder panel for figure layout mockups.
 
@@ -33,6 +33,8 @@ def placeholderplot(description: str) -> Axes:
     ----------
     description : str
         Text to display in the center of the placeholder panel.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes.
 
     Returns
     -------
@@ -54,7 +56,8 @@ def placeholderplot(description: str) -> Axes:
     if not isinstance(description, str):
         raise TypeError("[placeholderplot] 'description' must be a string.")
 
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     ax.cla()
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
@@ -138,7 +141,14 @@ def placeholderplot(description: str) -> Axes:
     return ax
 
 
-def sankeyplot(data: pd.DataFrame, x: str, y: str, label_rotation: float = 0) -> Axes:
+def sankeyplot(
+    data: pd.DataFrame,
+    x: str,
+    y: str,
+    label_rotation: float = 0,
+    *,
+    ax: Axes | None = None,
+) -> Axes:
     """
     Create a Sankey diagram showing flows between two categorical variables.
 
@@ -156,6 +166,8 @@ def sankeyplot(data: pd.DataFrame, x: str, y: str, label_rotation: float = 0) ->
     label_rotation : float, default: 0
         Rotation angle, in degrees, applied to both left and right Sankey
         labels.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes.
 
     Returns
     -------
@@ -186,7 +198,8 @@ def sankeyplot(data: pd.DataFrame, x: str, y: str, label_rotation: float = 0) ->
     validate_columns_exist(data, [x, y], "sankeyplot")
     validate_dataframe_not_empty(data, "sankeyplot")
 
-    ax = plt.gca()
+    if ax is None:
+        ax = plt.gca()
     keys = np.union1d(data[x].unique(), data[y].unique())
     colors = sns.color_palette(n_colors=len(keys))
     color_dict = dict(zip(keys, colors))
@@ -201,7 +214,7 @@ def sankeyplot(data: pd.DataFrame, x: str, y: str, label_rotation: float = 0) ->
     return ax
 
 
-def phyloplot(adata: AnnData) -> None:
+def phyloplot(adata: AnnData, *, ax: Axes | None = None) -> Axes:
     """
     Create a phylogenetic tree plot with associated heatmaps.
 
@@ -209,11 +222,13 @@ def phyloplot(adata: AnnData) -> None:
     ----------
     adata : AnnData
         Annotated data matrix containing tree structure and annotations.
+    ax : matplotlib.axes.Axes, optional
+        Host axes for the phylogenetic heatmap. If None, uses the current axes.
 
     Returns
     -------
-    None
-        The plot is displayed directly; no Axes object is returned.
+    matplotlib.axes.Axes
+        The host Axes containing the mutation heatmap.
 
     See Also
     --------
@@ -229,11 +244,17 @@ def phyloplot(adata: AnnData) -> None:
 
     import cnsplots.helpers._phylo as helper_phylo
 
-    helper_phylo.phyloplot(adata)
+    if ax is None:
+        ax = plt.gca()
+    return helper_phylo.phyloplot(adata, ax=ax)
 
 
 def forestplot(
-    model: object, bar_width: float | None = None, add_pvalue: bool = True
+    model: object,
+    bar_width: float | None = None,
+    add_pvalue: bool = True,
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a forest plot displaying effect sizes from a regression model.
@@ -252,6 +273,9 @@ def forestplot(
     add_pvalue : bool, optional
         Whether to add the p-value bar panel alongside the forest plot
         (Cox models only). Default is True.
+    ax : matplotlib.axes.Axes, optional
+        Axes to use for the primary forest panel. If None, uses the current
+        axes. The optional p-value panel is appended to this axes.
 
     Returns
     -------
@@ -345,13 +369,9 @@ def forestplot(
         x1err = ["lower_ci", "upper_ci"]
         x1label = "AUC (95% CI)"
         x2label = ""
-    fig = plt.gcf()
-
-    if model_name == "cox" and add_pvalue:
-        gs = grid_spec.GridSpec(1, 2, width_ratios=[5, 3])
-    else:
-        gs = grid_spec.GridSpec(1, 1)
-    ax1 = fig.add_subplot(gs[0])
+    if ax is None:
+        ax = plt.gca()
+    ax1 = ax
 
     unique_hue_groups = data["hue_group"].unique()
     colors = sns.color_palette(n_colors=len(unique_hue_groups))
@@ -405,7 +425,8 @@ def forestplot(
         ax1.axvline(x=0.5, color="red", linestyle="--", linewidth=0.8)
 
     if model_name == "cox" and add_pvalue:
-        ax2 = fig.add_subplot(gs[1])
+        divider = make_axes_locatable(ax1)
+        ax2 = divider.append_axes("right", size="60%", pad=0.1)
         if bar_width is None:
             bar_width = (
                 0.8 / len(unique_hue_groups) if len(unique_hue_groups) > 1 else 0.6
@@ -441,7 +462,11 @@ def forestplot(
 
 
 def rocplot(
-    data: pd.DataFrame, true_label_col: str, pred_prob_cols: str | list[str]
+    data: pd.DataFrame,
+    true_label_col: str,
+    pred_prob_cols: str | list[str],
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a receiver operating characteristic (ROC) curve plot.
@@ -454,6 +479,8 @@ def rocplot(
         Column name for the true binary labels (0 or 1).
     pred_prob_cols : str or list of str
         Column name(s) for predicted probabilities.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes.
 
     Returns
     -------
@@ -494,21 +521,20 @@ def rocplot(
     # Validate binary labels
     validate_binary_column(data, true_label_col, "rocplot")
 
+    if ax is None:
+        ax = plt.gca()
     for col in pred_prob_cols:
         fpr, tpr, _ = roc_curve(data[true_label_col], data[col])
         roc_auc = auc(fpr, tpr)
-        plt.plot(fpr, tpr, label=f"{col} (AUC={roc_auc:.2f})", linewidth=1)
+        ax.plot(fpr, tpr, label=f"{col} (AUC={roc_auc:.2f})", linewidth=1)
 
-    plt.plot(
-        [0, 1], [0, 1], color="black", linestyle="--", linewidth=0.8, dashes=(8, 5)
-    )
-    plt.xlim([-0.02, 1.02])
-    plt.ylim([-0.02, 1.02])
-    plt.xticks([0, 0.2, 0.4, 0.6, 0.8, 1])
-    plt.yticks([0, 0.2, 0.4, 0.6, 0.8, 1])
-    plt.xlabel("False Positive Rate")
-    plt.ylabel("True Positive Rate")
-    ax = plt.gca()
+    ax.plot([0, 1], [0, 1], color="black", linestyle="--", linewidth=0.8, dashes=(8, 5))
+    ax.set_xlim((-0.02, 1.02))
+    ax.set_ylim((-0.02, 1.02))
+    ax.set_xticks([0, 0.2, 0.4, 0.6, 0.8, 1])
+    ax.set_yticks([0, 0.2, 0.4, 0.6, 0.8, 1])
+    ax.set_xlabel("False Positive Rate")
+    ax.set_ylabel("True Positive Rate")
     ax.legend(loc="lower right")
 
     legend = ax.get_legend()

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -111,6 +111,7 @@ def survivalplot(
     *,
     overall_test: Literal["logrank", "trend"] = "logrank",
     pairs: list[tuple[str, str]] | None = None,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a Kaplan-Meier survival plot with statistical comparisons.
@@ -145,6 +146,8 @@ def survivalplot(
         When omitted, the sole contrast is reported automatically for two groups;
         no contrast is inferred for three or more groups. Pass an empty list to
         suppress pairwise inference.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes.
 
     Returns
     -------
@@ -230,28 +233,23 @@ def survivalplot(
                 f"'{hue}': {missing_groups}."
             )
 
-    ax: Any = None
+    if ax is None:
+        ax = plt.gca()
     data[hue] = pd.Categorical(data[hue], categories=hue_order, ordered=True)
     data = data.sort_values(hue)
     kmf = ll.KaplanMeierFitter()
-    for i, group in enumerate(hue_order):
+    for group in hue_order:
         df = data[data[hue] == group]
         label = f"{group} (n={df.shape[0]})"
         kmf.fit(df[duration], df[event], label=label)
-        if i != 0:
-            ax = kmf.plot_survival_function(
-                linewidth=1, ci_show=False, show_censors=True, censor_styles={"ms": 3}
-            )
-        else:
-            ax = kmf.plot_survival_function(
-                ax=ax,
-                linewidth=1,
-                ci_show=False,
-                show_censors=True,
-                censor_styles={"ms": 3},
-            )
-    assert ax is not None
-    plt.ylim(-0.05, 1.01)
+        kmf.plot_survival_function(
+            ax=ax,
+            linewidth=1,
+            ci_show=False,
+            show_censors=True,
+            censor_styles={"ms": 3},
+        )
+    ax.set_ylim(-0.05, 1.01)
     ax.set_xlabel(time_label)
     ax.set_ylabel("Survival probability")
 
@@ -327,10 +325,12 @@ def survivalplot(
         )
     ax.text(0, 0, "\n".join(annotation_lines))
 
-    if ax.get_legend() is not None:
-        for handle in ax.get_legend().legend_handles:
-            if hasattr(handle, "set_linewidth"):
-                handle.set_linewidth(1.7)
+    legend = ax.get_legend()
+    if legend is not None:
+        for handle in legend.legend_handles:
+            set_linewidth = getattr(handle, "set_linewidth", None)
+            if callable(set_linewidth):
+                set_linewidth(1.7)
 
     return ax
 
@@ -350,6 +350,8 @@ def cumulativeincidenceplot(
     censor_mark_length: float = _DEFAULT_CENSOR_MARK_LENGTH,
     time_label: str = "Time",
     seed: int | None = 0,
+    *,
+    ax: Axes | None = None,
 ) -> Axes:
     """
     Create a cumulative incidence plot for competing risks analysis.
@@ -397,6 +399,9 @@ def cumulativeincidenceplot(
         Seed used by lifelines when tied event times require jittering. The default
         makes tied-data plots deterministic. The caller's NumPy random state is
         restored after fitting.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes. Any risk table is linked
+        to this axes and created on the same figure.
 
     Returns
     -------
@@ -456,7 +461,8 @@ def cumulativeincidenceplot(
     from lifelines.plotting import add_at_risk_counts
 
     data = data.copy()
-    ax: Any = None
+    if ax is None:
+        ax = plt.gca()
     if hue_order is None or set(data[hue].unique()) != set(hue_order):
         hue_order = list(data[hue].unique())
     _validate_censor_mark_position(censor_mark_position, hue_order)
@@ -483,10 +489,7 @@ def cumulativeincidenceplot(
             right_on=duration,
         )
         df = df.loc[df[event] == 0].copy()
-        if i == 0:
-            ax = fitter.plot(linewidth=1, ci_show=False)
-        else:
-            ax = fitter.plot(ax=ax, linewidth=1, ci_show=False)
+        fitter.plot(ax=ax, linewidth=1, ci_show=False)
         line_color = ax.get_lines()[-1].get_color()
         group_censor_mark_position = _resolve_censor_mark_position(
             censor_mark_position, i
@@ -507,7 +510,6 @@ def cumulativeincidenceplot(
                     colors=line_color,
                     linewidth=1,
                 )
-    assert ax is not None
     ax.set_ylim(_CIF_Y_LIMITS)
     ax.set_ylabel("Cumulative incidence probability")
     ax.set_xlabel(time_label)
@@ -542,5 +544,6 @@ def cumulativeincidenceplot(
             rows_to_show=rows,
             ypos=risk_table_ypos,
             xticks=xticks.tolist(),
+            fig=ax.figure,
         )
     return ax

--- a/tests/test_axes_api.py
+++ b/tests/test_axes_api.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+from matplotlib.axes import Axes
+
+import cnsplots as cns
+
+
+PLOT_NAMES = [
+    "barplot",
+    "lollipopplot",
+    "stackplot",
+    "stripplot",
+    "pieplot",
+    "donutplot",
+    "boxplot",
+    "violinplot",
+    "distplot",
+    "kdeplot",
+    "histplot",
+    "ridgeplot",
+    "qqplot",
+    "regplot",
+    "scatterplot",
+    "lineplot",
+    "slopeplot",
+]
+
+
+def _artist_count(ax: Axes) -> int:
+    return len(ax.lines) + len(ax.collections) + len(ax.patches) + len(ax.texts)
+
+
+def test_core_plot_axes_are_explicit_keyword_only_parameters() -> None:
+    for name in PLOT_NAMES:
+        parameter = inspect.signature(getattr(cns, name)).parameters["ax"]
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is None
+
+
+@pytest.mark.parametrize(
+    ("wrapper", "seaborn_function"),
+    [(cns.histplot, sns.histplot), (cns.lineplot, sns.lineplot)],
+)
+def test_seaborn_passthrough_signatures_match_named_parameters(
+    wrapper: Callable[..., Axes],
+    seaborn_function: Callable[..., Axes],
+) -> None:
+    wrapper_parameters = inspect.signature(wrapper).parameters
+    seaborn_parameters = inspect.signature(seaborn_function).parameters
+
+    assert list(wrapper_parameters) == list(seaborn_parameters)
+    for name, parameter in seaborn_parameters.items():
+        assert wrapper_parameters[name].kind is parameter.kind
+        assert wrapper_parameters[name].default == parameter.default
+
+
+def test_core_plots_draw_on_and_return_supplied_axes(
+    categorical_df: pd.DataFrame,
+    stack_df: pd.DataFrame,
+    numeric_df: pd.DataFrame,
+    line_df: pd.DataFrame,
+) -> None:
+    slope_data = pd.DataFrame(
+        {
+            "site": ["S1", "S1", "S2", "S2"],
+            "value": [1.0, 2.0, 2.0, 1.5],
+            "condition": ["before", "after"] * 2,
+            "subject": ["P1", "P1", "P2", "P2"],
+        }
+    )
+    plotters: list[tuple[str, Callable[[Axes], Axes]]] = [
+        (
+            "barplot",
+            lambda ax: cns.barplot(categorical_df, x="group", y="value", ax=ax),
+        ),
+        (
+            "lollipopplot",
+            lambda ax: cns.lollipopplot(categorical_df, x="group", y="value", ax=ax),
+        ),
+        (
+            "stackplot",
+            lambda ax: cns.stackplot(stack_df, x="treatment", stack="response", ax=ax),
+        ),
+        (
+            "stripplot",
+            lambda ax: cns.stripplot(categorical_df, x="group", y="value", ax=ax),
+        ),
+        ("pieplot", lambda ax: cns.pieplot(categorical_df, x="group", ax=ax)),
+        ("donutplot", lambda ax: cns.donutplot(categorical_df, x="group", ax=ax)),
+        (
+            "boxplot",
+            lambda ax: cns.boxplot(categorical_df, x="group", y="value", ax=ax),
+        ),
+        (
+            "violinplot",
+            lambda ax: cns.violinplot(categorical_df, x="group", y="value", ax=ax),
+        ),
+        ("distplot", lambda ax: cns.distplot(numeric_df, x="x", ax=ax)),
+        (
+            "ridgeplot",
+            lambda ax: cns.ridgeplot(categorical_df, "value", "group", ax=ax),
+        ),
+        ("qqplot", lambda ax: cns.qqplot(numeric_df, x="x", ax=ax)),
+        ("regplot", lambda ax: cns.regplot(numeric_df, x="x", y="y", ax=ax)),
+        (
+            "scatterplot",
+            lambda ax: cns.scatterplot(numeric_df, x="x", y="y", ax=ax),
+        ),
+        (
+            "lineplot",
+            lambda ax: cns.lineplot(line_df, x="time", y="value", ax=ax),
+        ),
+        (
+            "slopeplot",
+            lambda ax: cns.slopeplot(
+                slope_data,
+                x="site",
+                y="value",
+                hue="condition",
+                pair="subject",
+                ax=ax,
+            ),
+        ),
+    ]
+
+    for name, plotter in plotters:
+        _, (target_ax, current_ax) = plt.subplots(1, 2)
+        plt.sca(current_ax)
+
+        result = plotter(target_ax)
+
+        assert result is target_ax, name
+        assert _artist_count(target_ax) > 0, name
+        assert _artist_count(current_ax) == 0, name
+        plt.close(target_ax.figure)
+
+
+@pytest.mark.parametrize("plot_name", ["barplot", "boxplot", "violinplot"])
+def test_statistical_pairs_support_explicit_axes(
+    plot_name: str,
+    categorical_df: pd.DataFrame,
+) -> None:
+    _, (target_ax, current_ax) = plt.subplots(1, 2)
+    plt.sca(current_ax)
+
+    result = getattr(cns, plot_name)(
+        categorical_df,
+        x="group",
+        y="value",
+        pairs=[("A", "B")],
+        ax=target_ax,
+    )
+
+    assert result is target_ax
+    assert target_ax.texts
+    assert _artist_count(current_ax) == 0
+
+
+def test_kdeplot_annotations_stay_on_supplied_axes(numeric_df: pd.DataFrame) -> None:
+    _, (target_ax, current_ax) = plt.subplots(1, 2)
+    plt.sca(current_ax)
+
+    result = cns.kdeplot(numeric_df, x="x", add_mode=True, ax=target_ax)
+
+    assert result is target_ax
+    assert target_ax.lines
+    assert target_ax.texts
+    assert _artist_count(current_ax) == 0
+
+
+def test_histplot_colorbar_uses_supplied_host_axes() -> None:
+    rng = np.random.default_rng(0)
+    data = pd.DataFrame({"x": rng.normal(size=100), "y": rng.normal(size=100)})
+    _, (target_ax, current_ax) = plt.subplots(1, 2)
+    plt.sca(current_ax)
+
+    result = cns.histplot(data, x="x", y="y", cbar=True, ax=target_ax)
+
+    assert result is target_ax
+    assert target_ax.collections[0].colorbar is not None
+    assert target_ax.collections[0].colorbar.ax.figure is target_ax.figure
+    assert _artist_count(current_ax) == 0
+
+
+def test_passthrough_wrappers_keep_vector_and_wide_form_support() -> None:
+    _, (hist_ax, line_ax) = plt.subplots(1, 2)
+
+    hist_result = cns.histplot(x=np.arange(5), ax=hist_ax)
+    line_result = cns.lineplot(
+        pd.DataFrame({"first": [1, 2, 3], "second": [3, 2, 1]}),
+        ax=line_ax,
+    )
+
+    assert hist_result is hist_ax
+    assert line_result is line_ax
+
+
+def test_passthrough_wrappers_validate_string_semantic_mappings() -> None:
+    data = pd.DataFrame({"x": [1, 2], "y": [2, 3]})
+
+    with pytest.raises(ValueError, match="missing_weight"):
+        cns.histplot(data, x="x", weights="missing_weight")
+    with pytest.raises(ValueError, match="missing_style"):
+        cns.lineplot(data, x="x", y="y", style="missing_style")

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -387,7 +387,7 @@ def test_upsetplot_clears_white_figure_patch(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(sets_mod, "_import_upsetplot_module", lambda: fake_module)
     monkeypatch.setattr(sets_mod, "setup_ax", lambda ax: None)
 
-    axes = cns.upsetplot({"A": {"x"}, "B": {"x", "y"}})
+    axes = cast(Any, cns.upsetplot({"A": {"x"}, "B": {"x", "y"}}))
 
     assert axes["matrix"].figure.patch.facecolor == "none"
     assert axes["matrix"].figure.patch.alpha == 0
@@ -1217,7 +1217,7 @@ def test_remaining_visual_internal_coverage(
         lambda self: volcano_legend,
         raising=False,
     )
-    monkeypatch.setattr(genomics_mod.utils, "take_legend_out", lambda: None)
+    monkeypatch.setattr(genomics_mod.utils, "take_legend_out", lambda **kwargs: None)
     cns.figure(120, 120)
     cns.volcanoplot(volcano_df)
     assert volcano_legend.legend_handles[0].sizes == [20]

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -558,10 +558,13 @@ def test_sets_and_specialized_plots(
     axes = cns.upsetplot(sets_fixture, min_subset_size=1)
     assert set(axes) >= {"matrix", "intersections"}
     assert all(ax is None or ax.get_facecolor()[-1] == 0 for ax in axes.values())
-    assert axes["matrix"].figure.patch.get_facecolor()[-1] == 0
+    matrix_ax = axes["matrix"]
+    shading_ax = axes["shading"]
+    assert matrix_ax is not None
+    assert shading_ax is not None
+    assert matrix_ax.figure.patch.get_facecolor()[-1] == 0
     assert all(
-        not tick.tick1line.get_visible()
-        for tick in axes["shading"].yaxis.get_major_ticks()
+        not tick.tick1line.get_visible() for tick in shading_ax.yaxis.get_major_ticks()
     )
 
     fig = plt.figure()
@@ -572,10 +575,10 @@ def test_sets_and_specialized_plots(
     with cns.settings.context(legend_fontsize=None, title_fontsize=12):
         cns.figure(120, 120)
         inherited_axes = cns.upsetplot(sets_fixture, min_subset_size=1)
-        assert inherited_axes["intersections"].texts
-        assert {
-            text.get_fontsize() for text in inherited_axes["intersections"].texts
-        } == {12}
+        intersections_ax = inherited_axes["intersections"]
+        assert intersections_ax is not None
+        assert intersections_ax.texts
+        assert {text.get_fontsize() for text in intersections_ax.texts} == {12}
 
     custom_fig = plt.figure()
     custom_fig.patch.set_facecolor("red")

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -16,10 +16,119 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+import seaborn as sns
+from matplotlib.axes import Axes
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.text import Text
 
 import cnsplots as cns
+
+
+_PUBLIC_PLOT_NAMES = frozenset(
+    {
+        "barplot",
+        "boxplot",
+        "confusionplot",
+        "cumulativeincidenceplot",
+        "distplot",
+        "donutplot",
+        "dotplot",
+        "forestplot",
+        "gseaplot",
+        "heatmapplot",
+        "histplot",
+        "kdeplot",
+        "lineplot",
+        "lollipopplot",
+        "phyloplot",
+        "pieplot",
+        "placeholderplot",
+        "qqplot",
+        "regplot",
+        "ridgeplot",
+        "rocplot",
+        "sankeyplot",
+        "scatterplot",
+        "slopeplot",
+        "stackplot",
+        "stripplot",
+        "survivalplot",
+        "upsetplot",
+        "vennplot",
+        "violinplot",
+        "volcanoplot",
+    }
+)
+
+_SEABORN_WRAPPER_PARAMETERS = {
+    "histplot": (
+        "data",
+        "x",
+        "y",
+        "hue",
+        "weights",
+        "stat",
+        "bins",
+        "binwidth",
+        "binrange",
+        "discrete",
+        "cumulative",
+        "common_bins",
+        "common_norm",
+        "multiple",
+        "element",
+        "fill",
+        "shrink",
+        "kde",
+        "kde_kws",
+        "line_kws",
+        "thresh",
+        "pthresh",
+        "pmax",
+        "cbar",
+        "cbar_ax",
+        "cbar_kws",
+        "palette",
+        "hue_order",
+        "hue_norm",
+        "color",
+        "log_scale",
+        "legend",
+        "ax",
+        "kwargs",
+    ),
+    "lineplot": (
+        "data",
+        "x",
+        "y",
+        "hue",
+        "size",
+        "style",
+        "units",
+        "weights",
+        "palette",
+        "hue_order",
+        "hue_norm",
+        "sizes",
+        "size_order",
+        "size_norm",
+        "dashes",
+        "markers",
+        "style_order",
+        "estimator",
+        "errorbar",
+        "n_boot",
+        "seed",
+        "orient",
+        "sort",
+        "err_style",
+        "err_kws",
+        "legend",
+        "ci",
+        "ax",
+        "kwargs",
+    ),
+}
 
 
 def _pdf_media_box_size(path: Path) -> tuple[float, float]:
@@ -187,6 +296,70 @@ def test_public_callable_annotations_resolve() -> None:
 
     assert missing_annotations == {}
     assert unresolved_annotations == {}
+
+
+def test_public_plot_axes_signature_and_return_contract() -> None:
+    import cnsplots.plots as plots
+    from cnsplots.helpers._heatmap import (
+        ClusterMapPlotterNew,
+        DotClustermapPlotterNew,
+    )
+    from matplotlib_venn._common import VennDiagram
+
+    assert set(plots.__all__) == _PUBLIC_PLOT_NAMES
+    assert all(getattr(plots, name) is getattr(cns, name) for name in plots.__all__)
+
+    return_types: dict[str, object] = {}
+    for name in sorted(_PUBLIC_PLOT_NAMES):
+        plotter = getattr(cns, name)
+        ax_parameter = inspect.signature(plotter).parameters["ax"]
+        assert ax_parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert ax_parameter.default is None
+
+        hints = get_type_hints(plotter)
+        assert hints["ax"] == Axes | None
+        return_types[name] = hints["return"]
+
+    specialized_returns = {
+        "heatmapplot": ClusterMapPlotterNew,
+        "dotplot": DotClustermapPlotterNew,
+        "upsetplot": dict[str, Axes | None],
+        "vennplot": VennDiagram,
+    }
+    assert {
+        name: return_types.pop(name) for name in specialized_returns
+    } == specialized_returns
+    assert set(return_types.values()) == {Axes}
+
+
+@pytest.mark.parametrize(
+    ("plot_name", "seaborn_plotter"),
+    [("histplot", sns.histplot), ("lineplot", sns.lineplot)],
+)
+def test_public_seaborn_wrapper_signature_contract(
+    plot_name: str,
+    seaborn_plotter: Any,
+) -> None:
+    wrapper_parameters = inspect.signature(getattr(cns, plot_name)).parameters
+    seaborn_parameters = inspect.signature(seaborn_plotter).parameters
+
+    assert tuple(wrapper_parameters) == _SEABORN_WRAPPER_PARAMETERS[plot_name]
+    assert tuple(wrapper_parameters) == tuple(seaborn_parameters)
+    assert {
+        name: (parameter.kind, parameter.default)
+        for name, parameter in wrapper_parameters.items()
+    } == {
+        name: (parameter.kind, parameter.default)
+        for name, parameter in seaborn_parameters.items()
+    }
+
+
+def test_public_vennplot_backend_return_contract() -> None:
+    _, ax = plt.subplots()
+    venn = cns.vennplot([{1, 2}, {2, 3}], ["A", "B"], ax=ax)
+
+    assert venn.get_label_by_id("11").get_text() == "1"
+    assert venn.get_patch_by_id("11").axes is ax
 
 
 def test_public_stackplot_signature_contract() -> None:

--- a/tests/test_special_axes.py
+++ b/tests/test_special_axes.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+import warnings
+
+import anndata as ad
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.transforms import Bbox
+
+import cnsplots as cns
+import cnsplots._utils as plot_utils
+
+
+SPECIAL_PLOT_NAMES = [
+    "placeholderplot",
+    "sankeyplot",
+    "phyloplot",
+    "forestplot",
+    "rocplot",
+    "heatmapplot",
+    "dotplot",
+    "confusionplot",
+    "volcanoplot",
+    "gseaplot",
+    "survivalplot",
+    "cumulativeincidenceplot",
+    "upsetplot",
+    "vennplot",
+]
+
+
+def _artist_count(ax: Axes) -> int:
+    return len(ax.lines) + len(ax.collections) + len(ax.patches) + len(ax.texts)
+
+
+def _assert_within(host_box: Bbox, axes: list[Axes]) -> None:
+    eps = 1e-9
+    for ax in axes:
+        box = ax.get_position()
+        assert box.x0 >= host_box.x0 - eps
+        assert box.y0 >= host_box.y0 - eps
+        assert box.x1 <= host_box.x1 + eps
+        assert box.y1 <= host_box.y1 + eps
+
+
+def test_host_relative_axes_locator_handles_non_layout_axes() -> None:
+    fig, host_ax = plt.subplots()
+    host_ax.set_position((0.1, 0.1, 0, 0.5))
+    plot_utils._anchor_axes_to_host(host_ax, [])
+
+    host_ax.set_position((0.1, 0.1, 0.5, 0.5))
+    other_fig, other_ax = plt.subplots()
+    plot_utils._anchor_axes_to_host(host_ax, [host_ax, other_ax])
+    assert not hasattr(host_ax, "_cnsplots_sync_embedded_axes")
+
+    child_ax = fig.add_axes((0.2, 0.2, 0.2, 0.2))
+    plot_utils._anchor_axes_to_host(host_ax, [child_ax])
+    child_ax.remove()
+
+    sync = getattr(host_ax, "_cnsplots_sync_embedded_axes")
+    sync()
+
+    zero_child_ax = fig.add_axes((0.2, 0.2, 0, 0))
+    plot_utils._anchor_axes_to_host(host_ax, [zero_child_ax])
+
+    free_host_ax = fig.add_axes((0.1, 0.1, 0.5, 0.5))
+    free_child_ax = fig.add_axes((0.2, 0.2, 0.2, 0.2))
+    plot_utils._anchor_axes_to_host(free_host_ax, [free_child_ax])
+    assert free_child_ax.get_subplotspec() is None
+    assert not free_child_ax.get_in_layout()
+    plt.close(other_fig)
+
+
+def test_special_plot_axes_are_explicit_keyword_only_parameters() -> None:
+    for name in SPECIAL_PLOT_NAMES:
+        parameter = inspect.signature(getattr(cns, name)).parameters["ax"]
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is None
+
+
+def test_single_axes_special_plots_use_supplied_axes(
+    sankey_df: pd.DataFrame,
+    roc_df: pd.DataFrame,
+    volcano_df: pd.DataFrame,
+    survival_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(
+        sys.modules,
+        "adjustText",
+        types.SimpleNamespace(adjust_text=lambda *args, **kwargs: None),
+    )
+    plotters = [
+        lambda ax: cns.placeholderplot("Reserved", ax=ax),
+        lambda ax: cns.sankeyplot(sankey_df, x="source", y="target", ax=ax),
+        lambda ax: cns.rocplot(roc_df, "truth", "model_a", ax=ax),
+        lambda ax: cns.volcanoplot(volcano_df, n_show=1, ax=ax),
+        lambda ax: cns.survivalplot(
+            survival_df,
+            "time",
+            "event",
+            "group",
+            ax=ax,
+        ),
+    ]
+
+    for plotter in plotters:
+        _, (target_ax, current_ax) = plt.subplots(1, 2)
+        plt.sca(current_ax)
+
+        result = plotter(target_ax)
+
+        assert result is target_ax
+        assert _artist_count(target_ax) > 0
+        assert _artist_count(current_ax) == 0
+        plt.close(target_ax.figure)
+
+
+def test_forestplot_appends_pvalue_panel_to_supplied_axes() -> None:
+    model = types.SimpleNamespace(
+        name="cox",
+        hue=None,
+        results=pd.DataFrame(
+            {
+                "display_label": ["Age", "Stage"],
+                "exp(coef)": [1.2, 0.9],
+                "log10_pvalue": [1.1, 0.7],
+                "exp(coef) lower_err": [0.1, 0.1],
+                "exp(coef) upper_err": [0.2, 0.15],
+                "hue_group": ["All", "All"],
+            }
+        ),
+    )
+    fig, (target_ax, current_ax) = plt.subplots(1, 2)
+    host_box = target_ax.get_position().frozen()
+    plt.sca(current_ax)
+
+    result = cns.forestplot(model, ax=target_ax)
+    fig.canvas.draw()
+
+    assert result is target_ax
+    assert _artist_count(current_ax) == 0
+    pvalue_ax = fig.axes[-1]
+    assert pvalue_ax is not current_ax
+    assert pvalue_ax.figure is fig
+    assert pvalue_ax.get_position().x0 > target_ax.get_position().x1
+    _assert_within(host_box, [target_ax, pvalue_ax])
+
+
+def test_confusionplot_anchors_stats_overlay_to_supplied_axes(
+    confusion_df: pd.DataFrame,
+) -> None:
+    fig, (target_ax, current_ax) = plt.subplots(1, 2)
+    plt.sca(current_ax)
+
+    result = cns.confusionplot(
+        confusion_df,
+        x="pred",
+        y="truth",
+        add_pvalue=True,
+        ax=target_ax,
+    )
+    fig.canvas.draw()
+
+    assert result is target_ax
+    assert _artist_count(current_ax) == 0
+    stats_ax = fig.axes[-1]
+    assert stats_ax is not current_ax
+    assert stats_ax.get_position().bounds == pytest.approx(
+        target_ax.get_position().bounds
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fig.tight_layout()
+    assert not any("not compatible with tight_layout" in str(w.message) for w in caught)
+    fig.canvas.draw()
+    assert stats_ax.get_position().bounds == pytest.approx(
+        target_ax.get_position().bounds
+    )
+
+
+def test_heatmap_backends_use_supplied_host_axes(
+    heatmap_adata: ad.AnnData,
+    dotplot_df: pd.DataFrame,
+) -> None:
+    fig, (heatmap_ax, current_ax) = plt.subplots(1, 2, layout="constrained")
+    layout_engine = fig.get_layout_engine()
+    plt.sca(current_ax)
+
+    heatmap = cns.heatmapplot(
+        heatmap_adata,
+        row_annotation=["score"],
+        row_cluster=False,
+        col_cluster=False,
+        ax=heatmap_ax,
+    )
+    fig.canvas.draw()
+
+    assert heatmap.ax is heatmap_ax
+    assert heatmap.cbars
+    assert fig.get_layout_engine() is layout_engine
+    assert _artist_count(current_ax) == 0
+    _assert_within(
+        heatmap_ax.get_position(original=True).frozen(),
+        [ax for ax in fig.axes if ax not in (heatmap_ax, current_ax)],
+    )
+    plt.close(fig)
+
+    fig, (dot_ax, current_ax) = plt.subplots(1, 2, layout="constrained")
+    layout_engine = fig.get_layout_engine()
+    plt.sca(current_ax)
+    dot = cns.dotplot(
+        dotplot_df,
+        x="sample",
+        y="gene",
+        color="mean_expr",
+        size="pct_expr",
+        value="score",
+        ax=dot_ax,
+    )
+    fig.canvas.draw()
+
+    assert dot.ax is dot_ax
+    assert dot.cbars
+    assert fig.get_layout_engine() is layout_engine
+    assert _artist_count(current_ax) == 0
+    _assert_within(
+        dot_ax.get_position(original=True).frozen(),
+        [ax for ax in fig.axes if ax not in (dot_ax, current_ax)],
+    )
+
+    normal_fig, normal_ax = plt.subplots()
+    assert normal_fig.get_layout_engine() is None
+    normal_heatmap = cns.heatmapplot(
+        heatmap_adata,
+        row_annotation=["score"],
+        row_cluster=False,
+        col_cluster=False,
+        ax=normal_ax,
+    )
+    normal_fig.canvas.draw()
+
+    assert normal_fig.get_layout_engine() is None
+    _assert_within(
+        normal_ax.get_position().frozen(), list(normal_heatmap.heatmap_axes.flat)
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        normal_fig.tight_layout()
+    assert not any("not compatible with tight_layout" in str(w.message) for w in caught)
+
+
+def test_gseaplot_uses_supplied_axes_and_figure(
+    gsea_plot_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_dotplot(
+        data: pd.DataFrame,
+        cmap: object,
+        y: str,
+        x: str,
+        cutoff: float,
+        column: str,
+        ax: Axes,
+        top_term: int,
+        size: float,
+    ) -> None:
+        scatter = ax.scatter(data[x], np.arange(len(data)), c=data[column])
+        ax.figure.colorbar(scatter, ax=ax)
+        handle = plt.Line2D([], [], marker="o", linestyle="none", color="black")
+        ax.legend([handle], ["20"], title="size")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "gseapy",
+        types.SimpleNamespace(dotplot=fake_dotplot),
+    )
+    fig, (target_ax, current_ax) = plt.subplots(1, 2)
+    plt.sca(current_ax)
+
+    result = cns.gseaplot(gsea_plot_df, y="Clean_Term", ax=target_ax)
+
+    assert result is target_ax
+    assert _artist_count(target_ax) > 0
+    assert _artist_count(current_ax) == 0
+    assert fig.axes[-1].figure is fig
+
+
+def test_cumulativeincidence_risk_table_uses_supplied_axes_figure(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    fig, (target_ax, current_ax) = plt.subplots(1, 2)
+    plt.sca(current_ax)
+
+    result = cns.cumulativeincidenceplot(
+        competing_risk_df,
+        "time",
+        "event",
+        "group",
+        show_risk_table=True,
+        ax=target_ax,
+    )
+
+    assert result is target_ax
+    assert _artist_count(current_ax) == 0
+    assert fig.axes[-1].figure is fig
+    assert fig.axes[-1] is not current_ax
+
+
+def test_phyloplot_uses_and_returns_supplied_heatmap_axes(
+    phylo_adata: ad.AnnData,
+) -> None:
+    fig, (target_ax, current_ax) = plt.subplots(1, 2)
+    host_box = target_ax.get_position().frozen()
+    plt.sca(current_ax)
+
+    result = cns.phyloplot(phylo_adata, ax=target_ax)
+    fig.canvas.draw()
+
+    assert result is target_ax
+    assert _artist_count(target_ax) > 0
+    assert _artist_count(current_ax) == 0
+    phylo_axes = [ax for ax in fig.axes if ax is not current_ax]
+    assert len(phylo_axes) == 5
+    _assert_within(host_box, phylo_axes)
+
+
+def test_set_plots_use_supplied_axes(
+    sets_fixture: dict[str, set[int]],
+) -> None:
+    fig, (upset_ax, current_ax) = plt.subplots(1, 2)
+    initial_size = fig.get_size_inches().copy()
+    initial_facecolor = fig.patch.get_facecolor()
+    initial_alpha = fig.patch.get_alpha()
+    plt.sca(current_ax)
+
+    axes = cns.upsetplot(sets_fixture, ax=upset_ax, min_subset_size=1)
+    fig.canvas.draw()
+
+    assert all(ax is None or ax.figure is fig for ax in axes.values())
+    assert _artist_count(current_ax) == 0
+    np.testing.assert_allclose(fig.get_size_inches(), initial_size)
+    assert fig.patch.get_facecolor() == initial_facecolor
+    assert fig.patch.get_alpha() == initial_alpha
+    _assert_within(
+        upset_ax.get_position().frozen(),
+        [ax for ax in axes.values() if ax is not None],
+    )
+
+    venn_fig, (venn_ax, current_ax) = plt.subplots(1, 2)
+    plt.sca(current_ax)
+    diagram = cns.vennplot(
+        list(sets_fixture.values())[:2],
+        labels=["A", "B"],
+        ax=venn_ax,
+    )
+
+    assert diagram.get_label_by_id("A").get_text() == "A"
+    assert _artist_count(venn_ax) > 0
+    assert _artist_count(current_ax) == 0
+    plt.close(venn_fig)
+
+
+def test_upsetplot_rejects_conflicting_embedding_options(
+    sets_fixture: dict[str, set[int]],
+) -> None:
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match="either 'ax' or 'fig'"):
+        cns.upsetplot(sets_fixture, ax=ax, fig=fig)
+    with pytest.raises(ValueError, match="element_size"):
+        cns.upsetplot(sets_fixture, ax=ax, element_size=17)
+
+
+def test_upsetplot_tracks_constrained_layout_host(
+    sets_fixture: dict[str, set[int]],
+) -> None:
+    fig, (host_ax, other_ax) = plt.subplots(1, 2, layout="constrained")
+    layout_engine = fig.get_layout_engine()
+
+    axes = cns.upsetplot(sets_fixture, ax=host_ax, min_subset_size=1)
+    fig.canvas.draw()
+
+    assert fig.get_layout_engine() is layout_engine
+    _assert_within(
+        host_ax.get_position().frozen(),
+        [ax for ax in axes.values() if ax is not None],
+    )
+
+    initial_host_box = host_ax.get_position().frozen()
+    fig.set_size_inches(9, 4)
+    fig.canvas.draw()
+
+    assert host_ax.get_position().bounds != pytest.approx(initial_host_box.bounds)
+    _assert_within(
+        host_ax.get_position().frozen(),
+        [ax for ax in axes.values() if ax is not None],
+    )

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
         assert_type(cns.palettes("Set1"), list[tuple[float, float, float]])
         assert_type(cns.palettes("parula"), Colormap)
         assert_type(cns.boxplot(data, x="group", y="value"), Axes)
+        assert_type(cns.histplot(data, x="x", ax=ax), Axes)
+        assert_type(cns.lineplot(data, x="x", y="y", ax=ax), Axes)
         assert_type(cns.regplot(data, x="x", y="y", color=(0.1, 0.2, 0.3)), Axes)
 
         panels = cns.multipanel()


### PR DESCRIPTION
## What changed

- Add a keyword-only `ax` parameter to all 31 public plotting functions.
- Keep ordinary plots on and returning the supplied Matplotlib axes.
- Embed multi-panel heatmap, dot, UpSet, forest, confusion, and phylogenetic layouts within caller-owned axes.
- Expose complete Seaborn-compatible signatures for `histplot` and `lineplot`.
- Align return annotations, docstrings, examples, and public API documentation.
- Add axes-composition, layout-engine, signature, typing, and return-contract coverage.

## How it was tested

- `make test` — 353 tests passed with 100% coverage.
- `make lint` — all hooks passed.
- `git diff --check` — passed.

## Risks and follow-ups

- Composite plots create helper axes inside the supplied host and preserve the caller layout engine; regression tests cover constrained and tight layouts.
- Heatmap, dot, UpSet, and Venn plots retain their backend-native return objects for compatibility.
- No known follow-ups.