### PR TITLE
🐛 Preserve release docs deployments

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -12,7 +12,8 @@ permissions:
 
 concurrency:
   group: gh-pages
-  cancel-in-progress: true
+  cancel-in-progress: false
+  queue: max
 
 jobs:
   deploy:

--- a/tests/test_docs_build_script.py
+++ b/tests/test_docs_build_script.py
@@ -55,6 +55,15 @@ def _write_docs_source(repo_root: Path) -> Path:
     return docs_dir
 
 
+def test_docs_workflow_serializes_main_and_tag_deployments():
+    repo_root = Path(__file__).resolve().parents[1]
+    workflow = (repo_root / ".github" / "workflows" / "ci-docs.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "group: gh-pages\n  cancel-in-progress: false\n  queue: max" in workflow
+
+
 def test_sphinx_build_stages_docs_and_repository_inputs(tmp_path, monkeypatch):
     docs_build = _load_docs_build_script()
     repo_root = tmp_path / "repo"


### PR DESCRIPTION
## What changed

- Queue documentation deployments instead of canceling active or pending main/tag runs.
- Add regression coverage for the deployment concurrency settings.

## Testing

- make test
- make lint

## Risks or follow-ups

Queued documentation builds can use more Actions time during a burst, but remain serialized. The canceled v0.5.0 tag run was rerun separately to repair the currently published site.