### PR TITLE
🔇 Silence SVG FontTools logs

### DIFF
--- a/src/cnsplots/_svg.py
+++ b/src/cnsplots/_svg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import warnings
 from pathlib import Path
@@ -68,9 +69,17 @@ def _save_svg(filepath: str, root: str, bbox_inches=None) -> None:
         tmp_dir_path = Path(tmp_dir)
         tmp_pdf = tmp_dir_path / f"{stem}.pdf"
         tmp_svg = tmp_dir_path / "1.svg"
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            plt.savefig(tmp_pdf, **savefig_kwargs)
+        fonttools_logger = logging.getLogger("fontTools")
+        previous_level = fonttools_logger.level
+        try:
+            fonttools_logger.setLevel(
+                max(fonttools_logger.getEffectiveLevel(), logging.ERROR)
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                plt.savefig(tmp_pdf, **savefig_kwargs)
+        finally:
+            fonttools_logger.setLevel(previous_level)
         try:
             subprocess.run(
                 [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import subprocess
 import sys
@@ -930,6 +931,41 @@ def test_svg_helpers_and_export(
     with pytest.warns(RuntimeWarning, match="boom"):
         _svg._save_svg(str(failed_path), str(output_dir / "failed"))
     assert failed_path.exists()
+
+
+def test_svg_export_suppresses_fonttools_logs_and_restores_level(
+    output_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fonttools_logger = logging.getLogger("fontTools")
+    previous_level = fonttools_logger.level
+    expected_level = logging.DEBUG
+    fonttools_logger.setLevel(expected_level)
+
+    def fake_savefig(*args: object, **kwargs: object) -> None:
+        if str(args[0]).endswith(".pdf"):
+            logging.getLogger("fontTools.subset").info("maxp pruned")
+
+    def missing_run(*args: object, **kwargs: object) -> object:
+        raise FileNotFoundError("mutool")
+
+    monkeypatch.setattr(_svg.plt, "savefig", fake_savefig)
+    monkeypatch.setattr(_svg.subprocess, "run", missing_run)
+
+    try:
+        with (
+            caplog.at_level(logging.INFO),
+            pytest.warns(RuntimeWarning, match="mutool"),
+        ):
+            _svg._save_svg(str(output_dir / "plot.svg"), str(output_dir / "plot"))
+
+        assert not [
+            record for record in caplog.records if record.name.startswith("fontTools")
+        ]
+        assert fonttools_logger.level == expected_level
+    finally:
+        fonttools_logger.setLevel(previous_level)
 
 
 def test_savefig_default_bounds_match_jpg_pdf_and_svg(


### PR DESCRIPTION
## What changed

- Suppress FontTools diagnostics while the optimized SVG path writes its intermediate Type 42 PDF.
- Restore the caller's existing FontTools logger level after export, including when PDF saving fails.
- Add regression coverage for log suppression and logger-level restoration.

## Why

The v0.5.0 lazy-import change removed the global FontTools logger override used in v0.4.0. The optimized SVG path still creates an intermediate PDF, so FontTools subsetting messages became visible whenever the application's root logger was configured at INFO.

## Testing

- `make test` — 355 tests passed with 100% coverage.
- `make lint` — all hooks passed.
- Manual SVG export with root logging at INFO emitted zero FontTools records.

## Risks and follow-ups

Risk is low because suppression is limited to the intermediate PDF stage and the previous logger level is restored in a `finally` block. Direct PDF exports are unchanged.
