### PR TITLE
🐛 Silence FontTools PDF export logs

### DIFF
--- a/src/cnsplots/_setup.py
+++ b/src/cnsplots/_setup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -228,6 +229,8 @@ def setup_matplotlib(
     if axes_linewidth is None:
         axes_linewidth = settings.axes_linewidth
 
+    fonttools_logger = logging.getLogger("fontTools")
+    fonttools_logger.setLevel(max(fonttools_logger.getEffectiveLevel(), logging.ERROR))
     _ensure_helvetica_bold()
     resolved_legend_fontsize, legend_title_fontsize = _resolve_legend_fontsizes(
         title_fontsize, legend_fontsize

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -451,7 +451,18 @@ def savefig(filepath: str | os.PathLike[str]) -> None:
             if bbox_inches is not None:
                 savefig_kwargs["bbox_inches"] = bbox_inches
                 savefig_kwargs["pad_inches"] = 0
-            plt.savefig(filepath, **savefig_kwargs)
+            if ext.lower() == ".pdf":
+                fonttools_logger = logging.getLogger("fontTools")
+                previous_level = fonttools_logger.level
+                try:
+                    fonttools_logger.setLevel(
+                        max(fonttools_logger.getEffectiveLevel(), logging.ERROR)
+                    )
+                    plt.savefig(filepath, **savefig_kwargs)
+                finally:
+                    fonttools_logger.setLevel(previous_level)
+            else:
+                plt.savefig(filepath, **savefig_kwargs)
     finally:
         if fig.dpi != original_dpi:
             fig.set_dpi(original_dpi)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -968,6 +968,35 @@ def test_svg_export_suppresses_fonttools_logs_and_restores_level(
         fonttools_logger.setLevel(previous_level)
 
 
+def test_pdf_export_suppresses_fonttools_logs_and_restores_level(
+    output_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fonttools_logger = logging.getLogger("fontTools")
+    previous_level = fonttools_logger.level
+    expected_level = logging.DEBUG
+    fonttools_logger.setLevel(expected_level)
+
+    def fake_savefig(*args: object, **kwargs: object) -> None:
+        logging.getLogger("fontTools.subset").info("maxp pruned")
+
+    monkeypatch.setattr(_utils.plt, "savefig", fake_savefig)
+
+    try:
+        cns.figure(120, 120)
+        plt.plot([0, 1], [0, 1])
+        with caplog.at_level(logging.INFO):
+            cns.savefig(str(output_dir / "plot.pdf"))
+
+        assert not [
+            record for record in caplog.records if record.name.startswith("fontTools")
+        ]
+        assert fonttools_logger.level == expected_level
+    finally:
+        fonttools_logger.setLevel(previous_level)
+
+
 def test_savefig_default_bounds_match_jpg_pdf_and_svg(
     output_dir: Path,
     categorical_df: pd.DataFrame,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -975,8 +975,6 @@ def test_pdf_export_suppresses_fonttools_logs_and_restores_level(
 ) -> None:
     fonttools_logger = logging.getLogger("fontTools")
     previous_level = fonttools_logger.level
-    expected_level = logging.DEBUG
-    fonttools_logger.setLevel(expected_level)
 
     def fake_savefig(*args: object, **kwargs: object) -> None:
         logging.getLogger("fontTools.subset").info("maxp pruned")
@@ -986,6 +984,8 @@ def test_pdf_export_suppresses_fonttools_logs_and_restores_level(
     try:
         cns.figure(120, 120)
         plt.plot([0, 1], [0, 1])
+        expected_level = logging.DEBUG
+        fonttools_logger.setLevel(expected_level)
         with caplog.at_level(logging.INFO):
             cns.savefig(str(output_dir / "plot.pdf"))
 
@@ -993,6 +993,28 @@ def test_pdf_export_suppresses_fonttools_logs_and_restores_level(
             record for record in caplog.records if record.name.startswith("fontTools")
         ]
         assert fonttools_logger.level == expected_level
+    finally:
+        fonttools_logger.setLevel(previous_level)
+
+
+def test_setup_suppresses_fonttools_logs_for_direct_pdf_export(
+    output_dir: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fonttools_logger = logging.getLogger("fontTools")
+    previous_level = fonttools_logger.level
+    fonttools_logger.setLevel(logging.DEBUG)
+
+    try:
+        output_dir.mkdir(parents=True)
+        cns.figure(120, 120)
+        plt.plot([0, 1], [0, 1])
+        with caplog.at_level(logging.INFO):
+            plt.gcf().savefig(output_dir / "direct.pdf")
+
+        assert not [
+            record for record in caplog.records if record.name.startswith("fontTools")
+        ]
     finally:
         fonttools_logger.setLevel(previous_level)
 


### PR DESCRIPTION
## What changed

- Suppress FontTools diagnostics while `cns.savefig()` writes direct PDFs, restoring the caller’s logger level afterward even if saving fails.
- Raise the FontTools logger to at least `ERROR` during explicit cnsplots Matplotlib setup so direct `Figure.savefig()` and other Matplotlib PDF entry points stay quiet.
- Preserve stricter caller levels such as `CRITICAL` and keep importing `cnsplots` side-effect-free.
- Add regression coverage for both cnsplots and direct Matplotlib PDF exports.

## Why

PR #86 suppressed these messages only while the optimized SVG path writes its intermediate PDF. The first version of this PR covered `cns.savefig()`, but the real application calls `mp.fig.savefig()` directly. That bypassed the wrapper and still exposed FontTools subsetting messages whenever the application root logger was configured at INFO.

## Testing

- `make test` — 357 tests passed with 100% coverage.
- `make lint` — all hooks passed.
- Reproduced with the Python interpreter from the reported `lcs` command and a direct `mp.fig.savefig(...pdf)` call; the PDF saved with no FontTools records.

## Risks and follow-ups

Explicit cnsplots Matplotlib setup now leaves the FontTools logger at `ERROR` or a pre-existing stricter level. This is intentional so later direct Matplotlib PDF exports remain quiet. Import behavior, non-FontTools logging, and stricter caller logging levels are unchanged. No follow-up work is required.