### PR TITLE
✨ Add survival annotation controls

### DIFF
--- a/examples/showcase.py
+++ b/examples/showcase.py
@@ -174,7 +174,13 @@ ax.set_title("Regplot")
 
 # Panel J: survivalplot
 mp.panel("J", 90, 90)
-ax = cns.survivalplot(data=survival_df, duration="time", event="event", hue="group")
+ax = cns.survivalplot(
+    data=survival_df,
+    duration="time",
+    event="event",
+    hue="group",
+    show_hazard_ratio=False,
+)
 # Keep the showcase annotation compact by dropping the CI from the HR line.
 for text in ax.texts:
     label = text.get_text()

--- a/examples/survivalplot.py
+++ b/examples/survivalplot.py
@@ -28,7 +28,12 @@ waltons = ll.datasets.load_waltons()
 # Kaplan-Meier survival curves with automatic log-rank test.
 cns.figure(150, 150)
 cns.survivalplot(
-    data=waltons, duration="T", event="E", hue="group", hue_order=["miR-137", "control"]
+    data=waltons,
+    duration="T",
+    event="E",
+    hue="group",
+    hue_order=["miR-137", "control"],
+    show_hazard_ratio=False,
 )
 _ = plt.legend(loc="upper right")
 plt.title("Kaplan-Meier Survival Curves")
@@ -60,6 +65,7 @@ ax = cns.cumulativeincidenceplot(
     xticks=np.arange(0, waltons["T"].max() + 2, 12),
     show_risk_table=True,
     risk_table_ypos=-0.2,
+    pvalue_loc="lower right",
 )
 ax.set_xlabel("Time (Months)")
 _ = plt.legend(loc="upper left")
@@ -78,6 +84,7 @@ ax = cns.cumulativeincidenceplot(
     hue="group",
     hue_order=["miR-137", "control"],
     show_risk_table=False,
+    pvalue_loc="lower right",
 )
 ax.set_xlabel("Time (Months)")
 _ = plt.legend(loc="upper left")
@@ -131,17 +138,18 @@ clinical_df = pd.DataFrame(survival_data)
 # Compare multiple treatment arms with an omnibus test and an explicitly
 # requested Cox contrast. Pair tuples are (reference, comparison).
 cns.figure(150, 180)
-cns.survivalplot(
+ax = cns.survivalplot(
     data=clinical_df,
     duration="time",
     event="event",
     hue="group",
     hue_order=["Control", "Treatment A", "Treatment B"],
     pairs=[("Control", "Treatment B")],
+    pvalue_loc="upper right",
 )
+ax.set_xlabel("Time (Months)")
 cns.take_legend_out()
 plt.title("Three-Arm Clinical Trial")
-plt.xlabel("Time (Months)")
 
 
 # %%
@@ -157,6 +165,7 @@ ax = cns.cumulativeincidenceplot(
     hue_order=["Control", "Treatment A", "Treatment B"],
     show_risk_table=True,
     risk_table_ypos=-0.25,
+    pvalue_loc="upper left",
 )
 ax.set_xlabel("Time (Months)")
 cns.take_legend_out()
@@ -186,6 +195,7 @@ cns.cumulativeincidenceplot(
     event="E",
     hue="group",
     show_risk_table=False,
+    pvalue_loc="center",
 )
 mp.get_axes("B").legend().remove()
 mp.get_axes("B").set_title("Cumulative Incidence")
@@ -215,16 +225,17 @@ for _ in range(n // 2):
 biomarker_df = pd.DataFrame(biomarker_data)
 
 cns.figure(150, 150)
-cns.survivalplot(
+ax = cns.survivalplot(
     data=biomarker_df,
     duration="time",
     event="event",
     hue="biomarker",
     hue_order=["High", "Low"],
+    pvalue_loc="upper right",
 )
+ax.set_xlabel("Time (Months)")
 cns.take_legend_out()
 plt.title("Survival by Biomarker Expression")
-plt.xlabel("Time (Months)")
 
 
 # %%
@@ -241,6 +252,7 @@ ax = cns.cumulativeincidenceplot(
     xticks=np.arange(0, 80, 10),
     show_risk_table=True,
     risk_table_ypos=-0.2,
+    pvalue_loc="lower right",
 )
 ax.set_xlabel("Time (Months)")
 _ = plt.legend(loc="upper left")
@@ -252,13 +264,13 @@ plt.title("Custom X-Axis Ticks")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The curves automatically handle censored observations (shown as vertical marks).
 cns.figure(150, 150)
-cns.survivalplot(
+ax = cns.survivalplot(
     data=clinical_df,
     duration="time",
     event="event",
     hue="group",
     hue_order=["Control", "Treatment B"],
 )
-cns.take_legend_out()
+ax.set_xlabel("Time (Months)")
+_ = plt.legend(loc="upper right")
 plt.title("Survival with Censoring Marks")
-plt.xlabel("Time (Months)")

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -21,10 +21,74 @@ logger = logging.getLogger(__name__)
 
 CensorMarkPosition = Literal["line", "above", "below", "none"]
 VisibleCensorMarkPosition = Literal["line", "above", "below"]
+PValueLoc = Literal[
+    "upper left",
+    "upper center",
+    "upper right",
+    "center left",
+    "center",
+    "center right",
+    "right",
+    "lower left",
+    "lower center",
+    "lower right",
+]
+HorizontalAlignment = Literal["left", "center", "right"]
+VerticalAlignment = Literal["top", "center", "bottom"]
 
 _CIF_Y_LIMITS = (-0.05, 1.01)
 _DEFAULT_CENSOR_MARK_LENGTH = 0.02
 _CENSOR_MARK_POSITIONS = ("line", "above", "below", "none")
+_PVALUE_LOCATIONS: dict[
+    PValueLoc,
+    tuple[float, float, HorizontalAlignment, VerticalAlignment],
+] = {
+    "upper left": (0.02, 0.98, "left", "top"),
+    "upper center": (0.5, 0.98, "center", "top"),
+    "upper right": (0.98, 0.98, "right", "top"),
+    "center left": (0.02, 0.5, "left", "center"),
+    "center": (0.5, 0.5, "center", "center"),
+    "center right": (0.98, 0.5, "right", "center"),
+    "right": (0.98, 0.5, "right", "center"),
+    "lower left": (0.02, 0.02, "left", "bottom"),
+    "lower center": (0.5, 0.02, "center", "bottom"),
+    "lower right": (0.98, 0.02, "right", "bottom"),
+}
+
+
+def _add_pvalue_annotation(
+    ax: Axes,
+    text: str,
+    pvalue_loc: PValueLoc,
+    *,
+    data_position: tuple[float, float] | None = None,
+) -> None:
+    if data_position is not None:
+        ax.text(
+            *data_position,
+            text,
+            fontsize=plt.rcParams["legend.fontsize"],
+            linespacing=1.25,
+        )
+        return
+
+    if pvalue_loc not in _PVALUE_LOCATIONS:
+        valid_locations = "', '".join(_PVALUE_LOCATIONS)
+        raise ValueError(
+            "[survival plots] Parameter 'pvalue_loc' must be one of "
+            f"'{valid_locations}', got {pvalue_loc!r}"
+        )
+    x, y, horizontalalignment, verticalalignment = _PVALUE_LOCATIONS[pvalue_loc]
+    ax.text(
+        x,
+        y,
+        text,
+        transform=ax.transAxes,
+        ha=horizontalalignment,
+        va=verticalalignment,
+        fontsize=plt.rcParams["legend.fontsize"],
+        linespacing=1.25,
+    )
 
 
 def _format_valid_censor_mark_positions() -> str:
@@ -111,6 +175,8 @@ def survivalplot(
     *,
     overall_test: Literal["logrank", "trend"] = "logrank",
     pairs: list[tuple[str, str]] | None = None,
+    show_hazard_ratio: bool = True,
+    pvalue_loc: PValueLoc = "lower left",
     ax: Axes | None = None,
 ) -> Axes:
     """
@@ -146,6 +212,15 @@ def survivalplot(
         When omitted, the sole contrast is reported automatically for two groups;
         no contrast is inferred for three or more groups. Pass an empty list to
         suppress pairwise inference.
+    show_hazard_ratio : bool, default: True
+        Whether to show pairwise hazard ratios, confidence intervals, and Cox
+        p-values. If False, pairwise Cox inference is skipped and only the overall
+        log-rank or trend p-value is shown. Any value passed to ``pairs`` is ignored.
+    pvalue_loc : str, default: 'lower left'
+        Axes-relative location for the p-value and hazard-ratio annotation. Accepts
+        the fixed Matplotlib legend locations: ``'upper left'``, ``'upper center'``,
+        ``'upper right'``, ``'center left'``, ``'center'``, ``'center right'``,
+        ``'right'``, ``'lower left'``, ``'lower center'``, or ``'lower right'``.
     ax : matplotlib.axes.Axes, optional
         Axes to draw on. If None, uses the current axes.
 
@@ -211,11 +286,13 @@ def survivalplot(
         hue_order = observed_groups
     assert hue_order is not None
 
-    resolved_pairs = (
-        [(hue_order[0], hue_order[1])]
-        if pairs is None and len(hue_order) == 2
-        else ([] if pairs is None else pairs)
-    )
+    resolved_pairs: list[tuple[str, str]] = []
+    if show_hazard_ratio:
+        resolved_pairs = (
+            [(hue_order[0], hue_order[1])]
+            if pairs is None and len(hue_order) == 2
+            else ([] if pairs is None else pairs)
+        )
     for pair in resolved_pairs:
         if not isinstance(pair, tuple) or len(pair) != 2:
             raise ValueError(
@@ -259,7 +336,7 @@ def survivalplot(
                 data[duration], data[hue], data[event]
             )
             overall_p = num2tex.num2tex(logrank_result.p_value, precision=2)
-            overall_label = "Omnibus log-rank"
+            overall_label = "Log-rank"
             logger.info("P-value was determined by two-sided omnibus log-rank test.")
         except Exception as e:
             raise RuntimeError(
@@ -314,16 +391,21 @@ def survivalplot(
                 f"{comparison!r} vs {reference!r}. This may indicate insufficient "
                 f"data or model convergence issues. Details: {e}"
             ) from e
-        annotation_lines.append(
-            f"{comparison} vs {reference}: HR = {hazard_ratio:.2f} "
-            f"(95% CI {ci1:.2f}-{ci2:.2f}), Cox P = " + rf"${pair_p:.2g}$"
+        if len(hue_order) > 2:
+            annotation_lines.append(f"{comparison} vs {reference}")
+        annotation_lines.extend(
+            [
+                f"HR = {hazard_ratio:.2f}",
+                f"95% CI {ci1:.2f}\N{EN DASH}{ci2:.2f}",
+                "Cox P = " + rf"${pair_p:.2g}$",
+            ]
         )
     if resolved_pairs:
         logger.info(
             "Pairwise hazard ratios and unadjusted two-sided P-values were determined "
             "by Cox proportional hazards models."
         )
-    ax.text(0, 0, "\n".join(annotation_lines))
+    _add_pvalue_annotation(ax, "\n".join(annotation_lines), pvalue_loc)
 
     legend = ax.get_legend()
     if legend is not None:
@@ -341,7 +423,7 @@ def cumulativeincidenceplot(
     event: str,
     hue: str,
     hue_order: list[str] | None = None,
-    pvalue_position: tuple[float, float] = (0, 0.5),
+    pvalue_position: tuple[float, float] | None = None,
     show_risk_table: bool = False,
     risk_table_rows: tuple[str, ...] = ("At risk",),
     risk_table_ypos: float = -0.2,
@@ -351,6 +433,7 @@ def cumulativeincidenceplot(
     time_label: str = "Time",
     seed: int | None = 0,
     *,
+    pvalue_loc: PValueLoc = "center left",
     ax: Axes | None = None,
 ) -> Axes:
     """
@@ -373,8 +456,9 @@ def cumulativeincidenceplot(
         Column name for the grouping variable to compare cumulative incidence curves.
     hue_order : list, optional
         Order of groups from hue to display and compare.
-    pvalue_position : tuple of float, default: (0, 0.5)
-        (x, y) coordinates for placing the Gray's test p-value annotation.
+    pvalue_position : tuple of float, optional
+        Data coordinates for placing the Gray's test p-value annotation. When
+        provided, this overrides ``pvalue_loc``.
     show_risk_table : bool, default: False
         Whether to display a risk table below the plot.
     risk_table_rows : tuple of str, default: ('At risk',)
@@ -399,6 +483,12 @@ def cumulativeincidenceplot(
         Seed used by lifelines when tied event times require jittering. The default
         makes tied-data plots deterministic. The caller's NumPy random state is
         restored after fitting.
+    pvalue_loc : str, default: 'center left'
+        Axes-relative location for the Gray's test p-value. Accepts the fixed
+        Matplotlib legend locations: ``'upper left'``, ``'upper center'``,
+        ``'upper right'``, ``'center left'``, ``'center'``, ``'center right'``,
+        ``'right'``, ``'lower left'``, ``'lower center'``, or ``'lower right'``.
+        Ignored when ``pvalue_position`` is provided.
     ax : matplotlib.axes.Axes, optional
         Axes to draw on. If None, uses the current axes. Any risk table is linked
         to this axes and created on the same figure.
@@ -530,7 +620,12 @@ def cumulativeincidenceplot(
         )
         p = num2tex.num2tex(pvalue, precision=2)
         logger.info("P-value was determined by Gray's K-sample test.")
-        ax.text(pvalue_position[0], pvalue_position[1], "P = " + rf"${p:.2g}$")
+        _add_pvalue_annotation(
+            ax,
+            "P = " + rf"${p:.2g}$",
+            pvalue_loc,
+            data_position=pvalue_position,
+        )
 
     if show_risk_table:
         rows = None if risk_table_rows is None else list(risk_table_rows)

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -176,8 +176,7 @@ def test_survival_plots(
         [1, 5 / 6, 2 / 3, 2 / 3, 4 / 9, 4 / 9, 0],
     )
     assert ax.texts[0].get_text() == (
-        "Omnibus log-rank P = $0.6$\n"
-        "Control vs Treatment: HR = 0.68 (95% CI 0.15-3.06), Cox P = $0.62$"
+        "Log-rank P = $0.6$\nHR = 0.68\n95% CI 0.15–3.06\nCox P = $0.62$"
     )
     assert "omnibus log-rank test" in caplog.text
 
@@ -186,7 +185,7 @@ def test_survival_plots(
     with caplog.at_level(logging.INFO, logger="cnsplots"):
         ax2 = cns.survivalplot(survival_three_group_df, "time", "event", "group")
     assert ax2.get_xlabel() == "Time"
-    assert ax2.texts[0].get_text() == "Omnibus log-rank P = $0.36$"
+    assert ax2.texts[0].get_text() == "Log-rank P = $0.36$"
     assert "omnibus log-rank test" in caplog.text
     assert "trend" not in caplog.text
 

--- a/tests/test_survival_hardening.py
+++ b/tests/test_survival_hardening.py
@@ -149,6 +149,62 @@ def test_cumulativeincidenceplot_accepts_multiple_competing_event_codes(
     assert ax.texts[0].get_text() == "P = $0.88$"
 
 
+def test_cumulativeincidenceplot_uses_center_left_default_location(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    ax = cns.cumulativeincidenceplot(
+        competing_risk_df,
+        "time",
+        "event",
+        "group",
+    )
+
+    annotation = ax.texts[0]
+
+    assert annotation.get_position() == (0.02, 0.5)
+    assert annotation.get_transform() is ax.transAxes
+    assert annotation.get_horizontalalignment() == "left"
+    assert annotation.get_verticalalignment() == "center"
+    assert annotation.get_bbox_patch() is None
+
+
+def test_cumulativeincidenceplot_supports_pvalue_location(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    ax = cns.cumulativeincidenceplot(
+        competing_risk_df,
+        "time",
+        "event",
+        "group",
+        pvalue_loc="upper right",
+    )
+
+    annotation = ax.texts[0]
+
+    assert annotation.get_position() == (0.98, 0.98)
+    assert annotation.get_transform() is ax.transAxes
+    assert annotation.get_horizontalalignment() == "right"
+    assert annotation.get_verticalalignment() == "top"
+
+
+def test_cumulativeincidenceplot_preserves_custom_data_position(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    ax = cns.cumulativeincidenceplot(
+        competing_risk_df,
+        "time",
+        "event",
+        "group",
+        pvalue_position=(2, 0.75),
+        pvalue_loc="upper right",
+    )
+
+    annotation = ax.texts[0]
+
+    assert annotation.get_position() == (2, 0.75)
+    assert annotation.get_transform() is ax.transData
+
+
 def test_cumulativeincidenceplot_ties_are_deterministic_without_rng_side_effects() -> (
     None
 ):

--- a/tests/test_survival_inference.py
+++ b/tests/test_survival_inference.py
@@ -28,7 +28,7 @@ def test_survivalplot_omnibus_test_is_category_order_invariant(
         )
         annotations.append(_annotation(ax))
 
-    assert annotations == ["Omnibus log-rank P = $0.36$"] * 2
+    assert annotations == ["Log-rank P = $0.36$"] * 2
 
 
 def test_survivalplot_trend_test_is_explicitly_ordered(
@@ -71,18 +71,28 @@ def test_survivalplot_trend_requires_complete_explicit_order(
     [
         (
             ("Low", "High"),
-            "High vs Low: HR = 0.38 (95% CI 0.08-1.75), Cox P = $0.21$",
+            [
+                "High vs Low",
+                "HR = 0.38",
+                "95% CI 0.08–1.75",
+                "Cox P = $0.21$",
+            ],
         ),
         (
             ("High", "Low"),
-            "Low vs High: HR = 2.66 (95% CI 0.57-12.43), Cox P = $0.21$",
+            [
+                "Low vs High",
+                "HR = 2.66",
+                "95% CI 0.57–12.43",
+                "Cox P = $0.21$",
+            ],
         ),
     ],
 )
 def test_survivalplot_reports_named_directional_pairwise_inference(
     survival_three_group_df: pd.DataFrame,
     pair: tuple[str, str],
-    expected: str,
+    expected: list[str],
 ) -> None:
     annotations = []
     for order in (["Low", "Mid", "High"], ["Low", "High", "Mid"]):
@@ -98,9 +108,104 @@ def test_survivalplot_reports_named_directional_pairwise_inference(
         annotations.append(_annotation(ax).splitlines())
 
     assert annotations == [
-        ["Omnibus log-rank P = $0.36$", expected],
-        ["Omnibus log-rank P = $0.36$", expected],
+        ["Log-rank P = $0.36$", *expected],
+        ["Log-rank P = $0.36$", *expected],
     ]
+
+
+def test_survivalplot_can_hide_hazard_ratio_results(
+    survival_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import lifelines
+
+    class UnexpectedCoxModel:
+        def __init__(self) -> None:
+            raise AssertionError("Pairwise Cox inference should be skipped")
+
+    monkeypatch.setattr(lifelines, "CoxPHFitter", UnexpectedCoxModel)
+
+    ax = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        pairs=[("Control", "Treatment")],
+        show_hazard_ratio=False,
+    )
+
+    assert _annotation(ax) == "Log-rank P = $0.6$"
+
+
+def test_survivalplot_uses_lower_left_default_location(
+    survival_three_group_df: pd.DataFrame,
+) -> None:
+    ax = cns.survivalplot(
+        survival_three_group_df,
+        "time",
+        "event",
+        "group",
+        hue_order=["Low", "Mid", "High"],
+        pairs=[("Low", "High")],
+    )
+
+    annotation = ax.texts[0]
+
+    assert annotation.get_position() == (0.02, 0.02)
+    assert annotation.get_transform() is ax.transAxes
+    assert annotation.get_horizontalalignment() == "left"
+    assert annotation.get_verticalalignment() == "bottom"
+    assert annotation.get_bbox_patch() is None
+    assert annotation.get_text().splitlines() == [
+        "Log-rank P = $0.36$",
+        "High vs Low",
+        "HR = 0.38",
+        "95% CI 0.08–1.75",
+        "Cox P = $0.21$",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("pvalue_loc", "position", "horizontalalignment", "verticalalignment"),
+    [
+        ("upper left", (0.02, 0.98), "left", "top"),
+        ("upper right", (0.98, 0.98), "right", "top"),
+        ("lower center", (0.5, 0.02), "center", "bottom"),
+    ],
+)
+def test_survivalplot_supports_legend_style_pvalue_locations(
+    survival_three_group_df: pd.DataFrame,
+    pvalue_loc: str,
+    position: tuple[float, float],
+    horizontalalignment: str,
+    verticalalignment: str,
+) -> None:
+    ax = cns.survivalplot(
+        survival_three_group_df,
+        "time",
+        "event",
+        "group",
+        pvalue_loc=cast(Any, pvalue_loc),
+    )
+
+    annotation = ax.texts[0]
+
+    assert annotation.get_position() == position
+    assert annotation.get_horizontalalignment() == horizontalalignment
+    assert annotation.get_verticalalignment() == verticalalignment
+
+
+def test_survivalplot_rejects_unknown_pvalue_location(
+    survival_three_group_df: pd.DataFrame,
+) -> None:
+    with pytest.raises(ValueError, match="'pvalue_loc' must be one of"):
+        cns.survivalplot(
+            survival_three_group_df,
+            "time",
+            "event",
+            "group",
+            pvalue_loc=cast(Any, "outside"),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- Add legend-style `pvalue_loc` controls to survival and cumulative-incidence plots while keeping annotations inside the axes.
- Shorten survival annotations, omit redundant two-group comparison labels, and allow users to hide hazard-ratio, confidence-interval, and Cox P-value results.
- Preserve explicit cumulative-incidence `pvalue_position` coordinates as an override.
- Update gallery examples and regression coverage for the new annotation behavior.

## Why

The previous survival annotation could become long and difficult to read over plotted curves, while cumulative-incidence P-values lacked a consistent axes-relative placement control.

## Testing

- `make test` — 366 passed with 100% coverage
- `make lint` — all hooks passed

## Risks and follow-ups

Annotations intentionally remain inside the axes, so especially dense plots may still require selecting a different `pvalue_loc`. No follow-up work is required.
