### PR TITLE
📝 Show total PyPI downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/faridrashidi/cnsplots/ci-tests.yml?branch=main&logo=github&logoColor=white&style=flat-square&label=tests&labelColor=000000&cacheSeconds=0)](https://github.com/faridrashidi/cnsplots/actions/workflows/ci-tests.yml)
 [![Docs](https://img.shields.io/website?url=https%3A%2F%2Fcnsplots.farid.one%2F&up_message=online&down_message=offline&logo=readthedocs&logoColor=white&style=flat-square&label=docs&labelColor=000000&cacheSeconds=0)](https://cnsplots.farid.one/)
+[![Downloads](https://img.shields.io/pepy/dt/cnsplots?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI%2BPHBhdGggZmlsbD0iI2ZmZiIgZD0iTTExIDNoMnYxMGwzLjUtMy41IDEuNCAxLjQtNS45IDUuOS01LjktNS45IDEuNC0xLjRMMTEgMTNWM3pNNSAxOGgxNHYzSDV6Ii8%2BPC9zdmc%2B&style=flat-square&label=downloads&labelColor=000000&cacheSeconds=0)](https://pepy.tech/project/cnsplots)
 [![PyPI](https://img.shields.io/pypi/v/cnsplots?logo=pypi&logoColor=white&style=flat-square&labelColor=000000&cacheSeconds=0)](https://pypi.org/project/cnsplots/)
 [![Python Version](https://img.shields.io/pypi/pyversions/cnsplots?logo=python&logoColor=white&style=flat-square&labelColor=000000&cacheSeconds=0)](https://pypi.org/project/cnsplots/)
 [![License](https://img.shields.io/pypi/l/cnsplots?logo=creativecommons&logoColor=white&style=flat-square&labelColor=000000&color=blueviolet&cacheSeconds=0)](https://github.com/faridrashidi/cnsplots/blob/main/LICENSE.md)


### PR DESCRIPTION
## What changed

- Add a total PyPI download-count badge to the README before the PyPI version badge.
- Match the existing flat-square badge styling with a black label, green count, and download-arrow icon.
- Link the badge to the cnsplots project on PePy so readers can inspect download statistics.

## Testing

- `make test` — 366 passed with 100% coverage.
- `make lint` — all pre-commit checks passed.

## Risks and follow-ups

- Low risk: this is a README-only change.
- The displayed count depends on Shields.io and PePy availability; no follow-up is currently required.
