### PR TITLE
⬆️ Upgrade pre-commit toolchain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ default_stages:
 minimum_pre_commit_version: 2.9.3
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.3
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: [--fix]
@@ -21,7 +21,7 @@ repos:
         pass_filenames: false
         always_run: true
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: detect-private-key
       - id: check-merge-conflict
@@ -41,21 +41,21 @@ repos:
       - id: debug-statements
       - id: requirements-txt-fixer
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.3
     hooks:
       - id: codespell
         additional_dependencies: [tomli]
   - repo: https://github.com/myint/rstcheck
-    rev: v6.2.4
+    rev: v6.3.0
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]
         args: ["--ignore-directives=autoclass,autofunction,minigallery"]
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.19.1
+    rev: 1.20.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==24.10.0]
+        additional_dependencies: [black==26.5.1]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
@@ -63,7 +63,7 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
   - repo: https://github.com/PyCQA/doc8
-    rev: v1.1.2
+    rev: v2.0.0
     hooks:
       - id: doc8
         args: [--max-line-length=88]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ target-version = "py310"
 line-length = 88
 src = ["src"]
 
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["cnsplots"]
 

--- a/src/cnsplots/helpers/_phylo.py
+++ b/src/cnsplots/helpers/_phylo.py
@@ -122,7 +122,7 @@ def _heatmap(
     leg_kws :   dict, optional
                 Keyword arguments passed to plt.legend()
     **sns_kws
-                Keyword argumentas passed through to `seaborn.heatmap()`
+                Keyword arguments passed through to `seaborn.heatmap()`
     Returns
     -------
     matplotlib axis


### PR DESCRIPTION
## What changed

- Upgrade all versioned pre-commit hooks and the Black dependency to their latest releases.
- Preserve the previous Ruff lint scope explicitly while adopting Ruff 0.16.
- Correct the spelling issue exposed by the updated codespell dictionary.

## Why

This keeps the development toolchain current without introducing a broad source rewrite or changing the package API.

## Testing

- `make lint`
- `make test` — 366 tests passed with 100% coverage

## Risks and follow-ups

Risk is low. Ruff 0.16 expands its default rule set, so the previous defaults are selected explicitly for compatibility. The existing unpinned `ty` behavior is unchanged. No follow-up work is required.
