### PR TITLE
✨ Add CNSPlots agent skill installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,26 @@ pip install cnsplots
 This installs every supported plotting and scientific integration. Imports
 remain lazy, so those backends are loaded only when their APIs are first used.
 
+### Agent Skill
+
+Install the bundled cnsplots skill so Codex and Claude Code can build plots
+using the package's current workflow and API:
+
+```bash
+cnsplots skill install
+```
+
+By default this installs the skill for both agents at user scope. Target one
+agent or the current project when needed:
+
+```bash
+cnsplots skill install --agent codex
+cnsplots skill install --agent claude --scope project
+```
+
+Use `$cnsplots` in Codex or `/cnsplots` in Claude Code to invoke it explicitly.
+Pass `--force` to update an existing installation after upgrading cnsplots.
+
 ### For Development
 
 First install [uv](https://docs.astral.sh/uv/), then:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,27 @@ pip install cnsplots
 This installs every supported plotting and scientific integration. Imports
 remain lazy, so those backends are loaded only when their APIs are first used.
 
+## Install the Agent Skill
+
+cnsplots includes an Agent Skills-compatible guide for building
+publication-ready plots. Install it for Codex and Claude Code with:
+
+```bash
+cnsplots skill install
+```
+
+The default user-scope destinations are `~/.agents/skills/cnsplots` for Codex
+and `~/.claude/skills/cnsplots` for Claude Code. You can target one agent or
+install into the current project:
+
+```bash
+cnsplots skill install --agent codex
+cnsplots skill install --agent claude --scope project
+```
+
+Invoke the installed skill as `$cnsplots` in Codex or `/cnsplots` in Claude
+Code. After upgrading cnsplots, pass `--force` to update an existing skill.
+
 ## Verify Installation
 
 After installation, verify that cnsplots is correctly installed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ Documentation = "https://cnsplots.farid.one"
 Repository = "https://github.com/faridrashidi/cnsplots"
 Issues = "https://github.com/faridrashidi/cnsplots/issues"
 
+[project.scripts]
+cnsplots = "cnsplots._cli:main"
+
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
@@ -81,7 +84,12 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.setuptools.package-data]
-cnsplots = ["py.typed"]
+cnsplots = [
+    "py.typed",
+    "_agent_skill/cnsplots/*.md",
+    "_agent_skill/cnsplots/agents/*.yaml",
+    "_agent_skill/cnsplots/references/*.md",
+]
 "cnsplots.datasets" = ["_data/*.csv", "_data/showcase/*.webp"]
 
 [tool.ruff]

--- a/src/cnsplots/_agent_skill/cnsplots/SKILL.md
+++ b/src/cnsplots/_agent_skill/cnsplots/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: cnsplots
+description: Create, revise, and troubleshoot publication-ready scientific plots in Python with cnsplots, including distribution, regression, heatmap, genomics, survival, set, flow, and multi-panel figures. Use when a user asks for cnsplots code, Cell/Nature/Science-style visualization, precise pixel-sized figures, statistical plot annotations, or editable SVG/PDF publication output.
+---
+
+# CNSPlots
+
+Build plots against the installed `cnsplots` version. Favor a short, runnable
+script that preserves the user's data semantics and produces the requested
+artifact.
+
+## Workflow
+
+1. Inspect the input data before choosing a plot.
+   - Confirm the relevant columns, dtypes, missing values, units, category
+     order, and event coding.
+   - Ask only when an unresolved choice would change the scientific meaning.
+   - Never invent labels, comparisons, thresholds, statistical tests, or units.
+
+2. Choose the narrowest suitable public plot function.
+   - Read [references/plot-catalog.md](references/plot-catalog.md) when selecting
+     a plot type or composing a multi-panel figure.
+   - Prefer `import cnsplots as cns` and the public names on `cns`.
+   - Do not call private modules or functions.
+
+3. Verify the installed API instead of guessing a signature.
+
+   ```bash
+   python - <<'PY'
+   import inspect
+   import cnsplots as cns
+
+   print(cns.__version__)
+   print(inspect.signature(cns.boxplot))
+   print(cns.boxplot.__doc__)
+   PY
+   ```
+
+   Replace `boxplot` with the selected public function. If `cnsplots` cannot be
+   imported, report that clearly and ask before changing the user's environment.
+
+4. Build the figure.
+   - In headless execution, set `MPLBACKEND=Agg` or call
+     `matplotlib.use("Agg")` before importing plotting backends.
+   - Start single-panel figures with `cns.figure(width=..., height=...)`.
+     Dimensions are in pixels.
+   - Pass `ax=` explicitly when composing with existing Matplotlib axes.
+   - Use `cns.multipanel` for labeled publication panels.
+   - Add titles and axis labels through the returned Matplotlib axes.
+   - Use `cns.settings.context(...)` for temporary style overrides rather than
+     leaving global settings changed.
+
+5. Save and validate the result.
+   - Use `cns.savefig(...)`. Prefer SVG or PDF for editable publication output
+     and PNG for a raster preview.
+   - Run the complete script, confirm the output exists and is non-empty, and
+     inspect or render it when visual tools are available.
+   - Check clipping, unreadable labels, misleading scales, legend collisions,
+     color distinguishability, and panel alignment.
+   - Return the runnable code, output path, and any scientific assumptions.
+
+## Baseline Pattern
+
+```python
+import matplotlib
+
+matplotlib.use("Agg")
+
+import cnsplots as cns
+
+cns.figure(width=180, height=150)
+ax = cns.boxplot(data=df, x="group", y="value")
+ax.set(xlabel="Group", ylabel="Value")
+cns.savefig("figure.svg")
+```
+
+Adapt this only after inspecting the selected function's installed signature and
+docstring.
+
+## Statistical Integrity
+
+- Treat `pairs`, event codes, reference groups, transformations, and thresholds
+  as analysis choices, not decoration.
+- State tests and comparison directions reflected by the installed function
+  documentation.
+- Do not imply causality or significance beyond the supplied data and chosen
+  analysis.
+- Preserve raw observations when the user requests them; do not silently replace
+  distributions with summaries.

--- a/src/cnsplots/_agent_skill/cnsplots/agents/openai.yaml
+++ b/src/cnsplots/_agent_skill/cnsplots/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CNSPlots"
+  short_description: "Build publication-ready scientific plots"
+  default_prompt: "Use $cnsplots to build a publication-ready scientific plot from my data."

--- a/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
+++ b/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
@@ -1,0 +1,97 @@
+# CNSPlots Plot Catalog
+
+Use this catalog to select a public function, then inspect its installed
+signature and docstring before writing code.
+
+## Distribution and group comparison
+
+- `boxplot`: quartiles and medians across categories; optional pairwise tests.
+- `violinplot`: distribution shape across categories.
+- `stripplot`: individual observations across categories.
+- `barplot`: group estimates displayed as bars.
+- `lollipopplot`: values or summaries with stems and markers.
+- `histplot`: binned univariate or bivariate distributions.
+- `kdeplot`: smoothed density estimates.
+- `distplot`: compact distribution visualization.
+- `ridgeplot`: stacked densities across groups.
+- `qqplot`: observed versus theoretical quantiles.
+
+## Relationships and change
+
+- `scatterplot`: relationships between numeric variables.
+- `regplot`: fitted relationship with regression context.
+- `lineplot`: trends or repeated measurements over an ordered axis.
+- `slopeplot`: changes between conditions or time points.
+
+## Matrices and classifications
+
+- `heatmapplot`: clustered or annotated matrix heatmaps.
+- `dotplot`: matrix-like values encoded by dot size and color.
+- `confusionplot`: predicted versus observed class performance.
+
+`heatmapplot` and `dotplot` return backend-native plotter objects rather than a
+plain Matplotlib `Axes`.
+
+## Proportions, sets, and flows
+
+- `stackplot`: categorical composition across groups.
+- `pieplot` and `donutplot`: parts of a whole when few categories are present.
+- `vennplot`: overlap among a small number of sets.
+- `upsetplot`: scalable set intersections.
+- `sankeyplot`: flow between source and target categories.
+
+`upsetplot` returns panel axes and `vennplot` returns a matplotlib-venn diagram
+object.
+
+## Survival and model summaries
+
+- `survivalplot`: Kaplan-Meier curves, overall tests, and optional pairwise
+  hazard-ratio inference.
+- `cumulativeincidenceplot`: competing-risk cumulative incidence.
+- `forestplot`: effect estimates and confidence intervals.
+- `CoxModel` and `LogisticModel`: fitted statistical models used by relevant
+  plotting workflows.
+
+Confirm event coding, reference groups, time units, and requested contrasts
+before plotting.
+
+## Genomics and evaluation
+
+- `volcanoplot`: effect size versus transformed adjusted significance.
+- `gseaplot`: gene-set enrichment results.
+- `rocplot`: receiver operating characteristic curves.
+- `phyloplot`: phylogenetic visualization from `AnnData`.
+- `prerank`: preranked enrichment analysis.
+
+Do not infer column transformations or significance thresholds. Verify the
+input columns expected by the installed version.
+
+## Figure composition and export
+
+- `figure`: initialize a styled single-panel canvas in pixel dimensions.
+- `multipanel`: create labeled, pixel-sized panels; `panel(...)` returns the
+  target `Axes`.
+- `add_panel_label`: label an existing axes.
+- `take_legend_out`: position a legend outside its axes.
+- `savefig`: save the current figure and create parent directories as needed.
+- `settings.context(...)`: apply temporary package-wide style settings.
+- `palettes`: retrieve curated categorical or continuous palettes.
+
+Typical multi-panel structure:
+
+```python
+import cnsplots as cns
+
+mp = cns.multipanel(max_width=540)
+
+ax_a = mp.panel("A", width=150, height=150)
+cns.boxplot(data=grouped, x="group", y="value", ax=ax_a)
+
+ax_b = mp.panel("B", width=150, height=150)
+cns.scatterplot(data=continuous, x="x", y="y", ax=ax_b)
+
+cns.savefig("multipanel.svg")
+```
+
+See the current API documentation at <https://cnsplots.farid.one/latest/api.html>
+when web access is available.

--- a/src/cnsplots/_cli.py
+++ b/src/cnsplots/_cli.py
@@ -42,8 +42,7 @@ def install_skill(
     """Install the packaged skill into one or more agent skill directories."""
     agent_names = tuple(_AGENT_SKILL_DIRS) if agent == "all" else (agent,)
     destinations = tuple(
-        (name, base_dir / _AGENT_SKILL_DIRS[name] / "cnsplots")
-        for name in agent_names
+        (name, base_dir / _AGENT_SKILL_DIRS[name] / "cnsplots") for name in agent_names
     )
 
     conflicts = tuple(path for _, path in destinations if path.exists())

--- a/src/cnsplots/_cli.py
+++ b/src/cnsplots/_cli.py
@@ -1,0 +1,106 @@
+"""Command-line helpers for cnsplots."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from importlib import resources
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable  # pragma: no cover
+else:
+    from importlib.abc import Traversable  # pragma: no cover
+
+_AGENT_SKILL_DIRS = {
+    "codex": Path(".agents") / "skills",
+    "claude": Path(".claude") / "skills",
+}
+
+
+def _skill_source() -> Traversable:
+    return resources.files("cnsplots").joinpath("_agent_skill").joinpath("cnsplots")
+
+
+def _copy_skill_tree(source: Traversable, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    for item in source.iterdir():
+        target = destination / item.name
+        if item.is_dir():
+            _copy_skill_tree(item, target)
+        else:
+            target.write_bytes(item.read_bytes())
+
+
+def install_skill(
+    agent: str,
+    *,
+    force: bool,
+    base_dir: Path,
+) -> tuple[tuple[str, Path], ...]:
+    """Install the packaged skill into one or more agent skill directories."""
+    agent_names = tuple(_AGENT_SKILL_DIRS) if agent == "all" else (agent,)
+    destinations = tuple(
+        (name, base_dir / _AGENT_SKILL_DIRS[name] / "cnsplots")
+        for name in agent_names
+    )
+
+    conflicts = tuple(path for _, path in destinations if path.exists())
+    if conflicts and not force:
+        paths = ", ".join(str(path) for path in conflicts)
+        raise FileExistsError(
+            f"refusing to overwrite existing skill at {paths}; pass --force to update"
+        )
+
+    source = _skill_source()
+    for _, destination in destinations:
+        _copy_skill_tree(source, destination)
+    return destinations
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cnsplots")
+    commands = parser.add_subparsers(dest="command", required=True)
+    skill = commands.add_parser("skill", help="manage the cnsplots agent skill")
+    skill_commands = skill.add_subparsers(dest="skill_command", required=True)
+    install = skill_commands.add_parser("install", help="install the agent skill")
+    install.add_argument(
+        "--agent",
+        choices=("all", "codex", "claude"),
+        default="all",
+        help="agent to configure (default: all)",
+    )
+    install.add_argument(
+        "--scope",
+        choices=("user", "project"),
+        default="user",
+        help="install globally for the user or into the current project",
+    )
+    install.add_argument(
+        "--force",
+        action="store_true",
+        help="update files in an existing cnsplots skill",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the cnsplots command line interface."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    base_dir = Path.home() if args.scope == "user" else Path.cwd()
+
+    try:
+        destinations = install_skill(
+            args.agent,
+            force=args.force,
+            base_dir=base_dir,
+        )
+    except FileExistsError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    for agent, destination in destinations:
+        print(f"Installed cnsplots skill for {agent}: {destination}")
+    return 0

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cnsplots import _cli
+
+
+def test_install_skill_copies_packaged_files_for_all_agents(tmp_path: Path) -> None:
+    destinations = _cli.install_skill(
+        "all",
+        force=False,
+        base_dir=tmp_path,
+    )
+
+    expected = (
+        ("codex", tmp_path / ".agents" / "skills" / "cnsplots"),
+        ("claude", tmp_path / ".claude" / "skills" / "cnsplots"),
+    )
+    assert destinations == expected
+
+    for _, destination in destinations:
+        skill = (destination / "SKILL.md").read_text(encoding="utf-8")
+        assert skill.startswith("---\nname: cnsplots\n")
+        assert "publication-ready scientific plots" in skill
+        assert (destination / "agents" / "openai.yaml").is_file()
+        assert (destination / "references" / "plot-catalog.md").is_file()
+
+
+def test_install_skill_selects_one_project_agent(tmp_path: Path) -> None:
+    destinations = _cli.install_skill(
+        "claude",
+        force=False,
+        base_dir=tmp_path,
+    )
+
+    assert destinations == (
+        ("claude", tmp_path / ".claude" / "skills" / "cnsplots"),
+    )
+    assert not (tmp_path / ".agents").exists()
+
+
+def test_install_skill_preflights_conflicts_before_copying(tmp_path: Path) -> None:
+    existing = tmp_path / ".agents" / "skills" / "cnsplots"
+    existing.mkdir(parents=True)
+
+    with pytest.raises(FileExistsError, match="pass --force to update"):
+        _cli.install_skill("all", force=False, base_dir=tmp_path)
+
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_install_skill_force_updates_existing_files(tmp_path: Path) -> None:
+    destination = tmp_path / ".agents" / "skills" / "cnsplots"
+    destination.mkdir(parents=True)
+    (destination / "SKILL.md").write_text("stale", encoding="utf-8")
+
+    _cli.install_skill("codex", force=True, base_dir=tmp_path)
+
+    assert (destination / "SKILL.md").read_text(encoding="utf-8").startswith(
+        "---\nname: cnsplots\n"
+    )
+
+
+def test_cli_installs_and_reports_project_skill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = _cli.main(
+        ["skill", "install", "--agent", "codex", "--scope", "project"]
+    )
+
+    assert result == 0
+    assert (
+        f"Installed cnsplots skill for codex: "
+        f"{tmp_path / '.agents' / 'skills' / 'cnsplots'}"
+        in capsys.readouterr().out
+    )
+
+
+def test_cli_reports_existing_skill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    destination = tmp_path / ".claude" / "skills" / "cnsplots"
+    destination.mkdir(parents=True)
+
+    result = _cli.main(
+        ["skill", "install", "--agent", "claude", "--scope", "project"]
+    )
+
+    assert result == 1
+    assert "error: refusing to overwrite existing skill" in capsys.readouterr().err

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -35,9 +35,7 @@ def test_install_skill_selects_one_project_agent(tmp_path: Path) -> None:
         base_dir=tmp_path,
     )
 
-    assert destinations == (
-        ("claude", tmp_path / ".claude" / "skills" / "cnsplots"),
-    )
+    assert destinations == (("claude", tmp_path / ".claude" / "skills" / "cnsplots"),)
     assert not (tmp_path / ".agents").exists()
 
 
@@ -58,8 +56,10 @@ def test_install_skill_force_updates_existing_files(tmp_path: Path) -> None:
 
     _cli.install_skill("codex", force=True, base_dir=tmp_path)
 
-    assert (destination / "SKILL.md").read_text(encoding="utf-8").startswith(
-        "---\nname: cnsplots\n"
+    assert (
+        (destination / "SKILL.md")
+        .read_text(encoding="utf-8")
+        .startswith("---\nname: cnsplots\n")
     )
 
 
@@ -70,15 +70,12 @@ def test_cli_installs_and_reports_project_skill(
 ) -> None:
     monkeypatch.chdir(tmp_path)
 
-    result = _cli.main(
-        ["skill", "install", "--agent", "codex", "--scope", "project"]
-    )
+    result = _cli.main(["skill", "install", "--agent", "codex", "--scope", "project"])
 
     assert result == 0
     assert (
         f"Installed cnsplots skill for codex: "
-        f"{tmp_path / '.agents' / 'skills' / 'cnsplots'}"
-        in capsys.readouterr().out
+        f"{tmp_path / '.agents' / 'skills' / 'cnsplots'}" in capsys.readouterr().out
     )
 
 
@@ -91,9 +88,7 @@ def test_cli_reports_existing_skill(
     destination = tmp_path / ".claude" / "skills" / "cnsplots"
     destination.mkdir(parents=True)
 
-    result = _cli.main(
-        ["skill", "install", "--agent", "claude", "--scope", "project"]
-    )
+    result = _cli.main(["skill", "install", "--agent", "claude", "--scope", "project"])
 
     assert result == 1
     assert "error: refusing to overwrite existing skill" in capsys.readouterr().err


### PR DESCRIPTION
## What changed

- Bundle a portable `cnsplots` Agent Skill with a progressive-disclosure plot catalog and Codex UI metadata.
- Add `cnsplots skill install` for Codex, Claude Code, or both at user or project scope.
- Package the skill in wheels and source distributions, document installation and invocation, and test safe installation and update behavior.

## Why

Users can give coding agents reliable, version-aligned guidance for creating publication-ready cnsplots figures without repeatedly explaining the plotting workflow or API conventions.

## Testing

- `make test` — 372 passed with 100% coverage
- `make lint`
- Skill schema validation with `quick_validate.py`
- Wheel and source-distribution build with `uv build`
- Independent forward test generating and visually checking SVG and PNG output

## Risks and follow-ups

Risk is low because installation is opt-in and refuses to overwrite an existing skill unless `--force` is supplied. A marketplace plugin can be added later if broader agent-native distribution is useful.
