### PR TITLE
🐛 Fix dark documentation plots

### DIFF
--- a/docs/_ext/theme_aware_matplotlib.py
+++ b/docs/_ext/theme_aware_matplotlib.py
@@ -23,6 +23,10 @@ from sphinx_gallery.utils import scale_image
 
 _DARK_FOREGROUND = mcolors.to_rgba("#e6e6e6")[:3]
 _DARK_BACKGROUND = mcolors.to_rgba("#202124")[:3]
+_HOMEPAGE_SHOWCASE_IMAGES = {
+    "sphx_glr_showcase_001.png",
+    "sphx_glr_showcase_001_dark.png",
+}
 
 
 def _map_neutral_color(value, *, light_background: bool = False):
@@ -193,6 +197,20 @@ def prepare_dark_gallery_thumbnails(app, env, docnames) -> None:
     gallery_dir = Path(app.srcdir) / "examples"
     thumbnail_size = tuple(app.config.sphinx_gallery_conf["thumbnail_size"])
     _prepare_dark_gallery_thumbnails(gallery_dir, thumbnail_size)
+
+
+def fallback_linkcheck_showcase_images(app, doctree) -> None:
+    """Use the static overview when linkcheck skips gallery execution."""
+    if app.builder.name != "linkcheck":
+        return
+
+    for image in doctree.findall(nodes.image):
+        uri = Path(image["uri"])
+        if (
+            uri.parent.as_posix() == "examples/images"
+            and uri.name in _HOMEPAGE_SHOWCASE_IMAGES
+        ):
+            image["uri"] = "_static/images/overview.png"
 
 
 def theme_gallery_thumbnail_nodes(app, doctree) -> None:

--- a/docs/_ext/theme_aware_matplotlib.py
+++ b/docs/_ext/theme_aware_matplotlib.py
@@ -1,0 +1,180 @@
+"""Generate light and dark variants of Sphinx-Gallery Matplotlib figures."""
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+from pathlib import Path
+from textwrap import indent
+from typing import Iterator
+
+import matplotlib as mpl
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.collections import Collection
+from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
+from matplotlib.patches import Patch
+from matplotlib.text import Text
+from sphinx_gallery.scrapers import matplotlib_scraper
+
+_DARK_FOREGROUND = mcolors.to_rgba("#e6e6e6")[:3]
+_DARK_BACKGROUND = mcolors.to_rgba("#202124")[:3]
+
+
+def _map_neutral_color(value, *, light_background: bool = False):
+    """Map neutral colors for a dark canvas without changing data colors."""
+    if isinstance(value, np.ndarray) and value.ndim > 1:
+        mapped = value.copy()
+        changed = False
+        for index, color in enumerate(value):
+            mapped_color, color_changed = _map_neutral_color(
+                color, light_background=light_background
+            )
+            if color_changed:
+                mapped[index] = mapped_color
+                changed = True
+        return mapped, changed
+
+    try:
+        red, green, blue, alpha = mcolors.to_rgba(value)
+    except (TypeError, ValueError):
+        return value, False
+
+    if alpha == 0 or max(red, green, blue) - min(red, green, blue) > 0.03:
+        return value, False
+
+    if light_background and min(red, green, blue) >= 0.85:
+        return (*_DARK_BACKGROUND, alpha), True
+    if max(red, green, blue) <= 0.3:
+        return (*_DARK_FOREGROUND, alpha), True
+    return value, False
+
+
+def _replace_color(changes, artist, getter_name, setter_name, **kwargs) -> None:
+    """Replace one artist color and record enough state to restore it."""
+    getter = getattr(artist, getter_name)
+    setter = getattr(artist, setter_name)
+    old_value = copy.deepcopy(getter())
+    new_value, changed = _map_neutral_color(old_value, **kwargs)
+    if changed:
+        setter(new_value)
+        changes.append((setter, old_value))
+
+
+@contextmanager
+def _dark_figure(fig: Figure) -> Iterator[None]:
+    """Temporarily adapt a figure's neutral foreground for a dark page."""
+    changes = []
+    canvas_patches = {fig.patch, *(ax.patch for ax in fig.axes)}
+    text_bbox_patches = {
+        bbox
+        for artist in fig.findobj(match=Text)
+        if (bbox := artist.get_bbox_patch()) is not None
+    }
+
+    for artist in fig.findobj():
+        if isinstance(artist, Text):
+            _replace_color(changes, artist, "get_color", "set_color")
+            bbox = artist.get_bbox_patch()
+            if bbox is not None:
+                _replace_color(
+                    changes,
+                    bbox,
+                    "get_facecolor",
+                    "set_facecolor",
+                    light_background=True,
+                )
+        elif isinstance(artist, Line2D):
+            _replace_color(changes, artist, "get_color", "set_color")
+            _replace_color(
+                changes, artist, "get_markerfacecolor", "set_markerfacecolor"
+            )
+            _replace_color(
+                changes, artist, "get_markeredgecolor", "set_markeredgecolor"
+            )
+        elif isinstance(artist, Patch):
+            if artist not in canvas_patches and artist not in text_bbox_patches:
+                _replace_color(changes, artist, "get_facecolor", "set_facecolor")
+            _replace_color(changes, artist, "get_edgecolor", "set_edgecolor")
+        elif isinstance(artist, Collection):
+            _replace_color(changes, artist, "get_facecolor", "set_facecolor")
+            _replace_color(changes, artist, "get_edgecolor", "set_edgecolor")
+
+    try:
+        yield
+    finally:
+        for setter, old_value in reversed(changes):
+            setter(old_value)
+
+
+def _dark_path(light_path: Path) -> Path:
+    """Return the dark companion path for a gallery image."""
+    return light_path.with_name(f"{light_path.stem}_dark{light_path.suffix}")
+
+
+def _savefig_kwargs(fig: Figure) -> dict[str, object]:
+    """Mirror Sphinx-Gallery's handling of explicit figure colors."""
+    kwargs: dict[str, object] = {}
+    for attribute in ("facecolor", "edgecolor"):
+        figure_color = getattr(fig, f"get_{attribute}")()
+        default_color = mpl.rcParams[f"figure.{attribute}"]
+        if mcolors.to_rgba(figure_color) != mcolors.to_rgba(default_color):
+            kwargs[attribute] = figure_color
+    return kwargs
+
+
+def _save_dark_companions(
+    figures: list[Figure], light_paths: list[Path], srcset: list[float]
+) -> dict[str, str]:
+    """Save dark figures and return light-to-dark filename replacements."""
+    replacements: dict[str, str] = {}
+
+    for fig, light_path in zip(figures, light_paths, strict=True):
+        kwargs = _savefig_kwargs(fig)
+        dpi = kwargs.get("dpi", mpl.rcParams["savefig.dpi"])
+        if dpi == "figure":
+            dpi = fig.dpi
+
+        with _dark_figure(fig):
+            dark_path = _dark_path(light_path)
+            fig.savefig(dark_path, **kwargs)
+            replacements[light_path.name] = dark_path.name
+
+            for multiplier in srcset:
+                suffix = f"{multiplier:.2f}".replace(".", "_")
+                light_srcset = light_path.with_name(
+                    f"{light_path.stem}_{suffix}x{light_path.suffix}"
+                )
+                dark_srcset = _dark_path(light_srcset)
+                fig.savefig(dark_srcset, dpi=multiplier * dpi, **kwargs)
+                replacements[light_srcset.name] = dark_srcset.name
+
+    return replacements
+
+
+def _mark_theme(rst: str, theme: str) -> str:
+    """Wrap gallery markup in a container recognized by Furo's theme switcher."""
+    return f"\n.. container:: only-{theme}\n\n{indent(rst, '   ')}"
+
+
+def theme_aware_matplotlib_scraper(block, block_vars, gallery_conf) -> str:
+    """Render transparent Matplotlib figures for both documentation themes."""
+    image_paths = block_vars["image_path_iterator"]
+    previous_count = len(image_paths)
+    figures = [plt.figure(number) for number in plt.get_fignums()]
+
+    light_rst = matplotlib_scraper(block, block_vars, gallery_conf)
+    new_paths = [Path(path) for path in image_paths.paths[previous_count:]]
+    if not light_rst or len(figures) != len(new_paths):
+        return light_rst
+
+    replacements = _save_dark_companions(
+        figures, new_paths, gallery_conf["image_srcset"]
+    )
+    dark_rst = light_rst
+    for light_name, dark_name in replacements.items():
+        dark_rst = dark_rst.replace(light_name, dark_name)
+
+    return _mark_theme(light_rst, "light") + _mark_theme(dark_rst, "dark")

--- a/docs/_ext/theme_aware_matplotlib.py
+++ b/docs/_ext/theme_aware_matplotlib.py
@@ -18,6 +18,7 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
 from matplotlib.text import Text
 from sphinx_gallery.scrapers import matplotlib_scraper
+from sphinx_gallery.utils import scale_image
 
 _DARK_FOREGROUND = mcolors.to_rgba("#e6e6e6")[:3]
 _DARK_BACKGROUND = mcolors.to_rgba("#202124")[:3]
@@ -157,6 +158,70 @@ def _save_dark_companions(
 def _mark_theme(rst: str, theme: str) -> str:
     """Wrap gallery markup in a container recognized by Furo's theme switcher."""
     return f"\n.. container:: only-{theme}\n\n{indent(rst, '   ')}"
+
+
+def _theme_thumbnail_markup(light_path: str, dark_path: str) -> str:
+    """Return theme-aware markup for one gallery thumbnail."""
+    return f""".. only:: html
+
+  .. container:: only-light
+
+    .. image:: /{light_path}
+      :alt:
+
+  .. container:: only-dark
+
+    .. image:: /{dark_path}
+      :alt:"""
+
+
+def _prepare_dark_gallery_thumbnails(
+    gallery_dir: Path, thumbnail_size: tuple[int, int]
+) -> None:
+    """Create dark gallery thumbnails and add theme-aware index markup."""
+    index_path = gallery_dir / "index.rst"
+    image_dir = gallery_dir / "images"
+    thumbnail_dir = image_dir / "thumb"
+    if not index_path.exists() or not thumbnail_dir.exists():
+        return
+
+    content = index_path.read_text(encoding="utf-8")
+    for light_thumbnail in thumbnail_dir.glob("sphx_glr_*_thumb.png"):
+        example_name = light_thumbnail.stem.removeprefix("sphx_glr_").removesuffix(
+            "_thumb"
+        )
+        dark_source = image_dir / f"sphx_glr_{example_name}_001_dark.png"
+        if not dark_source.exists():
+            continue
+
+        dark_thumbnail = _dark_path(light_thumbnail)
+        scale_image(
+            str(dark_source),
+            str(dark_thumbnail),
+            *thumbnail_size,
+        )
+
+        light_relative = light_thumbnail.relative_to(gallery_dir.parent).as_posix()
+        dark_relative = dark_thumbnail.relative_to(gallery_dir.parent).as_posix()
+        light_markup = f""".. only:: html
+
+  .. image:: /{light_relative}
+    :alt:"""
+        content = content.replace(
+            light_markup,
+            _theme_thumbnail_markup(light_relative, dark_relative),
+        )
+
+    index_path.write_text(content, encoding="utf-8")
+
+
+def prepare_dark_gallery_thumbnails(app, env, docnames) -> None:
+    """Prepare theme-aware thumbnails after Sphinx-Gallery generates sources."""
+    del env, docnames
+
+    gallery_dir = Path(app.srcdir) / "examples"
+    thumbnail_size = tuple(app.config.sphinx_gallery_conf["thumbnail_size"])
+    _prepare_dark_gallery_thumbnails(gallery_dir, thumbnail_size)
 
 
 def theme_aware_matplotlib_scraper(block, block_vars, gallery_conf) -> str:

--- a/docs/_ext/theme_aware_matplotlib.py
+++ b/docs/_ext/theme_aware_matplotlib.py
@@ -12,6 +12,7 @@ import matplotlib as mpl
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
+from docutils import nodes
 from matplotlib.collections import Collection
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
@@ -160,32 +161,15 @@ def _mark_theme(rst: str, theme: str) -> str:
     return f"\n.. container:: only-{theme}\n\n{indent(rst, '   ')}"
 
 
-def _theme_thumbnail_markup(light_path: str, dark_path: str) -> str:
-    """Return theme-aware markup for one gallery thumbnail."""
-    return f""".. only:: html
-
-  .. container:: only-light
-
-    .. image:: /{light_path}
-      :alt:
-
-  .. container:: only-dark
-
-    .. image:: /{dark_path}
-      :alt:"""
-
-
 def _prepare_dark_gallery_thumbnails(
     gallery_dir: Path, thumbnail_size: tuple[int, int]
 ) -> None:
-    """Create dark gallery thumbnails and add theme-aware index markup."""
-    index_path = gallery_dir / "index.rst"
+    """Create dark companions for generated gallery thumbnails."""
     image_dir = gallery_dir / "images"
     thumbnail_dir = image_dir / "thumb"
-    if not index_path.exists() or not thumbnail_dir.exists():
+    if not thumbnail_dir.exists():
         return
 
-    content = index_path.read_text(encoding="utf-8")
     for light_thumbnail in thumbnail_dir.glob("sphx_glr_*_thumb.png"):
         example_name = light_thumbnail.stem.removeprefix("sphx_glr_").removesuffix(
             "_thumb"
@@ -201,27 +185,38 @@ def _prepare_dark_gallery_thumbnails(
             *thumbnail_size,
         )
 
-        light_relative = light_thumbnail.relative_to(gallery_dir.parent).as_posix()
-        dark_relative = dark_thumbnail.relative_to(gallery_dir.parent).as_posix()
-        light_markup = f""".. only:: html
-
-  .. image:: /{light_relative}
-    :alt:"""
-        content = content.replace(
-            light_markup,
-            _theme_thumbnail_markup(light_relative, dark_relative),
-        )
-
-    index_path.write_text(content, encoding="utf-8")
-
 
 def prepare_dark_gallery_thumbnails(app, env, docnames) -> None:
-    """Prepare theme-aware thumbnails after Sphinx-Gallery generates sources."""
+    """Prepare dark thumbnails after Sphinx-Gallery generates sources."""
     del env, docnames
 
     gallery_dir = Path(app.srcdir) / "examples"
     thumbnail_size = tuple(app.config.sphinx_gallery_conf["thumbnail_size"])
     _prepare_dark_gallery_thumbnails(gallery_dir, thumbnail_size)
+
+
+def theme_gallery_thumbnail_nodes(app, doctree) -> None:
+    """Add theme-aware variants to gallery and API minigallery thumbnails."""
+    for image in list(doctree.findall(nodes.image)):
+        light_uri = Path(image["uri"])
+        if not (
+            light_uri.name.startswith("sphx_glr_")
+            and light_uri.name.endswith("_thumb.png")
+        ):
+            continue
+
+        dark_uri = _dark_path(light_uri)
+        dark_source = Path(app.srcdir) / str(dark_uri).lstrip("/")
+        if not dark_source.exists():
+            continue
+
+        light_container = nodes.container(classes=["only-light"])
+        light_container += image.deepcopy()
+        dark_image = image.deepcopy()
+        dark_image["uri"] = dark_uri.as_posix()
+        dark_container = nodes.container(classes=["only-dark"])
+        dark_container += dark_image
+        image.replace_self([light_container, dark_container])
 
 
 def theme_aware_matplotlib_scraper(block, block_vars, gallery_conf) -> str:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,10 @@ sys.path.insert(0, str(_conf_dir / "_ext"))
 
 import cnsplots as cns  # noqa: E402
 from gallery_order import GALLERY_CATEGORIES  # noqa: E402
-from theme_aware_matplotlib import prepare_dark_gallery_thumbnails  # noqa: E402
+from theme_aware_matplotlib import (  # noqa: E402
+    prepare_dark_gallery_thumbnails,
+    theme_gallery_thumbnail_nodes,
+)
 
 # -- Project information -----------------------------------------------------
 
@@ -632,6 +635,7 @@ def setup(app):
     )
     app.connect("env-before-read-docs", prepare_dark_gallery_thumbnails, priority=490)
     app.connect("env-before-read-docs", _regroup_flat_gallery_index)
+    app.connect("doctree-read", theme_gallery_thumbnail_nodes, priority=490)
     app.connect("config-inited", _configure_active_docs_build, priority=800)
     app.connect("html-page-context", _override_source_links)
     app.connect("html-page-context", _inject_page_seo)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(_conf_dir / "_ext"))
 import cnsplots as cns  # noqa: E402
 from gallery_order import GALLERY_CATEGORIES  # noqa: E402
 from theme_aware_matplotlib import (  # noqa: E402
+    fallback_linkcheck_showcase_images,
     prepare_dark_gallery_thumbnails,
     theme_gallery_thumbnail_nodes,
 )
@@ -635,6 +636,7 @@ def setup(app):
     )
     app.connect("env-before-read-docs", prepare_dark_gallery_thumbnails, priority=490)
     app.connect("env-before-read-docs", _regroup_flat_gallery_index)
+    app.connect("doctree-read", fallback_linkcheck_showcase_images, priority=480)
     app.connect("doctree-read", theme_gallery_thumbnail_nodes, priority=490)
     app.connect("config-inited", _configure_active_docs_build, priority=800)
     app.connect("html-page-context", _override_source_links)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(_conf_dir / "_ext"))
 
 import cnsplots as cns  # noqa: E402
 from gallery_order import GALLERY_CATEGORIES  # noqa: E402
+from theme_aware_matplotlib import prepare_dark_gallery_thumbnails  # noqa: E402
 
 # -- Project information -----------------------------------------------------
 
@@ -629,6 +630,7 @@ def setup(app):
     os.environ["CNSPLOTS_GALLERY_OUTPUT_DIR"] = str(
         Path(app.doctreedir) / "gallery-exports"
     )
+    app.connect("env-before-read-docs", prepare_dark_gallery_thumbnails, priority=490)
     app.connect("env-before-read-docs", _regroup_flat_gallery_index)
     app.connect("config-inited", _configure_active_docs_build, priority=800)
     app.connect("html-page-context", _override_source_links)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,7 @@ sphinx_gallery_conf = {
     "within_subsection_order": "gallery_order.GalleryExampleOrder",
     "backreferences_dir": "gen_modules/backreferences",  # Where to store backreferences
     "doc_module": ("cnsplots",),  # The module containing your functions
+    "image_scrapers": ("theme_aware_matplotlib.theme_aware_matplotlib_scraper",),
     "reference_url": {
         "cnsplots": None,  # Module to create cross-references for
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,21 @@
 
 cnsplots is a Python visualization library built on matplotlib and fully compatible with seaborn. It creates figures that meet the high standards of top-tier scientific publications while keeping the API simple and intuitive.
 
-```{image} _static/images/overview.png
+::::{container} only-light
+:::{image} examples/images/sphx_glr_showcase_001.png
 :alt: Overview of cnsplots visualizations
 :align: center
 :target: examples/showcase.html#figure-1
-```
+:::
+::::
+
+::::{container} only-dark
+:::{image} examples/images/sphx_glr_showcase_001_dark.png
+:alt: Overview of cnsplots visualizations
+:align: center
+:target: examples/showcase.html#figure-1
+:::
+::::
 
 ## Key Features
 

--- a/tests/test_docs_theme_images.py
+++ b/tests/test_docs_theme_images.py
@@ -1,0 +1,96 @@
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sphinx_gallery.scrapers import ImagePathIterator
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "docs" / "_ext"))
+
+from theme_aware_matplotlib import (  # noqa: E402  # ty: ignore[unresolved-import]
+    _dark_figure,
+    _dark_path,
+    _mark_theme,
+    theme_aware_matplotlib_scraper,
+)
+
+
+def test_dark_figure_changes_only_neutral_foreground():
+    fig, ax = plt.subplots()
+    black_line = ax.plot([0, 1], color="black")[0]
+    color_line = ax.plot([1, 0], color="#d62728")[0]
+    ax.set_title("Example")
+    image = ax.imshow(np.array([[[0.0, 0.2, 0.8]]]))
+
+    title_color = ax.title.get_color()
+    black_line_color = black_line.get_color()
+    canvas_color = ax.patch.get_facecolor()
+    image_array = image.get_array()
+    assert image_array is not None
+    image_data = image_array.copy()
+
+    with _dark_figure(fig):
+        assert ax.title.get_color() != title_color
+        assert black_line.get_color() != black_line_color
+        assert color_line.get_color() == "#d62728"
+        assert ax.patch.get_facecolor() == canvas_color
+        np.testing.assert_array_equal(image.get_array(), image_data)
+
+    assert ax.title.get_color() == title_color
+    assert black_line.get_color() == black_line_color
+    assert color_line.get_color() == "#d62728"
+    assert ax.patch.get_facecolor() == canvas_color
+
+
+def test_dark_path_preserves_srcset_suffix():
+    light_path = Path("sphx_glr_example_001_2_00x.png")
+
+    assert _dark_path(light_path) == Path("sphx_glr_example_001_2_00x_dark.png")
+
+
+def test_mark_theme_wraps_single_images_and_horizontal_lists():
+    single_image = ":class: sphx-glr-single-img\n"
+    horizontal_list = ".. rst-class:: sphx-glr-horizontal\n"
+
+    assert _mark_theme(single_image, "dark") == (
+        "\n.. container:: only-dark\n\n   :class: sphx-glr-single-img\n"
+    )
+    assert _mark_theme(horizontal_list, "light") == (
+        "\n.. container:: only-light\n\n   .. rst-class:: sphx-glr-horizontal\n"
+    )
+
+
+def test_scraper_generates_theme_specific_images_and_markup(tmp_path):
+    plt.figure()
+    plt.plot([0, 1], color="black")
+    plt.title("Theme test")
+    image_paths = ImagePathIterator(str(tmp_path / "sphx_glr_test_{0:03}.png"))
+
+    rst = theme_aware_matplotlib_scraper(
+        None,
+        {
+            "image_path_iterator": image_paths,
+            "example_globals": {},
+            "multi_image": None,
+            "file_conf": {},
+        },
+        {
+            "image_srcset": [2.0],
+            "matplotlib_animations": (False, None),
+            "compress_images": (),
+            "compress_images_args": (),
+            "src_dir": str(tmp_path),
+        },
+    )
+
+    expected_images = {
+        "sphx_glr_test_001.png",
+        "sphx_glr_test_001_2_00x.png",
+        "sphx_glr_test_001_dark.png",
+        "sphx_glr_test_001_2_00x_dark.png",
+    }
+    assert {path.name for path in tmp_path.glob("*.png")} == expected_images
+    assert ".. container:: only-light" in rst
+    assert ".. container:: only-dark" in rst
+    assert "/sphx_glr_test_001_dark.png" in rst
+    assert "/sphx_glr_test_001_2_00x_dark.png 2.00x" in rst

--- a/tests/test_docs_theme_images.py
+++ b/tests/test_docs_theme_images.py
@@ -11,6 +11,7 @@ from theme_aware_matplotlib import (  # noqa: E402  # ty: ignore[unresolved-impo
     _dark_figure,
     _dark_path,
     _mark_theme,
+    _prepare_dark_gallery_thumbnails,
     theme_aware_matplotlib_scraper,
 )
 
@@ -94,3 +95,37 @@ def test_scraper_generates_theme_specific_images_and_markup(tmp_path):
     assert ".. container:: only-dark" in rst
     assert "/sphx_glr_test_001_dark.png" in rst
     assert "/sphx_glr_test_001_2_00x_dark.png 2.00x" in rst
+
+
+def test_prepare_dark_gallery_thumbnails(tmp_path):
+    gallery_dir = tmp_path / "examples"
+    image_dir = gallery_dir / "images"
+    thumbnail_dir = image_dir / "thumb"
+    thumbnail_dir.mkdir(parents=True)
+
+    light_thumbnail = thumbnail_dir / "sphx_glr_test_thumb.png"
+    dark_source = image_dir / "sphx_glr_test_001_dark.png"
+    plt.imsave(light_thumbnail, np.ones((10, 10, 3)))
+    plt.imsave(dark_source, np.zeros((20, 20, 3)))
+
+    index_path = gallery_dir / "index.rst"
+    index_path.write_text(
+        """.. only:: html
+
+  .. image:: /examples/images/thumb/sphx_glr_test_thumb.png
+    :alt:
+
+  :doc:`/examples/test`
+""",
+        encoding="utf-8",
+    )
+
+    _prepare_dark_gallery_thumbnails(gallery_dir, (40, 28))
+
+    dark_thumbnail = thumbnail_dir / "sphx_glr_test_thumb_dark.png"
+    content = index_path.read_text(encoding="utf-8")
+    assert dark_thumbnail.exists()
+    assert ".. container:: only-light" in content
+    assert ".. container:: only-dark" in content
+    assert "/examples/images/thumb/sphx_glr_test_thumb_dark.png" in content
+    assert ":doc:`/examples/test`" in content

--- a/tests/test_docs_theme_images.py
+++ b/tests/test_docs_theme_images.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+from docutils import nodes
 from sphinx_gallery.scrapers import ImagePathIterator
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "docs" / "_ext"))
@@ -12,6 +13,7 @@ from theme_aware_matplotlib import (  # noqa: E402  # ty: ignore[unresolved-impo
     _dark_path,
     _mark_theme,
     _prepare_dark_gallery_thumbnails,
+    theme_gallery_thumbnail_nodes,
     theme_aware_matplotlib_scraper,
 )
 
@@ -108,24 +110,25 @@ def test_prepare_dark_gallery_thumbnails(tmp_path):
     plt.imsave(light_thumbnail, np.ones((10, 10, 3)))
     plt.imsave(dark_source, np.zeros((20, 20, 3)))
 
-    index_path = gallery_dir / "index.rst"
-    index_path.write_text(
-        """.. only:: html
-
-  .. image:: /examples/images/thumb/sphx_glr_test_thumb.png
-    :alt:
-
-  :doc:`/examples/test`
-""",
-        encoding="utf-8",
-    )
-
     _prepare_dark_gallery_thumbnails(gallery_dir, (40, 28))
 
     dark_thumbnail = thumbnail_dir / "sphx_glr_test_thumb_dark.png"
-    content = index_path.read_text(encoding="utf-8")
     assert dark_thumbnail.exists()
-    assert ".. container:: only-light" in content
-    assert ".. container:: only-dark" in content
-    assert "/examples/images/thumb/sphx_glr_test_thumb_dark.png" in content
-    assert ":doc:`/examples/test`" in content
+
+
+def test_theme_gallery_thumbnail_nodes(tmp_path):
+    thumbnail_dir = tmp_path / "examples" / "images" / "thumb"
+    thumbnail_dir.mkdir(parents=True)
+    (thumbnail_dir / "sphx_glr_test_thumb_dark.png").touch()
+
+    doctree = nodes.container()
+    doctree += nodes.image(uri="/examples/images/thumb/sphx_glr_test_thumb.png", alt="")
+    app = type("App", (), {"srcdir": str(tmp_path)})()
+
+    theme_gallery_thumbnail_nodes(app, doctree)
+
+    light_container, dark_container = doctree.children
+    assert light_container["classes"] == ["only-light"]
+    assert dark_container["classes"] == ["only-dark"]
+    assert light_container[0]["uri"].endswith("sphx_glr_test_thumb.png")
+    assert dark_container[0]["uri"].endswith("sphx_glr_test_thumb_dark.png")

--- a/tests/test_docs_theme_images.py
+++ b/tests/test_docs_theme_images.py
@@ -13,6 +13,7 @@ from theme_aware_matplotlib import (  # noqa: E402  # ty: ignore[unresolved-impo
     _dark_path,
     _mark_theme,
     _prepare_dark_gallery_thumbnails,
+    fallback_linkcheck_showcase_images,
     theme_gallery_thumbnail_nodes,
     theme_aware_matplotlib_scraper,
 )
@@ -132,3 +133,30 @@ def test_theme_gallery_thumbnail_nodes(tmp_path):
     assert dark_container["classes"] == ["only-dark"]
     assert light_container[0]["uri"].endswith("sphx_glr_test_thumb.png")
     assert dark_container[0]["uri"].endswith("sphx_glr_test_thumb_dark.png")
+
+
+def test_linkcheck_uses_static_showcase_fallback():
+    light_uri = "examples/images/sphx_glr_showcase_001.png"
+    dark_uri = "examples/images/sphx_glr_showcase_001_dark.png"
+    doctree = nodes.container()
+    doctree += nodes.image(uri=light_uri)
+    doctree += nodes.image(uri=dark_uri)
+
+    linkcheck_app = type(
+        "App",
+        (),
+        {"builder": type("Builder", (), {"name": "linkcheck"})()},
+    )()
+    fallback_linkcheck_showcase_images(linkcheck_app, doctree)
+
+    assert [image["uri"] for image in doctree.findall(nodes.image)] == [
+        "_static/images/overview.png",
+        "_static/images/overview.png",
+    ]
+
+    html_doctree = nodes.container()
+    html_doctree += nodes.image(uri=light_uri)
+    html_app = type("App", (), {"builder": type("Builder", (), {"name": "html"})()})()
+    fallback_linkcheck_showcase_images(html_app, html_doctree)
+
+    assert html_doctree[0]["uri"] == light_uri


### PR DESCRIPTION
## What changed

- Generate transparent light and dark variants for Sphinx-Gallery Matplotlib figures.
- Generate matching dark variants for example-gallery thumbnails.
- Select the appropriate figure and thumbnail assets through Furo theme-aware containers.
- Apply the thumbnail switch to both the gallery index and API-page minigalleries.
- Replace the homepage overview image with theme-aware Showcase Figure 1 assets.
- Use the existing static overview only inside linkcheck builds where gallery execution is disabled.
- Preserve plot data colors and embedded raster images while adapting neutral foreground elements.
- Add regression coverage for recoloring, asset generation, high-DPI variants, thumbnails, doctree rendering, and linkcheck fallback behavior.

## Why

Transparent gallery PNGs retained black text, axes, and outlines, making plots and thumbnails unreadable against the documentation dark background. API minigalleries render independently from the gallery index and therefore also need theme-aware thumbnail nodes. Linkcheck deliberately skips gallery execution, so it needs a validation-only fallback for the generated homepage images.

## Impact

Example plots, gallery thumbnails, API example cards, and the homepage showcase remain transparent and readable in both themes. README and normal HTML image paths are unchanged by the linkcheck-only fallback.

## Testing

- `make test` — 379 passed with 100% coverage.
- `make lint` — all hooks passed.
- `make doc-linkcheck` — passed with gallery execution disabled.
- Focused Sphinx HTML builds for `stackplot.py`, `showcase.py`, and the `boxplot.py` API minigallery passed with warnings treated as errors.
- Verified generated example-page, gallery-index, API-minigallery, and homepage theme selection in light and dark modes.

## Risks and follow-ups

Documentation builds now emit a second PNG for each Matplotlib gallery figure and a derived dark thumbnail, increasing generated documentation asset size. Package runtime behavior and README rendering are unchanged.