### PR TITLE
📝 Require PR body purpose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Clients must switch to the new export path before upgrading.
 - Use the same Gitmoji selection and tie-break rules as commit subjects.
 - Use the same `<emoji> <subject>` format as commit subjects.
 - PR body must include:
+  - the goal or purpose
   - what changed
   - how it was tested
   - any risks or follow-ups


### PR DESCRIPTION
## Goal / purpose

Ensure contributor instructions require every pull request description to explain why the change is needed.

## What changed

- Added the goal or purpose to the required PR body contents in `AGENTS.md`.

## How it was tested

- `make test` — 379 tests passed with 100% coverage.
- `make lint` — all pre-commit hooks passed.

## Risks or follow-ups

None. This is a documentation-only policy update.