### PR TITLE
💄 Add scrollable docs version menu

### DIFF
--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -955,90 +955,32 @@ article table.align-default {
 }
 
 .docs-version-switcher {
+  position: relative;
   margin: 1rem 0;
-  padding: 0.95rem 1rem 1rem;
+}
+
+.docs-version-switcher-summary {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.75rem 0.85rem;
   border: 1px solid var(--color-background-border);
   border-radius: 0.5rem;
-}
-
-.docs-version-switcher-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-bottom: 0.8rem;
-}
-
-.docs-version-switcher-title,
-.docs-version-switcher-select-label {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.docs-version-switcher-current {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.2rem 0.55rem;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--color-brand-primary) 24%,
-      var(--color-background-border)
-    );
-  border-radius: 999px;
-  background: color-mix(
-    in srgb,
-    var(--color-brand-primary) 9%,
-    var(--color-background-primary)
-  );
-  color: var(--color-foreground-secondary);
-  font-family: var(--font-stack--monospace);
-  font-size: 0.82rem;
-}
-
-.docs-version-switcher-field {
-  display: grid;
-  gap: 0.45rem;
-}
-
-.docs-version-switcher-select-label {
-  color: var(--color-foreground-secondary);
-}
-
-.docs-version-switcher-select-wrap {
-  position: relative;
-}
-
-.docs-version-switcher-select {
-  width: 100%;
-  padding: 0.82rem 2.8rem 0.82rem 0.95rem;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--color-brand-primary) 18%,
-      var(--color-background-border)
-    );
-  border-radius: 0.8rem;
-  background: color-mix(
-    in srgb,
-    var(--color-brand-primary) 3%,
-    var(--color-background-primary)
-  );
-  color: var(--color-foreground-primary);
-  font-family: var(--font-stack--monospace);
-  font-size: 0.95rem;
-  font-weight: 500;
-  appearance: none;
   cursor: pointer;
+  list-style: none;
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease,
     background-color 0.15s ease;
 }
 
-.docs-version-switcher-select:hover {
+.docs-version-switcher-summary::-webkit-details-marker {
+  display: none;
+}
+
+.docs-version-switcher-summary:hover,
+.docs-version-switcher[open] .docs-version-switcher-summary {
   border-color: color-mix(
     in srgb,
     var(--color-brand-primary) 48%,
@@ -1046,36 +988,113 @@ article table.align-default {
   );
   background: color-mix(
     in srgb,
-    var(--color-brand-primary) 6%,
+    var(--color-brand-primary) 5%,
     var(--color-background-primary)
   );
 }
 
-.docs-version-switcher-select:focus {
+.docs-version-switcher-summary:focus-visible {
   outline: none;
   border-color: var(--color-brand-primary);
   box-shadow: 0 0 0 4px
     color-mix(in srgb, var(--color-brand-primary) 18%, transparent);
 }
 
-.docs-version-switcher-select optgroup {
+.docs-version-switcher-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.docs-version-switcher-current {
   color: var(--color-foreground-secondary);
-  font-style: normal;
+  font-family: var(--font-stack--monospace);
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-align: right;
+}
+
+.docs-version-switcher-list {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  left: 0;
+  max-height: 10rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding: 0.4rem;
+  border: 1px solid var(--color-background-border);
+  border-radius: 0.5rem;
+  background: var(--color-background-primary);
+  box-shadow:
+    0 0.25rem 0.75rem rgb(0 0 0 / 18%),
+    0 0 0.1rem rgb(0 0 0 / 18%);
+}
+
+.docs-version-switcher-group + .docs-version-switcher-group {
+  margin-top: 0.35rem;
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--color-background-border);
+}
+
+.docs-version-switcher-group-title {
+  display: block;
+  padding: 0.15rem 0.55rem 0.25rem;
+  color: var(--color-foreground-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.docs-version-switcher-options {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.docs-version-switcher-link {
+  display: block;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.3rem;
+  color: var(--color-foreground-primary);
+  font-family: var(--font-stack--monospace);
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.docs-version-switcher-link:hover,
+.docs-version-switcher-link:focus-visible {
+  outline: none;
+  background: color-mix(
+    in srgb,
+    var(--color-brand-primary) 10%,
+    var(--color-background-primary)
+  );
+  color: var(--color-brand-primary);
+}
+
+.docs-version-switcher-link.is-active {
+  background: color-mix(
+    in srgb,
+    var(--color-brand-primary) 14%,
+    var(--color-background-primary)
+  );
+  color: var(--color-brand-primary);
   font-weight: 700;
 }
 
-.docs-version-switcher-select option {
-  color: var(--color-foreground-primary);
-}
-
 .docs-version-switcher-chevron {
-  position: absolute;
-  top: 50%;
-  right: 1rem;
-  width: 0.7rem;
-  height: 0.7rem;
+  width: 0.55rem;
+  height: 0.55rem;
   border-right: 2px solid var(--color-foreground-secondary);
   border-bottom: 2px solid var(--color-foreground-secondary);
-  pointer-events: none;
-  transform: translateY(-65%) rotate(45deg);
+  transform: translateY(-0.15rem) rotate(45deg);
+  transition: transform 0.15s ease;
+}
+
+.docs-version-switcher[open] .docs-version-switcher-chevron {
+  transform: translateY(0.15rem) rotate(225deg);
 }

--- a/docs/_static/js/repo-stats.js
+++ b/docs/_static/js/repo-stats.js
@@ -219,7 +219,7 @@
     return `${location.rootPath}/${latestDocsName}/`;
   }
 
-  function appendVersionGroup(select, label, entries, location) {
+  function appendSelectVersionGroup(select, label, entries, location) {
     if (!entries.length) {
       return;
     }
@@ -236,9 +236,41 @@
     select.appendChild(group);
   }
 
+  function appendVersionGroup(container, label, entries, location) {
+    if (!entries.length) {
+      return;
+    }
+
+    const group = document.createElement("div");
+    group.className = "docs-version-switcher-group";
+
+    const title = document.createElement("span");
+    title.className = "docs-version-switcher-group-title";
+    title.textContent = label;
+
+    const options = document.createElement("ul");
+    options.className = "docs-version-switcher-options";
+    entries.forEach(function (entry) {
+      const item = document.createElement("li");
+      const link = document.createElement("a");
+      link.className = "docs-version-switcher-link";
+      link.href = versionUrl(location, entry.version);
+      link.textContent = entry.title;
+      if (location.canonicalVersion === entry.version) {
+        link.classList.add("is-active");
+        link.setAttribute("aria-current", "page");
+      }
+      item.appendChild(link);
+      options.appendChild(item);
+    });
+    group.append(title, options);
+    container.appendChild(group);
+  }
+
   function updateVersionSwitcher(entries, location) {
+    const list = document.querySelector("#docs-version-switcher-list");
     const select = document.querySelector("#docs-version-switcher-select");
-    if (!select) {
+    if (!list && !select) {
       return;
     }
 
@@ -249,14 +281,27 @@
       return releaseVersionPattern.test(entry.version);
     });
 
-    select.textContent = "";
-    appendVersionGroup(select, "Development", developmentVersions, location);
-    appendVersionGroup(select, "Releases", releaseVersions, location);
-    select.onchange = function () {
-      if (this.value) {
-        window.location.assign(this.value);
-      }
-    };
+    if (list) {
+      list.textContent = "";
+      appendVersionGroup(list, "Development", developmentVersions, location);
+      appendVersionGroup(list, "Releases", releaseVersions, location);
+    }
+
+    if (select) {
+      select.textContent = "";
+      appendSelectVersionGroup(
+        select,
+        "Development",
+        developmentVersions,
+        location,
+      );
+      appendSelectVersionGroup(select, "Releases", releaseVersions, location);
+      select.onchange = function () {
+        if (this.value) {
+          window.location.assign(this.value);
+        }
+      };
+    }
 
     const currentLabel = document.querySelector(".docs-version-switcher-current");
     if (!currentLabel) {
@@ -347,7 +392,8 @@
 
   async function initDocsVersionNavigation() {
     if (
-      !document.querySelector("#docs-version-switcher-select")
+      !document.querySelector("#docs-version-switcher-list")
+      && !document.querySelector("#docs-version-switcher-select")
       && !document.querySelector(".docs-version-banner")
     ) {
       return;

--- a/docs/_templates/components/version-switcher.html
+++ b/docs/_templates/components/version-switcher.html
@@ -1,50 +1,49 @@
 {% if docs_release_versions or docs_development_version %}
-<div class="docs-version-switcher" aria-label="Documentation versions">
-  <div class="docs-version-switcher-header">
-    <span class="docs-version-switcher-title">Versions</span>
-    {% if docs_current_version_label %}
+<details class="docs-version-switcher">
+  <summary class="docs-version-switcher-summary">
+    <span class="docs-version-switcher-title">Version</span>
     <span class="docs-version-switcher-current"
       >{{ docs_current_version_label }}</span
     >
+    <span class="docs-version-switcher-chevron" aria-hidden="true"></span>
+  </summary>
+
+  <div id="docs-version-switcher-list" class="docs-version-switcher-list">
+    {% if docs_development_version %}
+    <div class="docs-version-switcher-group">
+      <span class="docs-version-switcher-group-title">Development</span>
+      <ul class="docs-version-switcher-options">
+        <li>
+          <a
+            class="docs-version-switcher-link{% if docs_current_version_name == docs_development_version.name %} is-active{% endif %}"
+            href="{{ docs_development_version.url }}"
+            {% if docs_current_version_name == docs_development_version.name %}
+            aria-current="page"
+            {% endif %}
+            >dev</a
+          >
+        </li>
+      </ul>
+    </div>
+    {% endif %} {% if docs_release_versions %}
+    <div class="docs-version-switcher-group">
+      <span class="docs-version-switcher-group-title">Releases</span>
+      <ul class="docs-version-switcher-options">
+        {% for item in docs_release_versions %}
+        <li>
+          <a
+            class="docs-version-switcher-link{% if docs_current_version_name == item.name %} is-active{% endif %}"
+            href="{{ item.url }}"
+            {% if docs_current_version_name == item.name %}
+            aria-current="page"
+            {% endif %}
+            >{{ item.name }}</a
+          >
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
     {% endif %}
   </div>
-
-  <div class="docs-version-switcher-field">
-    <div class="docs-version-switcher-select-wrap">
-      <select
-        id="docs-version-switcher-select"
-        class="docs-version-switcher-select"
-        aria-label="Select documentation version"
-        onchange="if (this.value) window.location.assign(this.value);"
-      >
-        {% if docs_development_version %}
-        <optgroup label="Development">
-          <option
-            value="{{ docs_development_version.url }}"
-            {% if current_version and current_version.name == docs_development_version.name %}
-            selected
-            {% endif %}
-          >
-            dev
-          </option>
-        </optgroup>
-        {% endif %} {% if docs_release_versions %}
-        <optgroup label="Releases">
-          {% for item in docs_release_versions %}
-          <option
-            value="{{ item.url }}"
-            {% if current_version and current_version.name == item.name %}
-            selected
-            {% endif %}
-          >
-            {{ item.name }}
-          </option>
-          {% endfor %}
-        </optgroup>
-        {% endif %}
-      </select>
-      <span class="docs-version-switcher-chevron" aria-hidden="true"></span>
-    </div>
-  </div>
-</div>
+</details>
 {% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -559,17 +559,37 @@ def _inject_version_navigation(
     app, pagename: str, templatename, context: dict[str, Any], doctree
 ):
     """Add ordered version-switcher and banner context for multiversion builds."""
-    del app, pagename, templatename, doctree
+    del app, templatename, doctree
 
     current_version = context.get("current_version")
     latest_version = context.get("latest_version")
     versions = context.get("versions")
 
     if current_version is None or latest_version is None or versions is None:
-        context["docs_release_versions"] = []
-        context["docs_development_version"] = None
+        page_suffix = "" if pagename == "index" else f"{pagename}.html"
+        page_suffix = f"/{page_suffix}" if page_suffix else "/"
+        try:
+            release_names = git(
+                "tag", "--list", "v*", "--sort=-version:refname"
+            ).splitlines()
+        except Exception:  # noqa: B902
+            release_names = []
+
+        context["docs_release_versions"] = [
+            {
+                "name": name,
+                "url": f"{_published_site_baseurl(name)}{page_suffix}",
+            }
+            for name in release_names
+            if _parse_release_name(name) != (-1, -1, -1)
+        ]
+        context["docs_development_version"] = {
+            "name": dev_docs_name,
+            "url": f"{_published_site_baseurl(dev_docs_name)}{page_suffix}",
+        }
         context["docs_version_banner"] = None
-        context["docs_current_version_label"] = None
+        context["docs_current_version_label"] = "dev (main)"
+        context["docs_current_version_name"] = dev_docs_name
         return
 
     release_versions = sorted(
@@ -584,6 +604,7 @@ def _inject_version_navigation(
 
     context["docs_release_versions"] = release_versions
     context["docs_development_version"] = development_version
+    context["docs_current_version_name"] = current_version.name
     context["docs_current_version_label"] = (
         "dev (main)" if current_version.name == dev_docs_name else current_version.name
     )


### PR DESCRIPTION
## Purpose

Make the documentation version switcher compact and usable as the release list grows.

## What changed

- Replaced the crowded native select card with a compact disclosure menu in the right sidebar.
- Added a capped, scrollable version list with grouped development and release links.
- Highlighted the current version and kept title labels in capital form.
- Added local-build version fallbacks while preserving the legacy select behavior on older published pages.

## Testing

- `make test` — 379 tests passed with 100% coverage.
- `make lint` — all checks passed.
- `make -C docs html` — documentation build succeeded.
- Verified the right-sidebar placement and scroll behavior in a local browser.

## Risks and follow-ups

Risk is limited to documentation navigation and styling. Local fallback links intentionally target the corresponding published documentation version because local builds contain only one version.
