### PR TITLE
✨ Control violin plot box colors

### DIFF
--- a/examples/violinplot.py
+++ b/examples/violinplot.py
@@ -78,14 +78,15 @@ mp.get_axes("B").set_title("width=0.9 (wide)")
 # %%
 # Grouped violin plot with hue
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``hue`` for side-by-side violins within each category.
+# Use ``hue`` for side-by-side violins within each category. Embedded boxes stay
+# white by default and can be colored independently with ``box_color``.
 cns.figure(180, 120)
 ax = cns.violinplot(
     data=tips,
     x="day",
     y="total_bill",
     hue="sex",
-    add_box=False,
+    box_color="white",
 )
 cns.take_legend_out()
 ax.set_title("Grouped Violin Plot")

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -12,6 +12,7 @@ import pandas as pd
 import scipy as sp
 import seaborn as sns
 from matplotlib.axes import Axes
+from matplotlib.typing import ColorType
 
 import cnsplots._utils as utils
 from cnsplots._utils import _legend_fontsize
@@ -200,6 +201,7 @@ def violinplot(
     add_box: bool = True,
     add_count: bool = False,
     *,
+    box_color: ColorType | None = "white",
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
@@ -229,6 +231,9 @@ def violinplot(
         Whether to overlay a narrow box plot inside each violin.
     add_count : bool, default: False
         Whether to add sample size (n) labels above each violin.
+    box_color : matplotlib color or None, default: "white"
+        Color of the embedded box plots. Set to ``None`` to color boxes according
+        to *hue*.
     hue : str, optional
         Column name for grouping violins within each category.
     order : list of str, optional
@@ -275,12 +280,16 @@ def violinplot(
             "use 'add_count' instead"
         )
 
+    boxprops: dict[str, Any] = {"edgecolor": "black", "zorder": 2}
+    if box_color is not None:
+        boxprops["facecolor"] = box_color
+
     args = {
         "showfliers": False,
         "showcaps": False,
         "showbox": True,
         "linewidth": 0.4,
-        "boxprops": {"edgecolor": "black", "zorder": 2},
+        "boxprops": boxprops,
         "medianprops": {"color": "black", "linewidth": 0.8},
         "whiskerprops": {"color": "black"},
         "capprops": {"color": "none"},
@@ -292,7 +301,6 @@ def violinplot(
             "linewidth": 0,
         },
         "width": 0.2,
-        "color": "white",
     }
     plotting: dict[str, Any] = {
         "data": data,

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -89,6 +89,47 @@ def test_boxplot_and_violinplot(
     assert ax3 is plt.gca()
 
 
+@pytest.mark.parametrize(
+    ("box_kwargs", "expected_color"),
+    [({}, "white"), ({"box_color": "#d95f02"}, "#d95f02")],
+)
+def test_violinplot_box_color(
+    categorical_df: pd.DataFrame,
+    box_kwargs: dict[str, Any],
+    expected_color: str,
+) -> None:
+    cns.figure(120, 120)
+    ax = cns.violinplot(
+        categorical_df,
+        x="group",
+        y="value",
+        hue="hue",
+        inner=None,
+        **box_kwargs,
+    )
+
+    box_patches = [patch for patch in ax.patches if isinstance(patch, PathPatch)]
+    assert box_patches
+    assert {patch.get_facecolor() for patch in box_patches} == {to_rgba(expected_color)}
+
+
+def test_violinplot_box_color_none_follows_hue(
+    categorical_df: pd.DataFrame,
+) -> None:
+    cns.figure(120, 120)
+    ax = cns.violinplot(
+        categorical_df,
+        x="group",
+        y="value",
+        hue="hue",
+        inner=None,
+        box_color=None,
+    )
+
+    box_patches = [patch for patch in ax.patches if isinstance(patch, PathPatch)]
+    assert len({patch.get_facecolor() for patch in box_patches}) > 1
+
+
 def test_barplot_and_lollipopplot(
     categorical_df: pd.DataFrame,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Goal

Resolve #99 by making embedded violin box colors independent from violin hue colors.

## What changed

- Added the keyword-only box_color option to violinplot.
- Kept embedded boxes white by default while supporting custom Matplotlib colors.
- Allowed box_color=None to restore hue-driven box colors.
- Added regression coverage and updated the grouped violin example.

## Testing

- make test — 382 tests passed with 100% coverage.
- make lint — all checks passed.

## Risks and follow-ups

The change is additive, aside from correcting the existing hue-dependent default box color. Existing inner and add_box behavior remains unchanged. No follow-up work is required.

Closes #99