### PR TITLE
🐛 Preserve survival annotation font

### DIFF
--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -396,7 +396,7 @@ def survivalplot(
         annotation_lines.extend(
             [
                 f"HR = {hazard_ratio:.2f}",
-                f"95% CI {ci1:.2f}\N{EN DASH}{ci2:.2f}",
+                f"95% CI {ci1:.2f}-{ci2:.2f}",
                 "Cox P = " + rf"${pair_p:.2g}$",
             ]
         )

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -176,7 +176,7 @@ def test_survival_plots(
         [1, 5 / 6, 2 / 3, 2 / 3, 4 / 9, 4 / 9, 0],
     )
     assert ax.texts[0].get_text() == (
-        "Log-rank P = $0.6$\nHR = 0.68\n95% CI 0.15–3.06\nCox P = $0.62$"
+        "Log-rank P = $0.6$\nHR = 0.68\n95% CI 0.15-3.06\nCox P = $0.62$"
     )
     assert "omnibus log-rank test" in caplog.text
 

--- a/tests/test_survival_inference.py
+++ b/tests/test_survival_inference.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, cast
 
 import matplotlib.pyplot as plt
@@ -74,7 +75,7 @@ def test_survivalplot_trend_requires_complete_explicit_order(
             [
                 "High vs Low",
                 "HR = 0.38",
-                "95% CI 0.08–1.75",
+                "95% CI 0.08-1.75",
                 "Cox P = $0.21$",
             ],
         ),
@@ -83,7 +84,7 @@ def test_survivalplot_trend_requires_complete_explicit_order(
             [
                 "Low vs High",
                 "HR = 2.66",
-                "95% CI 0.57–12.43",
+                "95% CI 0.57-12.43",
                 "Cox P = $0.21$",
             ],
         ),
@@ -160,9 +161,23 @@ def test_survivalplot_uses_lower_left_default_location(
         "Log-rank P = $0.36$",
         "High vs Low",
         "HR = 0.38",
-        "95% CI 0.08–1.75",
+        "95% CI 0.08-1.75",
         "Cox P = $0.21$",
     ]
+
+
+def test_survivalplot_annotation_preserves_package_font_on_save(
+    survival_df: pd.DataFrame,
+    tmp_path: Path,
+) -> None:
+    with cns.settings.context(font_family="serif"):
+        cns.figure(120, 120)
+        ax = cns.survivalplot(survival_df, "time", "event", "group")
+        annotation = ax.texts[0]
+
+        cns.savefig(tmp_path / "survival.png")
+
+        assert annotation.get_fontfamily() == ["serif"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose

Keep the survival plot P-value, hazard ratio, confidence interval, and Cox annotations consistent with the configured package font when figures are saved.

## Changes

- Replace the non-ASCII CI range separator that triggered the save-time Unicode font fallback.
- Add regression coverage confirming the annotation retains the configured font family after `cns.savefig`.

## Testing

- `make test` — 383 passed with 100% coverage
- `make lint` — all checks passed

## Risks and follow-ups

- CI ranges now use an ASCII hyphen instead of an en dash.
- No follow-up work is required.