### PR TITLE
📝 Add theme-aware README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Create visually stunning, journal-quality figures with minimal code. Built on ma
 
 ## Overview
 
-[![Overview](https://raw.githubusercontent.com/faridrashidi/cnsplots/main/docs/_static/images/overview.png)](https://cnsplots.farid.one/latest/examples/showcase.html#figure-1)
+<a href="https://cnsplots.farid.one/latest/examples/showcase.html#figure-1">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cnsplots.farid.one/latest/_images/sphx_glr_showcase_001_dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://cnsplots.farid.one/latest/_images/sphx_glr_showcase_001.png">
+    <img src="https://cnsplots.farid.one/latest/_images/sphx_glr_showcase_001.png" alt="cnsplots overview">
+  </picture>
+</a>
 
 **cnsplots** is a Python visualization library designed specifically for creating publication-ready scientific figures. It takes care of the tedious styling details so you can focus on your science.
 


### PR DESCRIPTION
## Goal

Make the README overview render an appropriate showcase image in both dark and light color schemes. The previous README always displayed a single light-mode image.

## What changed

- Replace the static Markdown image with a linked HTML `picture` element.
- Select the hosted dark showcase for dark mode and the hosted light showcase for light mode and fallback rendering.
- Preserve the link to the full showcase example.

This keeps the overview readable without changing the documentation's existing social-preview asset.

## Testing

- `make test` — 383 tests passed with 100% coverage.
- `make lint` — all hooks passed.
- Verified both hosted image URLs return PNG responses.

## Risks and follow-ups

The README images depend on the hosted `latest` documentation URLs remaining stable. No follow-up is currently required.
