### PR TITLE
✨ Expand survivalplot analysis options

### DIFF
--- a/examples/survivalplot.py
+++ b/examples/survivalplot.py
@@ -40,6 +40,75 @@ plt.title("Kaplan-Meier Survival Curves")
 
 
 # %%
+# Confidence bands and median survival
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Combine pointwise confidence bands with median-survival guides. The annotation
+# reports a group's median as ``not reached`` when its curve never falls to 0.5.
+cns.figure(150, 160)
+ax = cns.survivalplot(
+    data=waltons,
+    duration="T",
+    event="E",
+    hue="group",
+    hue_order=["miR-137", "control"],
+    ci_show=True,
+    show_median_survival=True,
+    show_hazard_ratio=False,
+    pvalue_loc="upper right",
+)
+ax.set_xlabel("Time")
+_ = ax.legend(loc="lower left")
+plt.title("Confidence Bands and Median Survival")
+
+
+# %%
+# Landmark analysis with a risk table
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Mark 36 time units, report each group's survival probability there, and run
+# the two-group fixed-time comparison. The same ticks are used by the risk table.
+cns.figure(170, 170)
+ax = cns.survivalplot(
+    data=waltons,
+    duration="T",
+    event="E",
+    hue="group",
+    hue_order=["miR-137", "control"],
+    landmark_time=36,
+    show_risk_table=True,
+    risk_table_ypos=-0.25,
+    xticks=np.arange(0, 61, 12),
+    show_hazard_ratio=False,
+    pvalue_loc="upper right",
+)
+ax.set_xlabel("Time")
+_ = ax.legend(loc="lower left")
+plt.title("36-Unit Landmark with Risk Table")
+
+
+# %%
+# Landmark survival and RMST
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Use a shared horizon to compare survival probability at 48 time units and the
+# area under each survival curve through that time. A single dashed guide marks
+# the common landmark and RMST truncation time.
+cns.figure(150, 170)
+ax = cns.survivalplot(
+    data=waltons,
+    duration="T",
+    event="E",
+    hue="group",
+    hue_order=["miR-137", "control"],
+    landmark_time=48,
+    rmst_time=48,
+    show_hazard_ratio=False,
+    pvalue_loc="upper right",
+)
+ax.set_xlabel("Time")
+_ = ax.legend(loc="lower left")
+plt.title("48-Unit Survival and RMST")
+
+
+# %%
 # Survival plot with legend outside
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Move legend to avoid overlapping curves.

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -173,6 +173,14 @@ def survivalplot(
     hue_order: list[str] | None = None,
     time_label: str = "Time",
     *,
+    ci_show: bool = False,
+    show_risk_table: bool = False,
+    risk_table_rows: tuple[str, ...] | None = ("At risk",),
+    risk_table_ypos: float = -0.2,
+    xticks: np.ndarray | Sequence[int | float] | None = None,
+    show_median_survival: bool = False,
+    landmark_time: float | None = None,
+    rmst_time: float | None = None,
     overall_test: Literal["logrank", "trend"] = "logrank",
     pairs: list[tuple[str, str]] | None = None,
     show_hazard_ratio: bool = True,
@@ -200,6 +208,29 @@ def survivalplot(
         Order of groups from hue to display and compare.
     time_label : str, default: "Time"
         Label for the time axis, including units when applicable.
+    ci_show : bool, default: False
+        Whether to display pointwise confidence bands for the Kaplan-Meier curves.
+    show_risk_table : bool, default: False
+        Whether to display a risk table below the plot.
+    risk_table_rows : tuple of str or None, default: ('At risk',)
+        Which rows to show in the risk table. Pass ``None`` to show at-risk,
+        censored, and event counts.
+    risk_table_ypos : float, default: -0.2
+        Vertical position of the risk table relative to the plot.
+    xticks : array-like, optional
+        Specific x-axis tick positions. These positions are also used by the risk
+        table when it is shown.
+    show_median_survival : bool, default: False
+        Whether to draw median-survival guides and include each group's median in
+        the statistical annotation. Medians that are not observed are reported as
+        ``not reached``.
+    landmark_time : float, optional
+        Time at which to mark and report each group's Kaplan-Meier survival
+        probability. For exactly two groups, also reports the two-sided fixed-time
+        log-minus-log comparison p-value.
+    rmst_time : float, optional
+        Truncation time through which to compute and report each group's restricted
+        mean survival time (RMST).
     overall_test : {'logrank', 'trend'}, default: 'logrank'
         Test used for the overall p-value. ``'logrank'`` performs a categorical
         omnibus log-rank test. ``'trend'`` performs a one-degree-of-freedom Cox
@@ -222,7 +253,8 @@ def survivalplot(
         ``'upper right'``, ``'center left'``, ``'center'``, ``'center right'``,
         ``'right'``, ``'lower left'``, ``'lower center'``, or ``'lower right'``.
     ax : matplotlib.axes.Axes, optional
-        Axes to draw on. If None, uses the current axes.
+        Axes to draw on. If None, uses the current axes. Any risk table is linked
+        to this axes and created on the same figure.
 
     Returns
     -------
@@ -245,6 +277,11 @@ def survivalplot(
     ...     hue_order=["control", "drug_a", "drug_b"],
     ...     time_label="Time (months)",
     ...     pairs=[("control", "drug_b")],
+    ...     ci_show=True,
+    ...     show_risk_table=True,
+    ...     show_median_survival=True,
+    ...     landmark_time=12,
+    ...     rmst_time=24,
     ... )
     >>> ax.set_title("Overall Survival by Treatment")
     """
@@ -263,7 +300,12 @@ def survivalplot(
     )
 
     import lifelines as ll
-    from lifelines.statistics import multivariate_logrank_test
+    from lifelines.plotting import add_at_risk_counts
+    from lifelines.statistics import (
+        multivariate_logrank_test,
+        survival_difference_at_fixed_point_in_time_test,
+    )
+    from lifelines.utils import restricted_mean_survival_time
 
     data = data.copy()
     observed_groups = list(data[hue].unique())
@@ -285,6 +327,29 @@ def survivalplot(
     if not has_explicit_order:
         hue_order = observed_groups
     assert hue_order is not None
+
+    common_follow_up = float(data.groupby(hue, observed=True)[duration].max().min())
+    for parameter_name, analysis_time in (
+        ("landmark_time", landmark_time),
+        ("rmst_time", rmst_time),
+    ):
+        if analysis_time is None:
+            continue
+        if (
+            isinstance(analysis_time, bool)
+            or not isinstance(analysis_time, (int, float, np.integer, np.floating))
+            or not np.isfinite(analysis_time)
+            or analysis_time <= 0
+        ):
+            raise ValueError(
+                f"[survivalplot] Parameter '{parameter_name}' must be a finite "
+                f"positive number, got {analysis_time!r}"
+            )
+        if analysis_time > common_follow_up:
+            raise ValueError(
+                f"[survivalplot] Parameter '{parameter_name}' must not exceed the "
+                f"common follow-up time ({common_follow_up:g}), got {analysis_time!r}"
+            )
 
     resolved_pairs: list[tuple[str, str]] = []
     if show_hazard_ratio:
@@ -314,21 +379,37 @@ def survivalplot(
         ax = plt.gca()
     data[hue] = pd.Categorical(data[hue], categories=hue_order, ordered=True)
     data = data.sort_values(hue)
-    kmf = ll.KaplanMeierFitter()
+    fitters: list[Any] = []
+    curve_colors: list[Any] = []
     for group in hue_order:
         df = data[data[hue] == group]
         label = f"{group} (n={df.shape[0]})"
+        if show_risk_table:
+            label = group
+        kmf = ll.KaplanMeierFitter()
         kmf.fit(df[duration], df[event], label=label)
+        fitters.append(kmf)
         kmf.plot_survival_function(
             ax=ax,
             linewidth=1,
-            ci_show=False,
+            ci_show=ci_show,
             show_censors=True,
             censor_styles={"ms": 3},
         )
+        curve = next(line for line in ax.lines if line.get_label() == label)
+        curve_colors.append(curve.get_color())
     ax.set_ylim(-0.05, 1.01)
     ax.set_xlabel(time_label)
     ax.set_ylabel("Survival probability")
+    if xticks is not None:
+        specified_xticks = np.asarray(list(xticks), dtype=float)
+        if specified_xticks.size > 0:
+            ax.set_xticks(specified_xticks)
+            current_xlim = ax.get_xlim()
+            ax.set_xlim(
+                min(current_xlim[0], specified_xticks.min()),
+                max(current_xlim[1], specified_xticks.max()),
+            )
 
     if overall_test == "logrank":
         try:
@@ -405,6 +486,75 @@ def survivalplot(
             "Pairwise hazard ratios and unadjusted two-sided P-values were determined "
             "by Cox proportional hazards models."
         )
+
+    if show_median_survival:
+        annotation_lines.append("Median survival")
+        for group, fitter, color in zip(hue_order, fitters, curve_colors, strict=True):
+            median = float(fitter.median_survival_time_)
+            if np.isfinite(median):
+                annotation_lines.append(f"{group} = {median:g}")
+                ax.hlines(
+                    0.5,
+                    0,
+                    median,
+                    colors=color,
+                    linestyles=":",
+                    linewidth=0.8,
+                )
+                ax.vlines(
+                    median,
+                    0,
+                    0.5,
+                    colors=color,
+                    linestyles=":",
+                    linewidth=0.8,
+                )
+            else:
+                annotation_lines.append(f"{group} = not reached")
+
+    analysis_guide_times = set()
+    if landmark_time is not None:
+        landmark_time = float(landmark_time)
+        analysis_guide_times.add(landmark_time)
+        landmark_estimates = [
+            float(fitter.predict(landmark_time)) for fitter in fitters
+        ]
+        annotation_lines.append(f"Survival at {landmark_time:g}")
+        for group, estimate, color in zip(
+            hue_order, landmark_estimates, curve_colors, strict=True
+        ):
+            annotation_lines.append(f"{group} = {estimate:.2f}")
+            ax.scatter(
+                landmark_time,
+                estimate,
+                color=color,
+                s=12,
+                zorder=3,
+            )
+        if len(fitters) == 2 and all(
+            0 < estimate < 1 for estimate in landmark_estimates
+        ):
+            landmark_result = survival_difference_at_fixed_point_in_time_test(
+                landmark_time, fitters[0], fitters[1]
+            )
+            landmark_p = num2tex.num2tex(landmark_result.p_value, precision=2)
+            annotation_lines.append("Landmark P = " + rf"${landmark_p:.2g}$")
+            logger.info(
+                "Landmark P-value was determined by a two-sided fixed-time "
+                "log-minus-log test."
+            )
+
+    if rmst_time is not None:
+        rmst_time = float(rmst_time)
+        analysis_guide_times.add(rmst_time)
+        annotation_lines.append(f"RMST to {rmst_time:g}")
+        for group, fitter in zip(hue_order, fitters, strict=True):
+            rmst = restricted_mean_survival_time(fitter, t=rmst_time)
+            annotation_lines.append(f"{group} = {rmst:.2f}")
+
+    for analysis_time in sorted(analysis_guide_times):
+        ax.axvline(analysis_time, color="0.5", linestyle="--", linewidth=0.8)
+
     _add_pvalue_annotation(ax, "\n".join(annotation_lines), pvalue_loc)
 
     legend = ax.get_legend()
@@ -413,6 +563,22 @@ def survivalplot(
             set_linewidth = getattr(handle, "set_linewidth", None)
             if callable(set_linewidth):
                 set_linewidth(1.7)
+
+    if show_risk_table:
+        rows = None if risk_table_rows is None else list(risk_table_rows)
+        visible_xticks = np.asarray(ax.get_xticks())
+        visible_xticks = visible_xticks[
+            (visible_xticks >= ax.get_xlim()[0] - 1e-8)
+            & (visible_xticks <= ax.get_xlim()[1] + 1e-8)
+        ]
+        add_at_risk_counts(
+            *fitters,
+            ax=ax,
+            rows_to_show=rows,
+            ypos=risk_table_ypos,
+            xticks=visible_xticks.tolist(),
+            fig=ax.figure,
+        )
 
     return ax
 

--- a/tests/test_survival_features.py
+++ b/tests/test_survival_features.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+def test_survivalplot_can_show_confidence_bands(
+    survival_df: pd.DataFrame,
+) -> None:
+    default_ax = cns.survivalplot(survival_df, "time", "event", "group")
+    assert len(default_ax.collections) == 0
+
+    plt.figure()
+    ci_ax = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        ci_show=True,
+    )
+    assert len(ci_ax.collections) == 2
+
+
+def test_survivalplot_risk_table_uses_supplied_axes_and_ticks(
+    survival_df: pd.DataFrame,
+) -> None:
+    fig, (target_ax, current_ax) = plt.subplots(1, 2)
+    plt.sca(current_ax)
+
+    result = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        show_risk_table=True,
+        xticks=[0, 4, 8],
+        ax=target_ax,
+    )
+
+    assert result is target_ax
+    assert list(target_ax.get_xticks()) == [0, 4, 8]
+    assert fig.axes[-1] is not current_ax
+    risk_table_labels = [
+        label.get_text().split() for label in fig.axes[-1].get_xticklabels()
+    ]
+    assert risk_table_labels == [
+        ["At", "risk", "Control", "6", "Treatment", "6"],
+        ["6", "5"],
+        ["2", "2"],
+    ]
+
+
+def test_survivalplot_can_annotate_median_survival(
+    survival_df: pd.DataFrame,
+) -> None:
+    data = survival_df.copy()
+    treatment = data["group"] == "Treatment"
+    data.loc[treatment, "event"] = 0
+    data.loc[treatment & (data["time"] == 4), "event"] = 1
+
+    ax = cns.survivalplot(
+        data,
+        "time",
+        "event",
+        "group",
+        show_hazard_ratio=False,
+        show_median_survival=True,
+    )
+
+    assert ax.texts[0].get_text().splitlines()[-3:] == [
+        "Median survival",
+        "Control = 8",
+        "Treatment = not reached",
+    ]
+    assert len(ax.collections) == 2
+
+
+def test_survivalplot_can_run_two_group_landmark_analysis(
+    survival_df: pd.DataFrame,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("INFO", logger="cnsplots"):
+        ax = cns.survivalplot(
+            survival_df,
+            "time",
+            "event",
+            "group",
+            landmark_time=6,
+        )
+
+    assert ax.texts[0].get_text().splitlines()[-4:] == [
+        "Survival at 6",
+        "Control = 0.67",
+        "Treatment = 0.62",
+        "Landmark P = $0.88$",
+    ]
+    assert "fixed-time log-minus-log test" in caplog.text
+    assert len(ax.collections) == 2
+    assert any(np.array_equal(line.get_xdata(), [6, 6]) for line in ax.lines)
+
+
+def test_survivalplot_skips_landmark_test_at_survival_boundary(
+    survival_df: pd.DataFrame,
+) -> None:
+    ax = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        landmark_time=1,
+    )
+
+    assert ax.texts[0].get_text().splitlines()[-3:] == [
+        "Survival at 1",
+        "Control = 1.00",
+        "Treatment = 1.00",
+    ]
+
+
+def test_survivalplot_can_report_rmst(survival_df: pd.DataFrame) -> None:
+    ax = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        rmst_time=8,
+    )
+
+    assert ax.texts[0].get_text().splitlines()[-3:] == [
+        "RMST to 8",
+        "Control = 7.17",
+        "Treatment = 6.92",
+    ]
+    assert any(np.array_equal(line.get_xdata(), [8, 8]) for line in ax.lines)
+
+
+@pytest.mark.parametrize("invalid_time", [True, "six", np.inf, 0])
+def test_survivalplot_requires_positive_finite_analysis_times(
+    survival_df: pd.DataFrame,
+    invalid_time: Any,
+) -> None:
+    with pytest.raises(ValueError, match="finite positive number"):
+        cns.survivalplot(
+            survival_df,
+            "time",
+            "event",
+            "group",
+            landmark_time=invalid_time,
+        )
+
+
+def test_survivalplot_analysis_times_require_common_follow_up(
+    survival_df: pd.DataFrame,
+) -> None:
+    with pytest.raises(ValueError, match="common follow-up time \\(11\\)"):
+        cns.survivalplot(
+            survival_df,
+            "time",
+            "event",
+            "group",
+            rmst_time=12,
+        )


### PR DESCRIPTION
## Goal

Expand `survivalplot` with the survival summaries and presentation controls needed for publication-ready Kaplan–Meier plots. Previously, confidence bands were hardcoded off and the plot lacked risk tables, median-survival guides, fixed-time landmark analysis, and RMST summaries.

## What changed

- Add optional confidence bands, aligned risk tables, configurable risk-table rows, and shared x-axis ticks.
- Add median-survival guides with explicit `not reached` reporting.
- Add fixed-time landmark estimates and a two-group log-minus-log comparison.
- Add group-specific restricted mean survival time summaries with common-follow-up validation.
- Add focused regression tests and three gallery examples combining the new features.

## Testing

- `make test` — 410 tests passed with 100% coverage.
- `make lint` — all formatting, typing, spelling, and documentation checks passed.
- Executed and visually inspected `examples/survivalplot.py` with the non-interactive Matplotlib backend.

## Risks and follow-ups

The new display and analysis features are opt-in, preserving existing plots by default. Landmark and RMST times must be positive and within every group's observed follow-up; a landmark p-value is reported only for exactly two groups with estimable interior survival probabilities. No follow-up work is required.
