### PR TITLE
✨ Support tabular heatmap inputs

### DIFF
--- a/examples/heatmapplot.py
+++ b/examples/heatmapplot.py
@@ -69,6 +69,33 @@ print(f"Row clusters: {len(cmp.row_order)}, Col clusters: {len(cmp.col_order)}")
 
 
 # %%
+# Heatmap from a DataFrame
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+# Pass a numeric DataFrame directly without converting it to AnnData. Its index and
+# columns become the heatmap labels. A two-dimensional NumPy array can be passed in
+# the same way and uses integer labels.
+expression_df = pd.DataFrame(
+    np.random.default_rng(42).normal(size=(12, 8)),
+    index=pd.Index([f"Sample {index + 1}" for index in range(12)]),
+    columns=pd.Index([f"Feature {index + 1}" for index in range(8)]),
+)
+
+cns.figure(200, 220)
+cmp = cns.heatmapplot(
+    expression_df,
+    label="Value",
+    xlabel="Features",
+    ylabel="Samples",
+    row_cluster=True,
+    col_cluster=True,
+    show_rownames=True,
+    show_colnames=True,
+    yticklabels_fontsize=6,
+    legend_hpad=5,
+)
+
+
+# %%
 # Simple heatmap without clustering
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Basic heatmap showing raw data without reordering.

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -28,7 +28,6 @@ from cnsplots._validation import (
     validate_adata_layer,
     validate_adata_obs_columns,
     validate_adata_var_columns,
-    validate_anndata,
     validate_columns_exist,
     validate_dataframe,
     validate_dataframe_not_empty,
@@ -65,6 +64,24 @@ def _anndata_to_heatmap_dataframe(adata: AnnData, layer: str | None) -> pd.DataF
     return pd.DataFrame(matrix, index=adata.obs_names, columns=adata.var_names)
 
 
+def _to_heatmap_dataframe(
+    data: AnnData | pd.DataFrame | np.ndarray, layer: str | None
+) -> pd.DataFrame:
+    if isinstance(data, AnnData):
+        return _anndata_to_heatmap_dataframe(data, layer)
+    if isinstance(data, np.ndarray):
+        if data.ndim != 2:
+            raise ValueError("[heatmapplot] Input data must be two-dimensional.")
+        data = pd.DataFrame(data)
+    elif not isinstance(data, pd.DataFrame):
+        raise TypeError(
+            "[heatmapplot] Parameter 'adata' must be an AnnData, pandas DataFrame, "
+            f"or numpy ndarray, got {type(data).__name__}"
+        )
+    validate_dataframe_not_empty(data, "heatmapplot")
+    return data
+
+
 def _style_plotter_colorbars(cbars: list[Any]) -> None:
     font_family = mpl.rcParams.get("font.family")
     legend_fontsize = _legend_fontsize()
@@ -87,7 +104,7 @@ def _style_plotter_colorbars(cbars: list[Any]) -> None:
 
 
 def heatmapplot(
-    adata: AnnData,
+    adata: AnnData | pd.DataFrame | np.ndarray,
     layer: str | None = None,
     row_annotation: list[str] | None = None,
     col_annotation: list[str] | None = None,
@@ -122,22 +139,28 @@ def heatmapplot(
 
     Parameters
     ----------
-    adata : AnnData
-        Annotated data matrix containing observations and variables.
+    adata : AnnData, pandas.DataFrame, or numpy.ndarray
+        Matrix to plot. DataFrame index and column labels are preserved. ndarray
+        inputs use integer row and column labels.
     layer : str, optional
         Key in `adata.layers` to use for the heatmap data. If None, uses `adata.X`.
+        Only supported when `adata` is an AnnData object.
     row_annotation : list of str, optional
-        Column names from `adata.obs` to display as row annotations.
+        Column names from `adata.obs` to display as row annotations. Only supported
+        when `adata` is an AnnData object.
     col_annotation : list of str, optional
-        Column names from `adata.var` to display as column annotations.
+        Column names from `adata.var` to display as column annotations. Only supported
+        when `adata` is an AnnData object.
     row_cluster : bool, default: False
         Whether to perform hierarchical clustering on rows.
     col_cluster : bool, default: False
         Whether to perform hierarchical clustering on columns.
     row_split : str or int, optional
-        Column name from `adata.obs` or number of splits for row grouping.
+        Column name from `adata.obs` or number of splits for row grouping. String
+        values are only supported when `adata` is an AnnData object.
     col_split : str or int, optional
-        Column name from `adata.var` or number of splits for column grouping.
+        Column name from `adata.var` or number of splits for column grouping. String
+        values are only supported when `adata` is an AnnData object.
     cmap : str, optional
         Colormap for the heatmap. Can be categorical (Set1, Set2, Ecotyper1, Dark2,
         Ecotyper2, Set3) or continuous (parula, gnuplot, bwr, hot).
@@ -194,29 +217,37 @@ def heatmapplot(
     >>> cns.heatmapplot(
     ...     adata, row_annotation=["cell_type", "batch"], col_cluster=True, cmap="bwr"
     ... )
+    >>> cns.heatmapplot(expression_df, row_cluster=True, col_cluster=True)
     """
-    # Validate inputs
-    validate_anndata(adata, "adata", "heatmapplot")
+    if isinstance(adata, AnnData):
+        if layer is not None:
+            validate_adata_layer(adata, layer, "heatmapplot")
+        if row_annotation is not None:
+            validate_adata_obs_columns(adata, row_annotation, "heatmapplot")
+        if col_annotation is not None:
+            validate_adata_var_columns(adata, col_annotation, "heatmapplot")
+        if isinstance(row_split, str):
+            validate_adata_obs_columns(adata, row_split, "heatmapplot")
+        if isinstance(col_split, str):
+            validate_adata_var_columns(adata, col_split, "heatmapplot")
+        row_metadata = adata.obs
+        col_metadata = adata.var
+    else:
+        if (
+            layer is not None
+            or row_annotation is not None
+            or col_annotation is not None
+            or isinstance(row_split, str)
+            or isinstance(col_split, str)
+        ):
+            raise ValueError(
+                "[heatmapplot] layer, row_annotation, col_annotation, and string "
+                "row_split/col_split are only supported for AnnData inputs."
+            )
+        row_metadata = None
+        col_metadata = None
 
-    # Validate layer if provided
-    if layer is not None:
-        validate_adata_layer(adata, layer, "heatmapplot")
-
-    # Validate row annotations
-    if row_annotation is not None:
-        validate_adata_obs_columns(adata, row_annotation, "heatmapplot")
-
-    # Validate column annotations
-    if col_annotation is not None:
-        validate_adata_var_columns(adata, col_annotation, "heatmapplot")
-
-    # Validate row split if it's a string
-    if isinstance(row_split, str):
-        validate_adata_obs_columns(adata, row_split, "heatmapplot")
-
-    # Validate column split if it's a string
-    if isinstance(col_split, str):
-        validate_adata_var_columns(adata, col_split, "heatmapplot")
+    df = _to_heatmap_dataframe(adata, layer)
 
     if cmap is None:
         cmap = settings.palette_seq
@@ -286,7 +317,8 @@ def heatmapplot(
     left_annotation: Any = None
     top_annotation: Any = None
     if row_annotation is not None:
-        rc_dict = _annot_helper(adata.obs, row_annotation)
+        assert row_metadata is not None
+        rc_dict = _annot_helper(row_metadata, row_annotation)
         left_annotation = pch.HeatmapAnnotation(
             axis=0,
             verbose=0,
@@ -299,17 +331,19 @@ def heatmapplot(
             **rc_dict,
         )
     if col_annotation is not None:
-        ca_dict = _annot_helper(adata.var, col_annotation)
+        assert col_metadata is not None
+        ca_dict = _annot_helper(col_metadata, col_annotation)
         top_annotation = pch.HeatmapAnnotation(axis=1, verbose=0, **ca_dict)
 
     row_split_val: Any = row_split
     col_split_val: Any = col_split
     if row_split is not None and not isinstance(row_split, int):
-        row_split_val = adata.obs[row_split]
+        assert row_metadata is not None
+        row_split_val = row_metadata[row_split]
     if col_split is not None and not isinstance(col_split, int):
-        col_split_val = adata.var[col_split]
+        assert col_metadata is not None
+        col_split_val = col_metadata[col_split]
 
-    df = _anndata_to_heatmap_dataframe(adata, layer)
     host_ax = ax
     fig = None if host_ax is None else host_ax.figure
     layout_fig = (

--- a/tests/test_heatmap_defects.py
+++ b/tests/test_heatmap_defects.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import types
 from pathlib import Path
+from typing import Any, cast
 
 import anndata as ad
 import matplotlib.pyplot as plt
@@ -132,3 +133,60 @@ def test_heatmapplot_preserves_missing_x_error() -> None:
 
     with pytest.raises(ValueError, match="X is None, cannot convert to dataframe"):
         cns.heatmapplot(adata)
+
+
+def test_heatmapplot_accepts_dataframe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0]],
+        index=pd.Index(["sample_1", "sample_2"]),
+        columns=pd.Index(["feature_1", "feature_2"]),
+    )
+    _stub_plotter(monkeypatch)
+
+    plotter = cns.heatmapplot(data)
+
+    pd.testing.assert_frame_equal(plotter.data2d, data)
+
+
+def test_heatmapplot_accepts_ndarray(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = np.array([[1.0, 2.0], [3.0, 4.0]])
+    _stub_plotter(monkeypatch)
+
+    plotter = cns.heatmapplot(data)
+
+    pd.testing.assert_frame_equal(plotter.data2d, pd.DataFrame(data))
+
+
+@pytest.mark.parametrize("data", [pd.DataFrame(), np.empty((0, 2))])
+def test_heatmapplot_rejects_empty_tabular_data(data: Any) -> None:
+    with pytest.raises(ValueError, match="Data is empty"):
+        cns.heatmapplot(data)
+
+
+def test_heatmapplot_rejects_non_matrix_input() -> None:
+    with pytest.raises(TypeError, match="AnnData, pandas DataFrame, or numpy ndarray"):
+        cns.heatmapplot(cast(Any, [[1.0, 2.0], [3.0, 4.0]]))
+
+    with pytest.raises(ValueError, match="two-dimensional"):
+        cns.heatmapplot(np.ones((2, 2, 2)))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"layer": "scaled"},
+        {"row_annotation": ["group"]},
+        {"col_annotation": ["group"]},
+        {"row_split": "group"},
+        {"col_split": "group"},
+    ],
+)
+def test_heatmapplot_rejects_anndata_options_for_dataframe(
+    kwargs: dict[str, Any],
+) -> None:
+    with pytest.raises(ValueError, match="only supported for AnnData"):
+        cns.heatmapplot(pd.DataFrame([[1.0]]), **kwargs)


### PR DESCRIPTION
## Goal

Allow `heatmapplot` to accept common matrix containers without requiring users to construct an AnnData object.

## Changes

- Accept labeled pandas DataFrames and two-dimensional NumPy arrays while preserving existing AnnData behavior.
- Preserve DataFrame row and column labels and assign default integer labels to ndarray inputs.
- Reject empty or non-matrix inputs and clearly identify options that require AnnData metadata.
- Add regression coverage and a DataFrame gallery example.

## Testing

- `make test` — 420 passed with 100% coverage.
- `make lint` — all configured checks passed.
- `MPLBACKEND=Agg uv run python examples/heatmapplot.py` — gallery example completed successfully.

## Risks and follow-ups

- `layer`, row/column annotations, and string-based row/column splits remain AnnData-only because plain matrices do not carry the required metadata.
- No dependency or configuration changes.