### PR TITLE
✨ Configure volcano plot thresholds

### DIFF
--- a/examples/volcanoplot.py
+++ b/examples/volcanoplot.py
@@ -29,6 +29,7 @@ pvals = np.clip(pvals, 1e-50, 1)
 de = pd.DataFrame(
     {
         "log2FoldChange": logfc,
+        "padj": pvals,
         "-log10(adjp)": -np.log10(pvals),
         "symbol": [f"Gene{i}" for i in range(n_genes)],
     }
@@ -43,6 +44,26 @@ de.head()
 cns.figure(200, 200)
 ax = cns.volcanoplot(de, x="log2FoldChange", y="-log10(adjp)", symbol="symbol")
 ax.set_title("Volcano Plot")
+
+
+# %%
+# Raw p-values and custom thresholds
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Transform raw adjusted p-values in the plot and apply stricter significance
+# and fold-change thresholds. The custom x column is also used as its axis label.
+raw_de = de.rename(columns={"log2FoldChange": "LFC"})
+cns.figure(200, 200)
+ax = cns.volcanoplot(
+    raw_de,
+    x="LFC",
+    y="padj",
+    symbol="symbol",
+    n_show=5,
+    pvalue_threshold=0.01,
+    fold_change_threshold=1,
+    transform_y=True,
+)
+ax.set_title("padj < 0.01 and |LFC| > 1")
 
 
 # %%

--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -35,6 +35,9 @@ def volcanoplot(
     show_list: list[str] | None = None,
     n_show: int = 10,
     *,
+    pvalue_threshold: float = 0.05,
+    fold_change_threshold: float = 0.5,
+    transform_y: bool = False,
     ax: Axes | None = None,
 ) -> Axes:
     """
@@ -60,6 +63,14 @@ def volcanoplot(
         Number of top upregulated and downregulated genes to label automatically
         when ``show_list`` is ``None``. If ``show_list`` is provided, it takes
         precedence and ``n_show`` is ignored.
+    pvalue_threshold : float, default: 0.05
+        P-value threshold used to identify significant features.
+    fold_change_threshold : float, default: 0.5
+        Absolute fold-change threshold used to identify upregulated and
+        downregulated features.
+    transform_y : bool, default: False
+        If True, treat ``y`` as raw p-values and plot their -log10 transform.
+        If False, ``y`` must already contain -log10-transformed values.
     ax : matplotlib.axes.Axes, optional
         Axes to draw on. If None, uses the current axes.
 
@@ -81,13 +92,15 @@ def volcanoplot(
     ... )
     >>> ax.set_title("Differential Expression")
 
-    >>> # Label fewer top genes automatically
+    >>> # Use raw p-values and custom thresholds
     >>> ax = cns.volcanoplot(
     ...     data=de_results,
-    ...     x="log2FoldChange",
-    ...     y="-log10(padj)",
+    ...     x="LFC",
+    ...     y="padj",
     ...     symbol="gene_name",
-    ...     n_show=5,
+    ...     pvalue_threshold=0.01,
+    ...     fold_change_threshold=1,
+    ...     transform_y=True,
     ... )
 
     >>> # Highlight specific genes
@@ -107,16 +120,49 @@ def volcanoplot(
         raise TypeError("[volcanoplot] Parameter 'n_show' must be an integer")
     if n_show < 0:
         raise ValueError("[volcanoplot] Parameter 'n_show' must be non-negative")
+    numeric_types = (int, float, np.integer, np.floating)
+    if isinstance(pvalue_threshold, bool) or not isinstance(
+        pvalue_threshold, numeric_types
+    ):
+        raise TypeError("[volcanoplot] Parameter 'pvalue_threshold' must be a number")
+    if not 0 < pvalue_threshold <= 1:
+        raise ValueError(
+            "[volcanoplot] Parameter 'pvalue_threshold' must be greater than 0 "
+            "and at most 1"
+        )
+    if isinstance(fold_change_threshold, bool) or not isinstance(
+        fold_change_threshold, numeric_types
+    ):
+        raise TypeError(
+            "[volcanoplot] Parameter 'fold_change_threshold' must be a number"
+        )
+    if not np.isfinite(fold_change_threshold) or fold_change_threshold < 0:
+        raise ValueError(
+            "[volcanoplot] Parameter 'fold_change_threshold' must be a finite, "
+            "non-negative number"
+        )
+    if not isinstance(transform_y, bool):
+        raise TypeError("[volcanoplot] Parameter 'transform_y' must be a boolean")
 
     import adjustText as at
 
     hue = "DEG"
     de = data.copy()
+    if transform_y:
+        if not pd.api.types.is_numeric_dtype(de[y]):
+            raise ValueError(f"[volcanoplot] Column '{y}' must be numeric")
+        if ((de[y] < 0) | (de[y] > 1)).any():
+            raise ValueError(
+                f"[volcanoplot] Column '{y}' must contain p-values between 0 and 1"
+            )
+        de[y] = -np.log10(de[y].clip(lower=np.finfo(float).tiny))
 
     de[hue] = "NS"
-    de.loc[de[y] > -np.log10(0.05), hue] = "p_adj < 0.05"
-    up = (de[y] > -np.log10(0.05)) & (de[x] > 0.5)
-    down = (de[y] > -np.log10(0.05)) & (de[x] < -0.5)
+    significance_cutoff = -np.log10(pvalue_threshold)
+    significance_label = f"p_adj < {pvalue_threshold:g}"
+    de.loc[de[y] > significance_cutoff, hue] = significance_label
+    up = (de[y] > significance_cutoff) & (de[x] > fold_change_threshold)
+    down = (de[y] > significance_cutoff) & (de[x] < -fold_change_threshold)
     if show_list is None:
         de["rank"] = de[y] * de[x].abs()
         de.loc[de.loc[up].nlargest(n_show, "rank").index, hue] = "Up"
@@ -135,10 +181,10 @@ def volcanoplot(
         x=x,
         y=y,
         size=hue,
-        sizes={"Down": 10, "NS": 2, "Up": 10, "p_adj < 0.05": 2},
+        sizes={"Down": 10, "NS": 2, "Up": 10, significance_label: 2},
         hue=hue,
         edgecolor=None,
-        palette={"Down": blue, "NS": "grey", "Up": red, "p_adj < 0.05": "black"},
+        palette={"Down": blue, "NS": "grey", "Up": red, significance_label: "black"},
         rasterized=True,
         ax=ax,
     )
@@ -163,8 +209,11 @@ def volcanoplot(
 
     ax.spines["right"].set_visible(True)
     ax.spines["top"].set_visible(True)
-    ax.set_xlabel("log2(fold change)")
-    ax.set_ylabel("\u2013log10(adjusted p-value)")
+    ax.set_xlabel("log2(fold change)" if x == "log2FoldChange" else x)
+    if transform_y:
+        ax.set_ylabel(f"\u2013log10({y})")
+    else:
+        ax.set_ylabel("\u2013log10(adjusted p-value)" if y == "-log10(adjp)" else y)
     ax.plot(
         [0, 0],
         [0, max(de[y])],

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -1071,6 +1071,70 @@ def test_genomics_plots(
     )
 
 
+def test_volcanoplot_supports_raw_pvalues_and_custom_thresholds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_adjust = types.SimpleNamespace(adjust_text=lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "adjustText", fake_adjust)
+    raw_data = pd.DataFrame(
+        {
+            "LFC": [-1.2, -2.0, 0.0, 0.8, 1.2],
+            "padj": [0.009, 0.02, 0.001, 0.001, 0.009],
+            "gene": ["DOWN", "P_TOO_HIGH", "SIG_ONLY", "FC_TOO_LOW", "UP"],
+        }
+    )
+    original_data = raw_data.copy()
+
+    cns.figure(120, 120)
+    ax = cns.volcanoplot(
+        raw_data,
+        x="LFC",
+        y="padj",
+        symbol="gene",
+        pvalue_threshold=0.01,
+        fold_change_threshold=1.0,
+        transform_y=True,
+    )
+
+    assert ax.get_xlabel() == "LFC"
+    assert ax.get_ylabel() == "–log10(padj)"
+    assert {text.get_text() for text in ax.texts} == {"DOWN", "UP"}
+    legend = ax.get_legend()
+    assert legend is not None
+    assert "p_adj < 0.01" in {text.get_text() for text in legend.texts}
+    offsets = np.asarray(ax.collections[0].get_offsets(), dtype=float)
+    offsets = offsets[np.argsort(offsets[:, 0])]
+    expected = raw_data.sort_values("LFC")
+    np.testing.assert_allclose(offsets[:, 0], expected["LFC"])
+    np.testing.assert_allclose(offsets[:, 1], -np.log10(expected["padj"]))
+    pd.testing.assert_frame_equal(raw_data, original_data)
+
+
+def test_volcanoplot_validates_custom_thresholds(
+    volcano_df: pd.DataFrame,
+) -> None:
+    with pytest.raises(TypeError, match="'pvalue_threshold' must be a number"):
+        cast(Any, cns.volcanoplot)(volcano_df, pvalue_threshold="0.01")
+    with pytest.raises(ValueError, match="must be greater than 0 and at most 1"):
+        cns.volcanoplot(volcano_df, pvalue_threshold=0)
+    with pytest.raises(TypeError, match="'fold_change_threshold' must be a number"):
+        cast(Any, cns.volcanoplot)(volcano_df, fold_change_threshold=True)
+    with pytest.raises(ValueError, match="must be a finite, non-negative number"):
+        cns.volcanoplot(volcano_df, fold_change_threshold=-1)
+    with pytest.raises(TypeError, match="'transform_y' must be a boolean"):
+        cast(Any, cns.volcanoplot)(volcano_df, transform_y=1)
+
+    nonnumeric = volcano_df.rename(columns={"-log10(adjp)": "padj"}).assign(
+        padj="invalid"
+    )
+    with pytest.raises(ValueError, match="Column 'padj' must be numeric"):
+        cns.volcanoplot(nonnumeric, y="padj", transform_y=True)
+
+    out_of_range = volcano_df.rename(columns={"-log10(adjp)": "padj"}).assign(padj=1.1)
+    with pytest.raises(ValueError, match="p-values between 0 and 1"):
+        cns.volcanoplot(out_of_range, y="padj", transform_y=True)
+
+
 def test_volcanoplot_annotations_use_legend_fontsize(
     volcano_df: pd.DataFrame,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Goal

Allow volcano plots to work with project-specific significance and fold-change thresholds, raw p-value columns, and custom x-axis columns.

## What changed

- Added configurable p-value and absolute fold-change thresholds while preserving the existing defaults.
- Added optional in-plot `-log10` transformation for raw p-values without mutating the input data.
- Used custom x and y column names for axis labels where appropriate.
- Added validation and regression coverage for the new options.
- Added a gallery example using raw `padj` values with `padj < 0.01` and `|LFC| > 1`.

## Testing

- `make test` — 422 passed with 100% coverage.
- `make lint` — passed.
- Executed the new gallery section with the headless Matplotlib backend.

## Risks and follow-ups

The existing transformed-y behavior and thresholds remain the defaults for backward compatibility. Raw p-value transformation is opt-in with `transform_y=True`; no follow-up work is currently required.
