### PR TITLE
🐛 Center ylabel on visible heatmap

### DIFF
--- a/src/cnsplots/helpers/_heatmap.py
+++ b/src/cnsplots/helpers/_heatmap.py
@@ -451,6 +451,21 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
             col_order=col_order,
         )
 
+    def post_processing(self) -> None:
+        super().post_processing()
+        if (
+            self.ylabel is None
+            or "position" in self.ylabel_kws
+            or not hasattr(self, "ax_heatmap")
+        ):
+            return
+        heatmap_box = self.ax_heatmap.get_window_extent()
+        host_box = self.ax.get_window_extent()
+        ylabel_y = (heatmap_box.y0 + heatmap_box.height / 2 - host_box.y0) / (
+            host_box.height
+        )
+        self.ax.yaxis.label.set_y(ylabel_y)
+
     def _define_axes(self, subplot_spec: Any = None) -> None:
         if not _define_axes_within_current_bounds(self, subplot_spec):
             super()._define_axes(subplot_spec)

--- a/tests/test_heatmap_defects.py
+++ b/tests/test_heatmap_defects.py
@@ -150,6 +150,25 @@ def test_heatmapplot_accepts_dataframe(
     pd.testing.assert_frame_equal(plotter.data2d, data)
 
 
+def test_heatmapplot_centers_ylabel_on_visible_heatmap() -> None:
+    data = pd.DataFrame(np.arange(12).reshape(4, 3))
+
+    plotter = cns.heatmapplot(
+        data,
+        xlabel="Features",
+        ylabel="Samples",
+        row_cluster=False,
+        col_cluster=False,
+    )
+    plotter.ax.figure.canvas.draw()
+
+    ylabel_box = plotter.ax.yaxis.label.get_window_extent()
+    heatmap_box = plotter.ax_heatmap.get_window_extent()
+    assert (ylabel_box.y0 + ylabel_box.y1) / 2 == pytest.approx(
+        (heatmap_box.y0 + heatmap_box.y1) / 2
+    )
+
+
 def test_heatmapplot_accepts_ndarray(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Purpose

Correct the vertical placement of heatmap y-axis labels, including the second heatmap gallery example.

## Changes

- Center automatically positioned y-axis labels on the visible heatmap after layout completes.
- Preserve explicitly configured y-axis label positions.
- Add a regression test comparing the rendered ylabel and heatmap centers.

## Testing

- `make test` — 423 passed with 100% coverage.
- `make lint` — passed.
- Regenerated and visually inspected `sphx_glr_heatmapplot_002`.

## Risks and follow-ups

Low risk: the adjustment only applies to automatic ylabel placement. No follow-up work is required.
