### PR TITLE
✨ Support Spearman in regplot

### DIFF
--- a/examples/regplot.py
+++ b/examples/regplot.py
@@ -34,6 +34,23 @@ ax.set_ylabel("Total Bill ($)")
 
 
 # %%
+# Spearman rank correlation
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# Use ``method="spearman"`` to report rank correlation for monotonic relationships.
+# The fitted line remains a linear regression fit.
+cns.figure(150, 150)
+ax = cns.regplot(
+    data=tips,
+    x="tip",
+    y="total_bill",
+    method="spearman",
+)
+ax.set_title("Spearman Correlation")
+ax.set_xlabel("Tip ($)")
+ax.set_ylabel("Total Bill ($)")
+
+
+# %%
 # Grouped regression plot with hue
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Fit separate regression lines for each group.

--- a/src/cnsplots/plots/_regression.py
+++ b/src/cnsplots/plots/_regression.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import matplotlib.pyplot as plt
 import num2tex
@@ -28,18 +28,37 @@ def _finite_xy_data(data: pd.DataFrame, x: str, y: str) -> pd.DataFrame:
     return data.loc[np.isfinite(xy_values).all(axis=1)]
 
 
-def _validate_pearson_sample_size(
+CorrelationMethod = Literal["pearson", "spearman"]
+
+
+def _validate_correlation_sample_size(
     data: pd.DataFrame,
+    method: CorrelationMethod,
     *,
     group: Any = None,
 ) -> None:
-    """Require enough plotted pairs for Pearson correlation."""
+    """Require enough plotted pairs for the selected correlation method."""
     if len(data) < 2:
         group_suffix = "" if group is None else f" in hue group {group!r}"
         raise ValueError(
-            "[regplot] Pearson correlation requires at least 2 finite paired "
+            f"[regplot] {method.capitalize()} correlation requires at least 2 "
+            "finite paired "
             f"observations{group_suffix}."
         )
+
+
+def _correlation_statistics(
+    data: pd.DataFrame,
+    x: str,
+    y: str,
+    method: CorrelationMethod,
+) -> tuple[float, float]:
+    """Return the selected correlation coefficient and p-value."""
+    if method == "pearson":
+        result = sp.stats.pearsonr(data[x], data[y])
+    else:
+        result = sp.stats.spearmanr(data[x], data[y])
+    return float(result.statistic), float(result.pvalue)
 
 
 def regplot(
@@ -50,6 +69,7 @@ def regplot(
     s: float = 3,
     color: ColorType = "black",
     *,
+    method: CorrelationMethod = "pearson",
     hue_order: list[str] | None = None,
     ax: Axes | None = None,
     **kwargs: Any,
@@ -58,7 +78,7 @@ def regplot(
     Create a regression plot with linear fit and correlation statistics.
 
     This function creates a scatter plot with a fitted regression line and displays
-    Pearson correlation coefficient and p-value.
+    a Pearson or Spearman correlation coefficient and p-value.
 
     Parameters
     ----------
@@ -80,6 +100,9 @@ def regplot(
         a legend is added, while a single overall regression line and correlation
         statistic are shown. If *hue* is also specified, *hue* takes precedence
         and *color* is ignored.
+    method : {"pearson", "spearman"}, default: "pearson"
+        Correlation method used for the coefficient and p-value annotation.
+        The fitted regression line remains linear for both methods.
     hue_order : list of str, optional
         Order of hue levels.
     ax : matplotlib.axes.Axes, optional
@@ -109,6 +132,9 @@ def regplot(
 
     >>> # Color points by a column (single regression line)
     >>> ax = cns.regplot(data=df, x="age", y="expression", color="cell_type")
+
+    >>> # Report Spearman rank correlation
+    >>> ax = cns.regplot(data=df, x="dose", y="response", method="spearman")
     """
     # Validate inputs
     validate_dataframe(data, "data", "regplot")
@@ -117,6 +143,11 @@ def regplot(
         columns_to_check.append(hue)
     validate_columns_exist(data, columns_to_check, "regplot")
     validate_dataframe_not_empty(data, "regplot")
+
+    if method not in ("pearson", "spearman"):
+        raise ValueError(
+            "[regplot] Parameter 'method' must be one of: 'pearson', 'spearman'"
+        )
 
     # Validate numeric columns
     validate_column_type(data, x, ["numeric"], "regplot")
@@ -132,15 +163,16 @@ def regplot(
     palette = plt.rcParams["axes.prop_cycle"].by_key()["color"]
     color_is_column = isinstance(color, str) and color in data.columns
     finite_data = _finite_xy_data(data, x, y)
+    correlation_symbol = "r" if method == "pearson" else r"\rho"
     if hue is not None:
         plot_data = finite_data.loc[finite_data[hue].notna()]
-        _validate_pearson_sample_size(plot_data)
+        _validate_correlation_sample_size(plot_data, method)
         hue_levels = list(plot_data[hue].unique()) if hue_order is None else hue_order
         hue_subsets = [
             (hue_val, plot_data[plot_data[hue] == hue_val]) for hue_val in hue_levels
         ]
         for hue_val, subset in hue_subsets:
-            _validate_pearson_sample_size(subset, group=hue_val)
+            _validate_correlation_sample_size(subset, method, group=hue_val)
         for idx, (hue_val, subset) in enumerate(hue_subsets):
             ax = sns.regplot(
                 data=subset,
@@ -151,11 +183,11 @@ def regplot(
                 label=hue_val,
                 **args,
             )
-            r, p_value = sp.stats.pearsonr(subset[x], subset[y])
+            coefficient, p_value = _correlation_statistics(subset, x, y, method)
             ax.text(
                 0.05,
                 0.95 - 0.08 * idx,
-                rf"{hue_val}: $r$={r:.2f},"
+                rf"{hue_val}: ${correlation_symbol}$={coefficient:.2f},"
                 rf" P=${num2tex.num2tex(p_value, precision=2):.2g}$",
                 color=palette[idx % len(palette)],
                 transform=ax.transAxes,
@@ -165,7 +197,7 @@ def regplot(
         ax.legend(title=hue)
     elif color_is_column:
         plot_data = finite_data.loc[finite_data[color].notna()]
-        _validate_pearson_sample_size(plot_data)
+        _validate_correlation_sample_size(plot_data, method)
         line_args = {k: v for k, v in args.items() if k != "scatter_kws"}
         ax = sns.regplot(
             data=plot_data,
@@ -188,11 +220,12 @@ def regplot(
                 alpha=1,
                 edgecolors="none",
             )
-        r, p_value = sp.stats.pearsonr(plot_data[x], plot_data[y])
+        coefficient, p_value = _correlation_statistics(plot_data, x, y, method)
         ax.text(
             0.05,
             0.95,
-            rf"$r$={r:.2f}, $P={num2tex.num2tex(p_value, precision=2):.2g}$",
+            rf"${correlation_symbol}$={coefficient:.2f}, "
+            rf"$P={num2tex.num2tex(p_value, precision=2):.2g}$",
             color="black",
             transform=ax.transAxes,
             ha="left",
@@ -203,7 +236,7 @@ def regplot(
             ax.get_legend(), 2 * s, marker_size=2 * np.sqrt(s / np.pi)
         )
     else:
-        _validate_pearson_sample_size(finite_data)
+        _validate_correlation_sample_size(finite_data, method)
         ax = sns.regplot(
             data=finite_data,
             x=x,
@@ -212,11 +245,12 @@ def regplot(
             color=color,
             **args,
         )
-        r, p_value = sp.stats.pearsonr(finite_data[x], finite_data[y])
+        coefficient, p_value = _correlation_statistics(finite_data, x, y, method)
         ax.text(
             0.05,
             0.95,
-            rf"$r$={r:.2f}, $P={num2tex.num2tex(p_value, precision=2):.2g}$",
+            rf"${correlation_symbol}$={coefficient:.2f}, "
+            rf"$P={num2tex.num2tex(p_value, precision=2):.2g}$",
             color=color,
             transform=ax.transAxes,
             ha="left",

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -410,7 +410,7 @@ def test_public_stackplot_signature_contract() -> None:
         ("histplot", {"hue", "hue_order"}, set()),
         ("scatterplot", {"hue", "hue_order"}, set()),
         ("lineplot", {"hue", "hue_order"}, set()),
-        ("regplot", {"hue", "hue_order"}, set()),
+        ("regplot", {"hue", "hue_order", "method"}, set()),
         ("slopeplot", {"hue", "hue_order"}, set()),
         ("dumbbellplot", {"hue", "hue_order", "order"}, set()),
     ],

--- a/tests/test_regression_plot_defects.py
+++ b/tests/test_regression_plot_defects.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import cast
+from typing import Any, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -34,6 +34,35 @@ def test_regplot_uses_only_finite_plotted_pairs_for_pearson() -> None:
         np.asarray(scatter.get_offsets(), dtype=float),
         data.loc[:2, ["x", "y"]].to_numpy(),
     )
+
+
+@pytest.mark.parametrize("grouping", [None, "hue", "color"])
+def test_regplot_supports_spearman_correlation(grouping: str | None) -> None:
+    data = pd.DataFrame(
+        {
+            "x": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            "y": [1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0],
+            "group": ["A"] * 4 + ["B"] * 4,
+        }
+    )
+
+    cns.figure(120, 120)
+    if grouping == "hue":
+        ax = cns.regplot(data, x="x", y="y", method="spearman", hue="group")
+    elif grouping == "color":
+        ax = cns.regplot(data, x="x", y="y", method="spearman", color="group")
+    else:
+        ax = cns.regplot(data, x="x", y="y", method="spearman")
+
+    assert ax.texts
+    assert all(r"$\rho$=1.00," in text.get_text() for text in ax.texts)
+
+
+def test_regplot_rejects_unknown_correlation_method() -> None:
+    data = pd.DataFrame({"x": [0.0, 1.0], "y": [0.0, 1.0]})
+
+    with pytest.raises(ValueError, match="method.*pearson.*spearman"):
+        cns.regplot(data, x="x", y="y", method=cast(Any, "kendall"))
 
 
 @pytest.mark.parametrize("hue", [None, "group"])


### PR DESCRIPTION
## Goal

Allow `regplot` users to report Spearman rank correlation when a monotonic, rank-based association is more appropriate than Pearson correlation.

## What changed

- Add a keyword-only `method` parameter supporting `"pearson"` and `"spearman"`, with Pearson retained as the default.
- Display Spearman coefficients with the rho symbol across standard, hue-grouped, and color-column plots.
- Validate unsupported correlation methods before plotting.
- Add a gallery example and regression tests for the new behavior.

## Testing

- `make test` — 427 tests passed with 100% coverage.
- `make lint` — all hooks passed.
- `MPLBACKEND=Agg uv run python examples/regplot.py` — example completed successfully.

## Risks and follow-ups

Risk is low because existing calls continue to use Pearson correlation by default. The fitted regression line remains linear for either correlation method. No follow-up work is currently required.
