### PR TITLE
🐛 Separate bar labels and p-values

### DIFF
--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -785,7 +785,16 @@ def _add_count_helper(data, attr, ax, axis="x"):
     set_ticklabels(new_tick_labels)
 
 
-def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=None):
+def _p_value_helper(
+    test,
+    data,
+    ax,
+    plotting,
+    pairs,
+    contingency=None,
+    format=None,
+    label_clearance=None,
+):
     resolved_format = settings.pvalue_format if format is None else format
     if resolved_format not in {"star", "threshold", "full"}:
         raise ValueError("format must be one of: 'star', 'threshold', 'full'")
@@ -868,6 +877,15 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=No
             )
         pairs = hue_pairs
 
+    line_offset_to_group = None
+    if label_clearance is not None and settings.pvalue_loc == "inside":
+        # statannotations expands the value axis as it stacks brackets. Account
+        # for that scaling so the requested on-screen label clearance remains.
+        annotation_step = 0.07 + label_clearance
+        expansion = 1.04 * (1 + len(pairs) * annotation_step)
+        denominator = max(1 - 1.04 * label_clearance, 0.1)
+        line_offset_to_group = label_clearance * expansion / denominator
+
     contingency_tables = None
     if contingency is not None:
         contingency = contingency.fillna(0)
@@ -928,11 +946,18 @@ def _p_value_helper(test, data, ax, plotting, pairs, contingency=None, format=No
         for table in contingency_tables:
             pvalues.append(stats.chi2_contingency(table)[1])
 
-    if contingency is None:
-        annotator.apply_and_annotate()
-    else:
+    if contingency is not None:
         annotator.set_pvalues(pvalues=pvalues)
-        annotator.annotate()
+
+    if line_offset_to_group is None:
+        if contingency is None:
+            annotator.apply_and_annotate()
+        else:
+            annotator.annotate()
+    else:
+        if contingency is None:
+            annotator.apply_test()
+        annotator.annotate(line_offset_to_group=line_offset_to_group)
 
     if test == "Mann-Whitney":
         logger.info("P-values were determined by two-sided Mann-Whitney U test.")

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -9,6 +9,7 @@ import seaborn as sns
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
 from matplotlib.patches import Patch
+from matplotlib.textpath import TextPath
 from scipy import stats
 
 import cnsplots._utils as utils
@@ -27,6 +28,38 @@ LollipopError = float | tuple[float, float]
 
 _LOLLIPOP_BOOTSTRAP_SAMPLES = 1000
 _LOLLIPOP_BOOTSTRAP_SEED = 0
+_BAR_LABEL_PADDING = 2
+_BAR_LABEL_PVALUE_GAP = 2
+_DEFAULT_PVALUE_GROUP_OFFSET = 0.06
+
+
+def _bar_label_pvalue_clearance(
+    ax: Axes,
+    labels: list[Any],
+    *,
+    orient: str,
+) -> float:
+    """Return enough axes-relative clearance for p-values above bar labels."""
+    visible_labels = [label for label in labels if label.get_text()]
+    if orient == "v":
+        label_extent = max(label.get_fontsize() for label in visible_labels)
+        axes_extent = ax.bbox.height * 72 / ax.figure.dpi
+    else:
+        label_extent = max(
+            TextPath(
+                (0, 0),
+                label.get_text(),
+                prop=label.get_fontproperties(),
+            )
+            .get_extents()
+            .width
+            for label in visible_labels
+        )
+        axes_extent = ax.bbox.width * 72 / ax.figure.dpi
+    required_clearance = (
+        label_extent + _BAR_LABEL_PADDING + _BAR_LABEL_PVALUE_GAP
+    ) / axes_extent
+    return max(_DEFAULT_PVALUE_GROUP_OFFSET, required_clearance)
 
 
 def _resolve_palette_column(
@@ -313,6 +346,7 @@ def barplot(
     if ax is None:
         ax = plt.gca()
     ax = sns.barplot(ax=ax, **plotting)
+    bar_labels = []
     if add_tip:
         for container in (
             item for item in ax.containers if isinstance(item, BarContainer)
@@ -321,15 +355,32 @@ def barplot(
                 "" if pd.isna(value) else str(round(value, 2))
                 for value in container.datavalues
             ]
-            ax.bar_label(
-                container,
-                labels=labels,
-                padding=2,
-                color="black",
-                fontsize=_legend_fontsize(),
+            bar_labels.extend(
+                ax.bar_label(
+                    container,
+                    labels=labels,
+                    padding=_BAR_LABEL_PADDING,
+                    color="black",
+                    fontsize=_legend_fontsize(),
+                )
             )
     if pairs is not None:
-        utils._p_value_helper("t-test_welch", data, ax, plotting, pairs)
+        pvalue_kwargs = {}
+        if bar_labels:
+            orient = "h" if pd.api.types.is_numeric_dtype(data[x]) else "v"
+            pvalue_kwargs["label_clearance"] = _bar_label_pvalue_clearance(
+                ax,
+                bar_labels,
+                orient=orient,
+            )
+        utils._p_value_helper(
+            "t-test_welch",
+            data,
+            ax,
+            plotting,
+            pairs,
+            **pvalue_kwargs,
+        )
     if show_legend:
         ax.legend(
             handles=legend_handles,

--- a/tests/test_plot_behavior_regressions.py
+++ b/tests/test_plot_behavior_regressions.py
@@ -8,7 +8,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.collections import LineCollection, PathCollection
+from matplotlib.container import BarContainer
 from matplotlib.patches import Rectangle
 from scipy import stats
 
@@ -171,6 +173,41 @@ def test_barplot_labels_each_hue_bar_and_skips_missing_order_levels() -> None:
         "2.0",
         "6.0",
     ]
+
+
+@pytest.mark.parametrize(("x", "y"), [("group", "value"), ("value", "group")])
+def test_barplot_pvalues_do_not_overlap_value_labels(
+    categorical_df: pd.DataFrame,
+    x: str,
+    y: str,
+) -> None:
+    cns.figure(100, 150)
+    ax = cast(Any, cns.barplot)(
+        categorical_df,
+        x=x,
+        y=y,
+        pairs="all",
+        add_tip=True,
+    )
+
+    ax.figure.canvas.draw()
+    renderer = cast(FigureCanvasAgg, ax.figure.canvas).get_renderer()
+    label_count = sum(
+        len(cast(Any, container.datavalues))
+        for container in ax.containers
+        if isinstance(container, BarContainer)
+    )
+    label_bounds = [text.get_window_extent(renderer) for text in ax.texts[:label_count]]
+    pvalue_bounds = [
+        artist.get_window_extent(renderer)
+        for artist in [*ax.lines, *ax.texts[label_count:]]
+    ]
+
+    assert not any(
+        label_bound.overlaps(pvalue_bound)
+        for label_bound in label_bounds
+        for pvalue_bound in pvalue_bounds
+    )
 
 
 def test_lollipop_rejects_ambiguous_palette_column_combinations() -> None:


### PR DESCRIPTION
## Purpose

Prevent bar value labels from crossing p-value brackets and annotation text when `add_tip=True` and statistical comparisons are shown together.

## Changes

- Measure the value-label extent for vertical and horizontal bar plots.
- Reserve label-aware clearance before drawing p-value annotations, accounting for the axis expansion caused by stacked comparisons.
- Add regression coverage that checks value labels against both p-value lines and text.

## Root cause

The p-value annotation layout started from bar heights and did not account for the fixed-size text drawn above or beside each bar. Stacking comparisons then expanded the value axis and reduced the visible clearance further.

## Testing

- `make test` — 429 tests passed with 100% coverage.
- `make lint` — all formatting, linting, type-checking, and repository hooks passed.
- Reproduced the affected gallery example and verified that the annotation bounding boxes no longer overlap.

## Risks and follow-ups

Risk is limited to p-value spacing when bar value labels are enabled. Bar plots without value labels and outside p-value annotations retain their existing layout. No follow-up work is required.
