### PR TITLE
✨ Add regplot equation annotations

### DIFF
--- a/examples/regplot.py
+++ b/examples/regplot.py
@@ -113,27 +113,6 @@ for i, day in enumerate(["Thur", "Fri", "Sat", "Sun"]):
 
 
 # %%
-# Regression plot with correlation statistics
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Add correlation coefficient and p-value annotation.
-cns.figure(150, 150)
-ax = cns.regplot(data=tips, x="tip", y="total_bill", s=5)
-
-r, p = stats.pearsonr(tips["tip"], tips["total_bill"])
-ax.text(
-    0.05,
-    0.95,
-    f"r = {r:.3f}\np = {p:.2e}",
-    transform=ax.transAxes,
-    fontsize=7,
-    verticalalignment="top",
-    bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
-)
-
-ax.set_title("With Correlation Stats")
-
-
-# %%
 # Regression plot for iris data
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Apply to a different dataset.
@@ -148,19 +127,7 @@ ax.set_title("Petal Dimensions by Species")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Show the regression equation on the plot.
 cns.figure(150, 150)
-ax = cns.regplot(data=tips, x="tip", y="total_bill", s=5)
-
-# Calculate regression parameters
-slope, intercept, r, p, se = stats.linregress(tips["tip"], tips["total_bill"])
-ax.text(
-    0.05,
-    0.95,
-    f"y = {slope:.2f}x + {intercept:.2f}\nR² = {r**2:.3f}",
-    transform=ax.transAxes,
-    fontsize=7,
-    verticalalignment="top",
-    bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
-)
+ax = cns.regplot(data=tips, x="tip", y="total_bill", s=5, add_equation=True)
 
 ax.set_title("With Regression Equation")
 ax.set_xlabel("Tip ($)")

--- a/src/cnsplots/plots/_regression.py
+++ b/src/cnsplots/plots/_regression.py
@@ -12,7 +12,7 @@ from matplotlib.axes import Axes
 from matplotlib.typing import ColorType
 from palettable.colorbrewer.colorbrewer import get_map as _get_brewer_map
 
-from cnsplots._utils import _resize_legend_markers
+from cnsplots._utils import _resize_legend_markers, take_legend_out
 from cnsplots._validation import (
     validate_column_type,
     validate_columns_exist,
@@ -61,6 +61,38 @@ def _correlation_statistics(
     return float(result.statistic), float(result.pvalue)
 
 
+def _add_regression_equation(
+    ax: Axes,
+    data: pd.DataFrame,
+    x: str,
+    y: str,
+    *,
+    color: ColorType,
+    y_position: float = 0.05,
+    label: Any = None,
+) -> None:
+    """Add a fitted linear equation to the bottom-right of an axes."""
+    result = sp.stats.linregress(data[x], data[y])
+    intercept = f"{result.intercept:+.2f}"
+    label_prefix = "" if label is None else f"{label}: "
+    ax.text(
+        0.95,
+        y_position,
+        f"{label_prefix}y = {result.slope:.2f}x {intercept[0]} {intercept[1:]}\n"
+        f"R² = {result.rvalue**2:.3f}",
+        color=color,
+        transform=ax.transAxes,
+        ha="right",
+        va="bottom",
+        bbox=dict(
+            boxstyle="round",
+            facecolor="white",
+            edgecolor="none",
+            alpha=1,
+        ),
+    )
+
+
 def regplot(
     data: pd.DataFrame,
     x: str,
@@ -70,6 +102,7 @@ def regplot(
     color: ColorType = "black",
     *,
     method: CorrelationMethod = "pearson",
+    add_equation: bool = False,
     hue_order: list[str] | None = None,
     ax: Axes | None = None,
     **kwargs: Any,
@@ -103,6 +136,10 @@ def regplot(
     method : {"pearson", "spearman"}, default: "pearson"
         Correlation method used for the coefficient and p-value annotation.
         The fitted regression line remains linear for both methods.
+    add_equation : bool, default: False
+        Whether to annotate each fitted line's equation and R-squared value in
+        the bottom-right of the axes. When a legend is present, it is moved
+        outside the axes to avoid covering the equation annotation.
     hue_order : list of str, optional
         Order of hue levels.
     ax : matplotlib.axes.Axes, optional
@@ -135,6 +172,9 @@ def regplot(
 
     >>> # Report Spearman rank correlation
     >>> ax = cns.regplot(data=df, x="dose", y="response", method="spearman")
+
+    >>> # Add the fitted equation and R-squared value
+    >>> ax = cns.regplot(data=df, x="dose", y="response", add_equation=True)
     """
     # Validate inputs
     validate_dataframe(data, "data", "regplot")
@@ -194,7 +234,19 @@ def regplot(
                 ha="left",
                 va="top",
             )
+            if add_equation:
+                _add_regression_equation(
+                    ax,
+                    subset,
+                    x,
+                    y,
+                    color=palette[idx % len(palette)],
+                    y_position=0.05 + 0.18 * idx,
+                    label=hue_val,
+                )
         ax.legend(title=hue)
+        if add_equation:
+            take_legend_out(ax=ax)
     elif color_is_column:
         plot_data = finite_data.loc[finite_data[color].notna()]
         _validate_correlation_sample_size(plot_data, method)
@@ -231,10 +283,14 @@ def regplot(
             ha="left",
             va="top",
         )
+        if add_equation:
+            _add_regression_equation(ax, plot_data, x, y, color="black")
         ax.legend(title=color)
         _resize_legend_markers(
             ax.get_legend(), 2 * s, marker_size=2 * np.sqrt(s / np.pi)
         )
+        if add_equation:
+            take_legend_out(ax=ax)
     else:
         _validate_correlation_sample_size(finite_data, method)
         ax = sns.regplot(
@@ -256,6 +312,8 @@ def regplot(
             ha="left",
             va="top",
         )
+        if add_equation:
+            _add_regression_equation(ax, finite_data, x, y, color=color)
 
     return ax
 

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -410,7 +410,7 @@ def test_public_stackplot_signature_contract() -> None:
         ("histplot", {"hue", "hue_order"}, set()),
         ("scatterplot", {"hue", "hue_order"}, set()),
         ("lineplot", {"hue", "hue_order"}, set()),
-        ("regplot", {"hue", "hue_order", "method"}, set()),
+        ("regplot", {"add_equation", "hue", "hue_order", "method"}, set()),
         ("slopeplot", {"hue", "hue_order"}, set()),
         ("dumbbellplot", {"hue", "hue_order", "order"}, set()),
     ],

--- a/tests/test_regression_plot_defects.py
+++ b/tests/test_regression_plot_defects.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.collections import PathCollection
 
 import cnsplots as cns
@@ -56,6 +57,46 @@ def test_regplot_supports_spearman_correlation(grouping: str | None) -> None:
 
     assert ax.texts
     assert all(r"$\rho$=1.00," in text.get_text() for text in ax.texts)
+
+
+@pytest.mark.parametrize("grouping", [None, "hue", "color"])
+def test_regplot_can_add_regression_equations(grouping: str | None) -> None:
+    data = pd.DataFrame(
+        {
+            "x": [0.0, 1.0, 0.0, 1.0],
+            "y": [1.0, 3.0, -2.0, 1.0],
+            "group": ["A", "A", "B", "B"],
+        }
+    )
+
+    cns.figure(120, 120)
+    kwargs: dict[str, Any] = {"add_equation": True}
+    if grouping is not None:
+        kwargs[grouping] = "group"
+    ax = cns.regplot(data, x="x", y="y", **kwargs)
+
+    equations = [text for text in ax.texts if "y =" in text.get_text()]
+    assert len(equations) == (2 if grouping == "hue" else 1)
+    assert equations[0].get_position() == (0.95, 0.05)
+    assert equations[0].get_horizontalalignment() == "right"
+    assert equations[0].get_verticalalignment() == "bottom"
+    patch = equations[0].get_bbox_patch()
+    assert patch is not None
+    assert patch.get_alpha() == 1
+    assert patch.get_facecolor()[-1] == 1
+    assert patch.get_edgecolor()[-1] == 0
+    if grouping == "hue":
+        assert equations[0].get_text() == "A: y = 2.00x + 1.00\nR² = 1.000"
+        assert equations[1].get_text() == "B: y = 3.00x - 2.00\nR² = 1.000"
+        assert equations[1].get_position() == pytest.approx((0.95, 0.23))
+    if grouping is not None:
+        legend = ax.get_legend()
+        assert legend is not None
+        ax.figure.canvas.draw()
+        renderer = cast(FigureCanvasAgg, ax.figure.canvas).get_renderer()
+        assert (
+            legend.get_window_extent(renderer).x0 >= ax.get_window_extent(renderer).x1
+        )
 
 
 def test_regplot_rejects_unknown_correlation_method() -> None:


### PR DESCRIPTION
## Goal

Make regression equations available directly through `regplot` and simplify the gallery example to demonstrate the public API.

## Changes

- Add the opt-in `add_equation` parameter to annotate fitted equations and R-squared values.
- Support ungrouped, color-mapped, and hue-grouped regressions with opaque, borderless bottom-right annotations.
- Move legends outside the axes when equation annotations would otherwise overlap them.
- Remove the redundant custom correlation-statistics example and update the equation example to use `add_equation=True`.
- Add behavior and public API contract coverage.

## Testing

- `make test` — 432 passed with 100% coverage.
- `make lint` — passed.

## Risks and follow-ups

The feature is opt-in, so existing plots retain their current behavior. No follow-up work is required.
