### PR TITLE
✨ Add configurable plot statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,10 @@ cns.boxplot(
     x="day",
     y="total_bill",
     pairs=[("Thur", "Fri"), ("Sat", "Sun")],  # Compare these pairs
+    test="t-test_welch",
+    p_adjust="holm",
 )
-# Prints: P-values were determined by two-sided Mann-Whitney U test.
+# Prints: P-values were determined by two-sided Welch's t-test.
 ```
 
 ### Custom Colors
@@ -241,14 +243,35 @@ blue = cns.BLUE
 Many plot functions include built-in statistical testing:
 
 ```python
-# Boxplot with Mann-Whitney U test
-cns.boxplot(data=df, x="group", y="value", pairs="all")
+# Boxplot with Mann-Whitney U test and Holm correction
+cns.boxplot(
+    data=df,
+    x="group",
+    y="value",
+    pairs="all",
+    test="Mann-Whitney",
+    p_adjust="holm",
+)
 
-# Barplot with Welch's t-test
-cns.barplot(data=df, x="group", y="value", pairs=[("A", "B")])
+# Barplot with Mann-Whitney U test and false-discovery-rate correction
+cns.barplot(
+    data=df,
+    x="group",
+    y="value",
+    pairs=[("A", "B"), ("A", "C")],
+    test="Mann-Whitney",
+    p_adjust="fdr_bh",
+)
 
-# Stackplot with Fisher's exact test
-cns.stackplot(data=df, x="group", stack="category", pairs=[("A", "B")])
+# Stackplot with an explicit chi-squared test and Bonferroni correction
+cns.stackplot(
+    data=df,
+    x="group",
+    stack="category",
+    pairs="all",
+    test="chi-squared",
+    p_adjust="bonferroni",
+)
 ```
 
 ### Export for Publication

--- a/examples/barplot.py
+++ b/examples/barplot.py
@@ -107,23 +107,35 @@ cns.barplot(data=tips, x="day", y="total_bill", palette=cols)
 # %%
 # Statistical comparisons (all pairs)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Add significance annotations for all pairwise comparisons.
+# Apply Benjamini-Hochberg correction across all pairwise Welch tests.
 cns.figure(100, 150, "Tableau")
-cns.barplot(data=tips, x="day", y="total_bill", pairs="all", add_tip=True)
+ax = cns.barplot(
+    data=tips,
+    x="day",
+    y="total_bill",
+    pairs="all",
+    test="t-test_welch",
+    p_adjust="fdr_bh",
+    add_tip=True,
+)
+ax.set_title("Welch Tests with FDR Correction")
 
 
 # %%
 # Statistical comparisons (specific pairs)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Compare only selected pairs of groups.
+# Switch to Mann-Whitney U and apply a Bonferroni correction.
 cns.figure(100, 150, "Set1")
-cns.barplot(
+ax = cns.barplot(
     data=tips,
     x="day",
     y="total_bill",
     pairs=[("Thur", "Fri"), ("Sat", "Sun")],
+    test="Mann-Whitney",
+    p_adjust="bonferroni",
     add_tip=True,
 )
+ax.set_title("Mann-Whitney with Bonferroni")
 
 
 # %%

--- a/examples/boxplot.py
+++ b/examples/boxplot.py
@@ -91,7 +91,7 @@ for index in range(tips["day"].nunique()):
 # %%
 # Boxplot with statistical comparisons (all pairs)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``pairs="all"`` to perform Mann-Whitney U tests between all groups.
+# Select Mann-Whitney U explicitly and use Holm correction across all pairs.
 # The ``add_count=True`` parameter adds sample sizes below each box.
 with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
     cns.figure(100, 150)
@@ -100,15 +100,17 @@ with cns.settings.context(pvalue_format="threshold", pvalue_fontsize=8):
         x="species",
         y="sepal_width",
         pairs="all",
+        test="Mann-Whitney",
+        p_adjust="holm",
         add_count=True,
     )
-ax.set_title("All Pairwise Comparisons\nwith Sample Counts")
+ax.set_title("Holm-Corrected Comparisons\nwith Sample Counts")
 
 
 # %%
 # Boxplot with specific pair comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Test only specific pairs by providing a list of tuples.
+# Test only specific pairs with Welch's t-test and control the false discovery rate.
 with cns.settings.context(pvalue_format="full", pvalue_fontsize=8):
     cns.figure(100, 150)
     ax = cns.boxplot(
@@ -116,8 +118,10 @@ with cns.settings.context(pvalue_format="full", pvalue_fontsize=8):
         x="species",
         y="sepal_width",
         pairs=[("setosa", "virginica"), ("versicolor", "virginica")],
+        test="t-test_welch",
+        p_adjust="fdr_bh",
     )
-ax.set_title("Selected Pair Comparisons")
+ax.set_title("Welch Tests with FDR Correction")
 
 
 # %%

--- a/examples/lollipopplot.py
+++ b/examples/lollipopplot.py
@@ -78,14 +78,17 @@ cns.take_legend_out()
 # %%
 # Statistical comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~
-# Add significance annotations for specific pairs.
+# Select Mann-Whitney U and apply Holm correction across the requested pairs.
 cns.figure(100, 150, "Set1")
-cns.lollipopplot(
+ax = cns.lollipopplot(
     data=tips,
     x="day",
     y="total_bill",
     pairs=[("Thur", "Fri"), ("Sat", "Sun")],
+    test="Mann-Whitney",
+    p_adjust="holm",
 )
+ax.set_title("Mann-Whitney with Holm Correction")
 
 
 # %%

--- a/examples/stackplot.py
+++ b/examples/stackplot.py
@@ -50,8 +50,8 @@ ax.set_title("Stacked Bar with Counts")
 # %%
 # Stacked bar plot with Fisher's exact test
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``pairs`` to test if proportions differ significantly between groups.
-# Fisher's exact test is used for 2x2 contingency tables.
+# Select Fisher's exact test for the 2x2 contingency tables and apply Holm
+# correction across the requested pairs.
 cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips,
@@ -59,14 +59,16 @@ ax = cns.stackplot(
     stack="sex",
     normalize=True,
     pairs=[("Thur", "Fri"), ("Fri", "Sat")],
+    test="fisher-exact",
+    p_adjust="holm",
 )
-ax.set_title("With Selected Statistical Comparisons")
+ax.set_title("Fisher Tests with Holm Correction")
 
 
 # %%
 # Stacked bar plot with custom stack order
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Control the order of stacked segments with ``stack_order``.
+# Control the stack order and explicitly use chi-squared for the 2x4 table.
 cns.figure(100, 120)
 ax = cns.stackplot(
     data=tips,
@@ -75,17 +77,25 @@ ax = cns.stackplot(
     normalize=True,
     stack_order=["Sun", "Sat", "Fri", "Thur"],
     pairs=[("Male", "Female")],
+    test="chi-squared",
 )
-ax.set_title("Custom Stack Order")
+ax.set_title("Explicit Chi-Squared Test")
 
 
 # %%
 # Stacked bar plot with all pairwise comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``pairs="all"`` to test all possible pairs.
+# Use ``pairs="all"`` and control the false discovery rate across every test.
 cns.figure(100, 150, "Tableau")
-ax = cns.stackplot(data=tips, x="day", stack="sex", normalize=True, pairs="all")
-ax.set_title("All Pairwise Comparisons")
+ax = cns.stackplot(
+    data=tips,
+    x="day",
+    stack="sex",
+    normalize=True,
+    pairs="all",
+    p_adjust="fdr_bh",
+)
+ax.set_title("All Pairs with FDR Correction")
 
 
 # %%

--- a/examples/violinplot.py
+++ b/examples/violinplot.py
@@ -31,24 +31,33 @@ ax.set_title("Basic Violin Plot")
 # %%
 # Violin plot with statistical testing
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``pairs="all"`` for Mann-Whitney U tests between all groups.
+# Use ``pairs="all"`` with Holm correction for all Mann-Whitney U tests.
 cns.figure(100, 150, "Tableau")
-ax = cns.violinplot(data=tips, x="day", y="total_bill", pairs="all")
-ax.set_title("Violin Plot with All Pairwise Comparisons")
+ax = cns.violinplot(
+    data=tips,
+    x="day",
+    y="total_bill",
+    pairs="all",
+    test="Mann-Whitney",
+    p_adjust="holm",
+)
+ax.set_title("Holm-Corrected Pairwise Comparisons")
 
 
 # %%
 # Violin plot with specific pair comparisons
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Test only selected pairs.
+# Test selected pairs with Welch's t-test and Benjamini-Hochberg correction.
 cns.figure(100, 150)
 ax = cns.violinplot(
     data=iris,
     x="species",
     y="sepal_length",
     pairs=[("setosa", "versicolor"), ("setosa", "virginica")],
+    test="t-test_welch",
+    p_adjust="fdr_bh",
 )
-ax.set_title("Selected Pair Comparisons")
+ax.set_title("Welch Tests with FDR Correction")
 
 
 # %%

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -74,6 +74,7 @@ _ContinuousPaletteName = Literal[
     "parula",
 ]
 _RGBColor = tuple[float, float, float]
+_P_ADJUST_METHODS = ("bonferroni", "holm", "fdr_bh", "fdr_by")
 
 RED = "#D6372E"
 BLUE = "#5189BB"
@@ -785,6 +786,15 @@ def _add_count_helper(data, attr, ax, axis="x"):
     set_ticklabels(new_tick_labels)
 
 
+def _validate_statistical_options(test, p_adjust, *, valid_tests):
+    if test not in valid_tests:
+        choices = ", ".join(repr(value) for value in valid_tests)
+        raise ValueError(f"test must be one of: {choices}")
+    if p_adjust is not None and p_adjust not in _P_ADJUST_METHODS:
+        choices = ", ".join(repr(value) for value in _P_ADJUST_METHODS)
+        raise ValueError(f"p_adjust must be one of: {choices}, or None")
+
+
 def _p_value_helper(
     test,
     data,
@@ -794,6 +804,7 @@ def _p_value_helper(
     contingency=None,
     format=None,
     label_clearance=None,
+    p_adjust=None,
 ):
     resolved_format = settings.pvalue_format if format is None else format
     if resolved_format not in {"star", "threshold", "full"}:
@@ -923,6 +934,7 @@ def _p_value_helper(
     annotator._pvalue_format = PValueFormatNew()
     annotator.configure(
         test=test if contingency is None else None,
+        comparisons_correction=p_adjust,
         text_format="full" if resolved_format == "full" else "star",
         loc=settings.pvalue_loc,
         line_width=0.5,

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Union, cast
+from typing import Any, Literal, Union, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -241,6 +241,8 @@ def barplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
+    test: Literal["Mann-Whitney", "t-test_welch"] = "t-test_welch",
+    p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
@@ -270,6 +272,10 @@ def barplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
+    test : {'Mann-Whitney', 't-test_welch'}, default: 't-test_welch'
+        Statistical test used for pairwise comparisons.
+    p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
+        Multiple-comparison correction applied across the resolved pairs.
     ax : matplotlib.axes.Axes, optional
         Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
@@ -294,6 +300,8 @@ def barplot(
     ...     x="treatment",
     ...     y="response",
     ...     pairs=[("control", "drug_a"), ("control", "drug_b")],
+    ...     test="Mann-Whitney",
+    ...     p_adjust="holm",
     ...     add_tip=True,
     ... )
     >>> ax.set_title("Treatment Response")
@@ -307,6 +315,11 @@ def barplot(
     columns = [x, y] if hue is None else [x, y, hue]
     validate_columns_exist(data, columns, "barplot")
     validate_dataframe_not_empty(data, "barplot")
+    utils._validate_statistical_options(
+        test,
+        p_adjust,
+        valid_tests=("Mann-Whitney", "t-test_welch"),
+    )
 
     if "addtip" in kwargs:
         raise TypeError(
@@ -374,11 +387,12 @@ def barplot(
                 orient=orient,
             )
         utils._p_value_helper(
-            "t-test_welch",
+            test,
             data,
             ax,
             plotting,
             pairs,
+            p_adjust=p_adjust,
             **pvalue_kwargs,
         )
     if show_legend:
@@ -411,6 +425,8 @@ def lollipopplot(
     palette: Any = None,
     baseline: float = 0,
     *,
+    test: Literal["Mann-Whitney", "t-test_welch"] = "t-test_welch",
+    p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
 ) -> Axes:
     """
@@ -462,6 +478,10 @@ def lollipopplot(
         or a column name in data for palette-as-column mapping.
     baseline : float, default: 0
         Value at which the stems originate.
+    test : {'Mann-Whitney', 't-test_welch'}, default: 't-test_welch'
+        Statistical test used for pairwise comparisons.
+    p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
+        Multiple-comparison correction applied across the resolved pairs.
     ax : matplotlib.axes.Axes, optional
         Axes on which to draw the plot. Defaults to the current Axes.
 
@@ -479,7 +499,13 @@ def lollipopplot(
     Examples
     --------
     >>> import cnsplots as cns
-    >>> ax = cns.lollipopplot(data=df, x="treatment", y="response")
+    >>> ax = cns.lollipopplot(
+    ...     data=df,
+    ...     x="treatment",
+    ...     y="response",
+    ...     pairs="all",
+    ...     p_adjust="fdr_bh",
+    ... )
     >>> ax.set_title("Treatment Response")
 
     >>> # Horizontal lollipop plot
@@ -498,6 +524,11 @@ def lollipopplot(
         raise ValueError("estimator must be one of: 'mean', 'median'")
     if errorbar not in {None, "se", "sd", "ci"}:
         raise ValueError("errorbar must be one of: 'se', 'sd', 'ci', or None")
+    utils._validate_statistical_options(
+        test,
+        p_adjust,
+        valid_tests=("Mann-Whitney", "t-test_welch"),
+    )
 
     palette_is_column = isinstance(palette, str) and palette in data.columns
     if hue is not None and palette_is_column and palette != hue:
@@ -643,7 +674,14 @@ def lollipopplot(
             plotting["hue"] = hue
         if hue_order is not None:
             plotting["hue_order"] = hue_order
-        utils._p_value_helper("t-test_welch", data, ax, plotting, pairs)
+        utils._p_value_helper(
+            test,
+            data,
+            ax,
+            plotting,
+            pairs,
+            p_adjust=p_adjust,
+        )
 
     # Legend
     if show_legend:
@@ -858,6 +896,8 @@ def stackplot(
     width: float = 0.5,
     normalize: bool = True,
     pairs: list[tuple[str, str]] | None = None,
+    test: Literal["auto", "fisher-exact", "chi-squared"] = "auto",
+    p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     add_count: bool = False,
     n_factor: int | float = 1,
     ax: Axes | None = None,
@@ -895,6 +935,11 @@ def stackplot(
     pairs : list of tuple of str, optional
         List of pairs of bar-category names for pairwise statistical comparisons
         from the selected bar variable.
+    test : {'auto', 'fisher-exact', 'chi-squared'}, default: 'auto'
+        Statistical test used for pairwise comparisons. Automatic selection uses
+        Fisher's exact test for two stack levels and chi-squared otherwise.
+    p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
+        Multiple-comparison correction applied across the resolved pairs.
     add_count : bool, default: False
         Whether to append total counts to the category tick labels in the
         format ``n=...``.
@@ -923,6 +968,8 @@ def stackplot(
     ...     stack="cell_type",
     ...     normalize=True,
     ...     pairs=[("lung", "liver")],
+    ...     test="chi-squared",
+    ...     p_adjust="holm",
     ... )
     >>> ax.set_title("Cell Type Distribution by Tissue")
 
@@ -938,6 +985,11 @@ def stackplot(
     assert bar is not None
     validate_columns_exist(data, [bar, stack], "stackplot")
     validate_dataframe_not_empty(data, "stackplot")
+    utils._validate_statistical_options(
+        test,
+        p_adjust,
+        valid_tests=("auto", "fisher-exact", "chi-squared"),
+    )
 
     data2 = data.value_counts([bar, stack]).reset_index()
     df = data2.pivot(index=bar, columns=stack, values="count")
@@ -974,14 +1026,20 @@ def stackplot(
             plotting = {"data": data2, "x": "count", "y": bar, "order": order}
         else:
             plotting = {"data": data2, "x": bar, "y": "count", "order": order}
-        if contingency.shape[1] == 2:
-            utils._p_value_helper(
-                "fisher-exact", data2, ax, plotting, pairs, contingency
-            )
-        else:
-            utils._p_value_helper(
-                "chi-squared", data2, ax, plotting, pairs, contingency
-            )
+        resolved_test = (
+            ("fisher-exact" if contingency.shape[1] == 2 else "chi-squared")
+            if test == "auto"
+            else test
+        )
+        utils._p_value_helper(
+            resolved_test,
+            data2,
+            ax,
+            plotting,
+            pairs,
+            contingency,
+            p_adjust=p_adjust,
+        )
 
     return ax
 

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Literal
 
 import matplotlib as mpl
 import matplotlib.patches  # noqa: F401  # ensure submodule is importable for isinstance checks
@@ -39,6 +39,8 @@ def boxplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
+    test: Literal["Mann-Whitney", "t-test_welch"] = "Mann-Whitney",
+    p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
@@ -73,6 +75,10 @@ def boxplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
+    test : {'Mann-Whitney', 't-test_welch'}, default: 'Mann-Whitney'
+        Statistical test used for pairwise comparisons.
+    p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
+        Multiple-comparison correction applied across the resolved pairs.
     ax : matplotlib.axes.Axes, optional
         Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
@@ -97,6 +103,8 @@ def boxplot(
     ...     x="treatment",
     ...     y="response",
     ...     pairs=[("control", "treated")],
+    ...     test="t-test_welch",
+    ...     p_adjust="holm",
     ...     showoutliers=True,
     ... )
     >>> ax.set_title("Treatment Response")
@@ -106,6 +114,11 @@ def boxplot(
     columns = [x, y] if hue is None else [x, y, hue]
     validate_columns_exist(data, columns, "boxplot")
     validate_dataframe_not_empty(data, "boxplot")
+    utils._validate_statistical_options(
+        test,
+        p_adjust,
+        valid_tests=("Mann-Whitney", "t-test_welch"),
+    )
 
     if "addcount" in kwargs:
         raise TypeError(
@@ -184,7 +197,14 @@ def boxplot(
         f" correspond to the {whis_str}."
     )
     if pairs is not None:
-        utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
+        utils._p_value_helper(
+            test,
+            data,
+            ax,
+            plotting,
+            pairs,
+            p_adjust=p_adjust,
+        )
 
     if add_count:
         utils._add_count_helper(data, x, ax)
@@ -205,6 +225,8 @@ def violinplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
+    test: Literal["Mann-Whitney", "t-test_welch"] = "Mann-Whitney",
+    p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
     **kwargs: Any,
 ) -> Axes:
@@ -240,6 +262,10 @@ def violinplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
+    test : {'Mann-Whitney', 't-test_welch'}, default: 'Mann-Whitney'
+        Statistical test used for pairwise comparisons.
+    p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
+        Multiple-comparison correction applied across the resolved pairs.
     ax : matplotlib.axes.Axes, optional
         Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
@@ -264,6 +290,7 @@ def violinplot(
     ...     x="condition",
     ...     y="expression",
     ...     pairs=[("control", "treated")],
+    ...     p_adjust="fdr_bh",
     ...     add_box=True,
     ... )
     >>> ax.set_title("Expression by Condition")
@@ -273,6 +300,11 @@ def violinplot(
     columns = [x, y] if hue is None else [x, y, hue]
     validate_columns_exist(data, columns, "violinplot")
     validate_dataframe_not_empty(data, "violinplot")
+    utils._validate_statistical_options(
+        test,
+        p_adjust,
+        valid_tests=("Mann-Whitney", "t-test_welch"),
+    )
 
     if "addcount" in kwargs:
         raise TypeError(
@@ -321,7 +353,14 @@ def violinplot(
     if add_box:
         sns.boxplot(ax=ax, **boxplot_kwargs)
     if pairs is not None:
-        utils._p_value_helper("Mann-Whitney", data, ax, plotting, pairs)
+        utils._p_value_helper(
+            test,
+            data,
+            ax,
+            plotting,
+            pairs,
+            p_adjust=p_adjust,
+        )
 
     if add_count:
         utils._add_count_helper(data, x, ax)

--- a/tests/test_statistical_options.py
+++ b/tests/test_statistical_options.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, cast
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+_CONTINUOUS_PLOTS = ("boxplot", "violinplot", "barplot", "lollipopplot")
+_P_ADJUST_METHODS = ("bonferroni", "holm", "fdr_bh", "fdr_by")
+
+
+@pytest.mark.parametrize(
+    ("plot_name", "default_test"),
+    [
+        ("boxplot", "Mann-Whitney"),
+        ("violinplot", "Mann-Whitney"),
+        ("barplot", "t-test_welch"),
+        ("lollipopplot", "t-test_welch"),
+        ("stackplot", "auto"),
+    ],
+)
+def test_statistical_options_are_keyword_only(
+    plot_name: str,
+    default_test: str,
+) -> None:
+    parameters = inspect.signature(getattr(cns, plot_name)).parameters
+
+    assert parameters["test"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["test"].default == default_test
+    assert parameters["p_adjust"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["p_adjust"].default is None
+
+
+@pytest.mark.parametrize("plot_name", _CONTINUOUS_PLOTS)
+def test_continuous_plots_forward_tests_and_corrections(
+    plot_name: str,
+    categorical_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        cns.utils,
+        "_p_value_helper",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    plotter = getattr(cns, plot_name)
+
+    for test in ("Mann-Whitney", "t-test_welch"):
+        for p_adjust in _P_ADJUST_METHODS:
+            cns.figure(120, 120)
+            plotter(
+                categorical_df,
+                x="group",
+                y="value",
+                pairs=[("A", "B")],
+                test=test,
+                p_adjust=p_adjust,
+            )
+            args, kwargs = calls[-1]
+            assert args[0] == test
+            assert kwargs["p_adjust"] == p_adjust
+            plt.close()
+
+
+@pytest.mark.parametrize(
+    ("plot_name", "expected_test"),
+    [
+        ("boxplot", "Mann-Whitney"),
+        ("violinplot", "Mann-Whitney"),
+        ("barplot", "t-test_welch"),
+        ("lollipopplot", "t-test_welch"),
+    ],
+)
+def test_continuous_plot_defaults_remain_uncorrected(
+    plot_name: str,
+    expected_test: str,
+    categorical_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        cns.utils,
+        "_p_value_helper",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    getattr(cns, plot_name)(
+        categorical_df,
+        x="group",
+        y="value",
+        pairs=[("A", "B")],
+    )
+
+    args, kwargs = calls[0]
+    assert args[0] == expected_test
+    assert kwargs["p_adjust"] is None
+
+
+def test_stackplot_selects_or_overrides_test(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        cns.utils,
+        "_p_value_helper",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    binary = pd.DataFrame(
+        {
+            "group": ["A", "A", "B", "B"],
+            "outcome": ["Yes", "No", "Yes", "No"],
+        }
+    )
+    multiclass = pd.DataFrame(
+        {
+            "group": ["A", "A", "A", "B", "B", "B"],
+            "outcome": ["One", "Two", "Three", "One", "Two", "Three"],
+        }
+    )
+
+    cns.stackplot(binary, x="group", stack="outcome", pairs=[("A", "B")])
+    cns.stackplot(multiclass, x="group", stack="outcome", pairs=[("A", "B")])
+    cns.stackplot(
+        binary,
+        x="group",
+        stack="outcome",
+        pairs=[("A", "B")],
+        test="chi-squared",
+        p_adjust="fdr_bh",
+    )
+    cns.stackplot(
+        multiclass,
+        x="group",
+        stack="outcome",
+        pairs=[("A", "B")],
+        test="fisher-exact",
+        p_adjust="bonferroni",
+    )
+
+    assert [call[0][0] for call in calls] == [
+        "fisher-exact",
+        "chi-squared",
+        "chi-squared",
+        "fisher-exact",
+    ]
+    assert [call[1]["p_adjust"] for call in calls] == [
+        None,
+        None,
+        "fdr_bh",
+        "bonferroni",
+    ]
+
+
+@pytest.mark.parametrize("plot_name", (*_CONTINUOUS_PLOTS, "stackplot"))
+def test_plots_reject_unsupported_statistical_options(
+    plot_name: str,
+    categorical_df: pd.DataFrame,
+) -> None:
+    plotter = getattr(cns, plot_name)
+    plotting = (
+        {"data": categorical_df, "x": "group", "stack": "binary"}
+        if plot_name == "stackplot"
+        else {"data": categorical_df, "x": "group", "y": "value"}
+    )
+
+    with pytest.raises(ValueError, match="test must be one of"):
+        plotter(**plotting, test="unsupported")
+    with pytest.raises(ValueError, match="p_adjust must be one of"):
+        plotter(**plotting, p_adjust="BH")
+
+
+def test_p_value_helper_corrects_all_resolved_pairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyAnnotator:
+        instances: list[DummyAnnotator] = []
+
+        def __init__(self, ax: object, pairs: object, **plotting: object) -> None:
+            self.pairs = list(cast(Any, pairs))
+            self.plotting = plotting
+            self.configured: dict[str, object] = {}
+            self.pvalues: list[float] | None = None
+            self._pvalue_format: object = None
+            self.instances.append(self)
+
+        def configure(self, **kwargs: object) -> None:
+            self.configured = kwargs
+
+        def apply_and_annotate(self) -> None:
+            return None
+
+        def set_pvalues(self, pvalues: list[float]) -> None:
+            self.pvalues = pvalues
+
+        def annotate(self) -> None:
+            return None
+
+    monkeypatch.setattr(cns.utils, "Annotator", DummyAnnotator)
+    data = pd.DataFrame(
+        {
+            "group": [group for group in "ABCDE" for _ in range(2)],
+            "value": list(range(10)),
+        }
+    )
+    _, ax = plt.subplots()
+
+    cns.utils._p_value_helper(
+        "Mann-Whitney",
+        data,
+        ax,
+        {"x": "group", "y": "value"},
+        "all",
+        p_adjust="holm",
+    )
+
+    continuous_annotator = DummyAnnotator.instances[-1]
+    assert len(continuous_annotator.pairs) == 10
+    assert continuous_annotator.configured["comparisons_correction"] == "holm"
+
+    contingency = pd.DataFrame(
+        [[3, 1], [1, 3]],
+        index=pd.Index(["A", "B"]),
+        columns=pd.Index(["Yes", "No"]),
+    )
+    cns.utils._p_value_helper(
+        "fisher-exact",
+        data,
+        ax,
+        {"x": "group", "y": "value"},
+        [("A", "B")],
+        contingency=contingency,
+        p_adjust="fdr_by",
+    )
+
+    contingency_annotator = DummyAnnotator.instances[-1]
+    assert contingency_annotator.configured["test"] is None
+    assert contingency_annotator.configured["comparisons_correction"] == "fdr_by"
+    assert contingency_annotator.pvalues is not None
+    assert len(contingency_annotator.pvalues) == 1


### PR DESCRIPTION
## Goal

Allow users to choose supported pairwise statistical tests and apply multiple-comparison corrections directly from plotting APIs.

## What changed

- Added keyword-only test and p_adjust options to box, violin, bar, lollipop, and stacked-bar plots.
- Forwarded canonical Bonferroni, Holm, Benjamini-Hochberg, and Benjamini-Yekutieli corrections through statannotations for continuous and contingency-table tests.
- Preserved existing defaults, including automatic Fisher versus chi-squared selection for stackplot.
- Added API, validation, forwarding, and pair-expansion tests plus README and gallery examples.

## Testing

- make test: 477 passed with 100% coverage.
- make lint: all hooks passed.
- Executed the five updated gallery scripts headlessly.

## Risks and follow-ups

Existing uncorrected defaults are unchanged. The public API intentionally exposes only the four currently integrated tests and canonical correction names.