### PR TITLE
✨ Add ROC bands and DeLong

### DIFF
--- a/examples/rocplot.py
+++ b/examples/rocplot.py
@@ -60,10 +60,17 @@ ax.set_title("Best Model ROC")
 # %%
 # Two model comparison
 # ~~~~~~~~~~~~~~~~~~~~
-# Compare the two best models.
+# Compare the two best models with pointwise 95% bootstrap confidence bands and
+# a paired, two-sided DeLong test of their AUCs.
 cns.figure(150, 150)
-ax = cns.rocplot(iris, "true_labels", ["model1_prob", "model2_prob"])
-ax.set_title("Top 2 Models")
+ax = cns.rocplot(
+    iris,
+    "true_labels",
+    ["model1_prob", "model2_prob"],
+    ci_show=True,
+    pairs="all",
+)
+ax.set_title("Top 2 Models with Uncertainty")
 cns.take_legend_out()
 
 

--- a/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
+++ b/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
@@ -62,7 +62,8 @@ before plotting.
 
 - `volcanoplot`: effect size versus transformed adjusted significance.
 - `gseaplot`: gene-set enrichment results.
-- `rocplot`: receiver operating characteristic curves.
+- `rocplot`: receiver operating characteristic curves with optional pointwise
+  bootstrap confidence bands and paired DeLong AUC comparisons.
 - `phyloplot`: phylogenetic visualization from `AnnData`.
 - `prerank`: preranked enrichment analysis.
 

--- a/src/cnsplots/helpers/_roc.py
+++ b/src/cnsplots/helpers/_roc.py
@@ -59,18 +59,17 @@ def _delong_auc_covariance(
     negative_ranks = np.vstack([rankdata(row, method="average") for row in negative])
     combined_ranks = np.vstack([rankdata(row, method="average") for row in combined])
 
-    aucs = combined_ranks[:, :n_positive].sum(axis=1) / (
-        n_positive * n_negative
-    ) - (n_positive + 1) / (2 * n_negative)
-    positive_placements = (
-        combined_ranks[:, :n_positive] - positive_ranks
-    ) / n_negative
-    negative_placements = 1 - (
-        combined_ranks[:, n_positive:] - negative_ranks
-    ) / n_positive
-    covariance = np.cov(positive_placements) / n_positive + np.cov(
-        negative_placements
-    ) / n_negative
+    aucs = combined_ranks[:, :n_positive].sum(axis=1) / (n_positive * n_negative) - (
+        n_positive + 1
+    ) / (2 * n_negative)
+    positive_placements = (combined_ranks[:, :n_positive] - positive_ranks) / n_negative
+    negative_placements = (
+        1 - (combined_ranks[:, n_positive:] - negative_ranks) / n_positive
+    )
+    covariance = (
+        np.cov(positive_placements) / n_positive
+        + np.cov(negative_placements) / n_negative
+    )
     return aucs, np.atleast_2d(covariance)
 
 

--- a/src/cnsplots/helpers/_roc.py
+++ b/src/cnsplots/helpers/_roc.py
@@ -1,0 +1,99 @@
+"""Statistical helpers for receiver operating characteristic curves."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import norm, rankdata
+from sklearn.metrics import roc_curve
+
+
+def _bootstrap_roc_confidence_band(
+    y_true: np.ndarray,
+    y_score: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return a deterministic pointwise 95% bootstrap ROC confidence band."""
+    y_true = np.asarray(y_true)
+    y_score = np.asarray(y_score)
+    negative_indices = np.flatnonzero(y_true == 0)
+    positive_indices = np.flatnonzero(y_true == 1)
+    fpr_grid = np.linspace(0, 1, 101)
+    bootstrap_tprs = np.empty((1000, fpr_grid.size))
+    rng = np.random.default_rng(42)
+
+    for bootstrap_index in range(bootstrap_tprs.shape[0]):
+        sample_indices = np.concatenate(
+            [
+                rng.choice(
+                    negative_indices,
+                    size=negative_indices.size,
+                    replace=True,
+                ),
+                rng.choice(
+                    positive_indices,
+                    size=positive_indices.size,
+                    replace=True,
+                ),
+            ]
+        )
+        fpr, tpr, _ = roc_curve(y_true[sample_indices], y_score[sample_indices])
+        bootstrap_tprs[bootstrap_index] = np.interp(fpr_grid, fpr, tpr)
+
+    lower, upper = np.percentile(bootstrap_tprs, [2.5, 97.5], axis=0)
+    return fpr_grid, lower, upper
+
+
+def _delong_auc_covariance(
+    y_true: np.ndarray,
+    predictions: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Estimate correlated ROC AUCs and their DeLong covariance matrix."""
+    y_true = np.asarray(y_true)
+    predictions = np.atleast_2d(np.asarray(predictions, dtype=float))
+    positive = predictions[:, y_true == 1]
+    negative = predictions[:, y_true == 0]
+    n_positive = positive.shape[1]
+    n_negative = negative.shape[1]
+    combined = np.concatenate([positive, negative], axis=1)
+
+    positive_ranks = np.vstack([rankdata(row, method="average") for row in positive])
+    negative_ranks = np.vstack([rankdata(row, method="average") for row in negative])
+    combined_ranks = np.vstack([rankdata(row, method="average") for row in combined])
+
+    aucs = combined_ranks[:, :n_positive].sum(axis=1) / (
+        n_positive * n_negative
+    ) - (n_positive + 1) / (2 * n_negative)
+    positive_placements = (
+        combined_ranks[:, :n_positive] - positive_ranks
+    ) / n_negative
+    negative_placements = 1 - (
+        combined_ranks[:, n_positive:] - negative_ranks
+    ) / n_positive
+    covariance = np.cov(positive_placements) / n_positive + np.cov(
+        negative_placements
+    ) / n_negative
+    return aucs, np.atleast_2d(covariance)
+
+
+def _delong_roc_test(
+    y_true: np.ndarray,
+    first_scores: np.ndarray,
+    second_scores: np.ndarray,
+) -> float:
+    """Return the paired, two-sided DeLong p-value for two ROC AUCs."""
+    aucs, covariance = _delong_auc_covariance(
+        y_true,
+        np.vstack([first_scores, second_scores]),
+    )
+    contrast = np.array([1.0, -1.0])
+    variance = float(contrast @ covariance @ contrast)
+    if variance < 0 and np.isclose(variance, 0, atol=1e-15):
+        variance = 0.0
+    if variance < 0:
+        raise ValueError("DeLong contrast variance must be non-negative.")
+
+    difference = float(aucs[0] - aucs[1])
+    if variance == 0:
+        return 1.0 if np.isclose(difference, 0) else 0.0
+
+    statistic = difference / np.sqrt(variance)
+    return float(2 * norm.sf(abs(statistic)))

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from itertools import combinations
+from typing import Any, Literal
 
 import matplotlib.pyplot as plt
+import num2tex
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -11,7 +13,9 @@ from matplotlib.axes import Axes
 from matplotlib.patches import Circle, FancyBboxPatch, Polygon
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from sklearn.metrics import auc, roc_curve
+from statsmodels.stats.multitest import multipletests
 
+import cnsplots.helpers._roc as helper_roc
 import cnsplots.helpers._sankey as helper_sankey
 from cnsplots._utils import _legend_fontsize
 from cnsplots._validation import (
@@ -32,6 +36,7 @@ _FOREST_PVALUE = "_forest_pvalue"
 _FOREST_GROUP = "_forest_group"
 _FOREST_HUE = "_forest_hue"
 _FOREST_ALL = "__forest_all__"
+_P_ADJUST_METHODS = ("bonferroni", "holm", "fdr_bh", "fdr_by")
 
 
 def placeholderplot(description: str, *, ax: Axes | None = None) -> Axes:
@@ -798,11 +803,85 @@ def forestplot(
     )
 
 
+def _resolve_roc_pairs(
+    pred_prob_cols: list[str],
+    pairs: Literal["all"] | list[tuple[str, str]] | None,
+) -> list[tuple[str, str]]:
+    """Validate and resolve requested ROC comparisons."""
+    if pairs is None:
+        return []
+    if len(set(pred_prob_cols)) != len(pred_prob_cols):
+        raise ValueError(
+            "[rocplot] Prediction columns must be unique when requesting comparisons."
+        )
+    if pairs == "all":
+        if len(pred_prob_cols) < 2:
+            raise ValueError(
+                "[rocplot] pairs='all' requires at least two prediction columns."
+            )
+        return list(combinations(pred_prob_cols, 2))
+    if not isinstance(pairs, list):
+        raise ValueError(
+            "[rocplot] 'pairs' must be a list of tuples, \"all\", or None."
+        )
+
+    resolved_pairs: list[tuple[str, str]] = []
+    seen_pairs: set[frozenset[str]] = set()
+    for pair in pairs:
+        if not isinstance(pair, tuple) or len(pair) != 2:
+            raise ValueError(
+                "[rocplot] Each item in 'pairs' must contain exactly two prediction "
+                "columns as a tuple."
+            )
+        first, second = pair
+        if first == second:
+            raise ValueError(
+                "[rocplot] Comparison pairs must contain two distinct prediction "
+                "columns."
+            )
+        missing = [column for column in pair if column not in pred_prob_cols]
+        if missing:
+            raise ValueError(
+                "[rocplot] Comparison pair contains prediction column(s) not plotted: "
+                f"{missing}."
+            )
+        pair_key = frozenset(pair)
+        if pair_key in seen_pairs:
+            raise ValueError(
+                "[rocplot] Comparison pairs must be unique regardless of order."
+            )
+        seen_pairs.add(pair_key)
+        resolved_pairs.append(pair)
+    return resolved_pairs
+
+
+def _validate_roc_scores(data: pd.DataFrame, columns: list[str]) -> None:
+    """Require complete, finite, real-valued ROC scores."""
+    validate_no_nulls(data, columns, "rocplot")
+    for column in columns:
+        values = data[column]
+        if (
+            not pd.api.types.is_numeric_dtype(values.dtype)
+            or pd.api.types.is_bool_dtype(values.dtype)
+            or np.iscomplexobj(values.to_numpy())
+        ):
+            raise ValueError(
+                f"[rocplot] Column '{column}' must contain real numeric scores."
+            )
+        if not np.isfinite(values.to_numpy(dtype=float)).all():
+            raise ValueError(
+                f"[rocplot] Column '{column}' must contain only finite scores."
+            )
+
+
 def rocplot(
     data: pd.DataFrame,
     true_label_col: str,
     pred_prob_cols: str | list[str],
     *,
+    ci_show: bool = False,
+    pairs: Literal["all"] | list[tuple[str, str]] | None = None,
+    p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
 ) -> Axes:
     """
@@ -816,6 +895,13 @@ def rocplot(
         Column name for the true binary labels (0 or 1).
     pred_prob_cols : str or list of str
         Column name(s) for predicted probabilities.
+    ci_show : bool, default: False
+        Whether to display deterministic pointwise 95% bootstrap confidence bands.
+    pairs : list of tuple of str or {'all'}, optional
+        Prediction-column pairs to compare with paired, two-sided DeLong tests. Use
+        ``'all'`` to compare every plotted pair. No comparisons are run by default.
+    p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
+        Multiple-comparison correction applied across the resolved DeLong tests.
     ax : matplotlib.axes.Axes, optional
         Axes to draw on. If None, uses the current axes.
 
@@ -842,6 +928,9 @@ def rocplot(
     ...     data=df,
     ...     true_label_col="outcome",
     ...     pred_prob_cols=["model_a_prob", "model_b_prob", "model_c_prob"],
+    ...     ci_show=True,
+    ...     pairs="all",
+    ...     p_adjust="holm",
     ... )
     """
     # Validate inputs
@@ -856,14 +945,46 @@ def rocplot(
     validate_columns_exist(data, columns_to_check, "rocplot")
 
     # Validate binary labels
+    validate_no_nulls(data, true_label_col, "rocplot")
     validate_binary_column(data, true_label_col, "rocplot")
+    _validate_roc_scores(data, pred_prob_cols)
+    resolved_pairs = _resolve_roc_pairs(pred_prob_cols, pairs)
+    if p_adjust is not None and p_adjust not in _P_ADJUST_METHODS:
+        choices = ", ".join(repr(value) for value in _P_ADJUST_METHODS)
+        raise ValueError(f"[rocplot] 'p_adjust' must be one of: {choices}, or None.")
+    if resolved_pairs:
+        class_counts = data[true_label_col].value_counts()
+        if (class_counts < 2).any():
+            raise ValueError(
+                "[rocplot] DeLong comparisons require at least two positive and two "
+                "negative observations."
+            )
 
     if ax is None:
         ax = plt.gca()
     for col in pred_prob_cols:
         fpr, tpr, _ = roc_curve(data[true_label_col], data[col])
         roc_auc = auc(fpr, tpr)
-        ax.plot(fpr, tpr, label=f"{col} (AUC={roc_auc:.2f})", linewidth=1)
+        (curve,) = ax.plot(
+            fpr,
+            tpr,
+            label=f"{col} (AUC={roc_auc:.2f})",
+            linewidth=1,
+        )
+        if ci_show:
+            ci_fpr, ci_lower, ci_upper = helper_roc._bootstrap_roc_confidence_band(
+                data[true_label_col].to_numpy(),
+                data[col].to_numpy(),
+            )
+            ax.fill_between(
+                ci_fpr,
+                ci_lower,
+                ci_upper,
+                color=curve.get_color(),
+                alpha=0.2,
+                linewidth=0,
+                zorder=curve.get_zorder() - 1,
+            )
 
     ax.plot([0, 1], [0, 1], color="black", linestyle="--", linewidth=0.8, dashes=(8, 5))
     ax.set_xlim((-0.02, 1.02))
@@ -880,5 +1001,38 @@ def rocplot(
             set_linewidth = getattr(handle, "set_linewidth", None)
             if callable(set_linewidth):
                 set_linewidth(1.7)
+
+    if resolved_pairs:
+        raw_pvalues = [
+            helper_roc._delong_roc_test(
+                data[true_label_col].to_numpy(),
+                data[first].to_numpy(),
+                data[second].to_numpy(),
+            )
+            for first, second in resolved_pairs
+        ]
+        displayed_pvalues = raw_pvalues
+        annotation_header = "DeLong test"
+        if p_adjust is not None:
+            displayed_pvalues = multipletests(raw_pvalues, method=p_adjust)[1].tolist()
+            annotation_header += f" ({p_adjust}-adjusted)"
+        annotation_lines = [annotation_header]
+        annotation_lines.extend(
+            f"{first} vs {second}: P = "
+            + rf"${num2tex.num2tex(pvalue, precision=2):.2g}$"
+            for (first, second), pvalue in zip(
+                resolved_pairs, displayed_pvalues, strict=True
+            )
+        )
+        ax.text(
+            0.02,
+            0.02,
+            "\n".join(annotation_lines),
+            transform=ax.transAxes,
+            ha="left",
+            va="bottom",
+            fontsize=_legend_fontsize(),
+            linespacing=1.25,
+        )
 
     return ax

--- a/tests/test_roc_features.py
+++ b/tests/test_roc_features.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, cast
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.metrics import roc_auc_score
+
+import cnsplots as cns
+from cnsplots.helpers import _roc
+from cnsplots.plots import _specialized
+
+
+def test_rocplot_statistical_options_are_keyword_only() -> None:
+    parameters = inspect.signature(cns.rocplot).parameters
+
+    assert parameters["ci_show"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["ci_show"].default is False
+    assert parameters["pairs"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["pairs"].default is None
+    assert parameters["p_adjust"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["p_adjust"].default is None
+
+
+def test_rocplot_defaults_remain_unchanged(roc_df: pd.DataFrame) -> None:
+    ax = cns.rocplot(roc_df, "truth", ["model_a", "model_b"])
+
+    assert [line.get_label() for line in ax.lines] == [
+        "model_a (AUC=1.00)",
+        "model_b (AUC=1.00)",
+        "_child2",
+    ]
+    assert len(ax.collections) == 0
+    assert len(ax.texts) == 0
+
+
+def test_bootstrap_roc_band_is_deterministic_and_rng_isolated() -> None:
+    y_true = np.array([0] * 8 + [1] * 8)
+    y_score = np.array(
+        [0.1, 0.2, 0.3, 0.35, 0.4, 0.45, 0.6, 0.7]
+        + [0.25, 0.4, 0.5, 0.55, 0.65, 0.75, 0.8, 0.9]
+    )
+    state_before = repr(np.random.get_state())
+
+    first = _roc._bootstrap_roc_confidence_band(y_true, y_score)
+    second = _roc._bootstrap_roc_confidence_band(y_true, y_score)
+
+    assert repr(np.random.get_state()) == state_before
+    for first_values, second_values in zip(first, second, strict=True):
+        np.testing.assert_array_equal(first_values, second_values)
+    fpr, lower, upper = first
+    np.testing.assert_array_equal(fpr, np.linspace(0, 1, 101))
+    assert np.all((0 <= lower) & (lower <= upper) & (upper <= 1))
+
+
+def test_rocplot_draws_one_matching_band_per_curve(
+    roc_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[np.ndarray, np.ndarray]] = []
+
+    def fake_band(
+        y_true: np.ndarray, y_score: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        calls.append((y_true, y_score))
+        return np.array([0.0, 1.0]), np.array([0.0, 0.5]), np.array([0.5, 1.0])
+
+    monkeypatch.setattr(_roc, "_bootstrap_roc_confidence_band", fake_band)
+
+    ax = cns.rocplot(
+        roc_df,
+        "truth",
+        ["model_a", "model_b"],
+        ci_show=True,
+    )
+
+    assert len(calls) == 2
+    assert len(ax.collections) == 2
+    for curve, band in zip(ax.lines[:2], ax.collections, strict=True):
+        np.testing.assert_allclose(
+            cast(Any, band.get_facecolor()[0]),
+            cast(Any, mcolors.to_rgba(curve.get_color(), alpha=0.2)),
+        )
+        assert band.get_zorder() == curve.get_zorder() - 1
+
+
+def _slow_delong_reference(
+    y_true: np.ndarray, predictions: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    positive = predictions[:, y_true == 1]
+    negative = predictions[:, y_true == 0]
+    positive_placements = np.empty_like(positive, dtype=float)
+    negative_placements = np.empty_like(negative, dtype=float)
+    for model_index in range(predictions.shape[0]):
+        placements = (
+            (positive[model_index, :, None] > negative[model_index, None, :])
+            + 0.5
+            * (positive[model_index, :, None] == negative[model_index, None, :])
+        )
+        positive_placements[model_index] = placements.mean(axis=1)
+        negative_placements[model_index] = placements.mean(axis=0)
+    aucs = positive_placements.mean(axis=1)
+    covariance = np.cov(positive_placements) / positive.shape[1] + np.cov(
+        negative_placements
+    ) / negative.shape[1]
+    return aucs, covariance
+
+
+def test_fast_delong_matches_tie_aware_reference() -> None:
+    y_true = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    predictions = np.array(
+        [
+            [0.1, 0.4, 0.4, 0.7, 0.3, 0.4, 0.8, 0.9],
+            [0.2, 0.3, 0.5, 0.6, 0.4, 0.5, 0.7, 0.8],
+        ]
+    )
+
+    aucs, covariance = _roc._delong_auc_covariance(y_true, predictions)
+    expected_aucs, expected_covariance = _slow_delong_reference(y_true, predictions)
+
+    np.testing.assert_allclose(aucs, expected_aucs)
+    np.testing.assert_allclose(covariance, expected_covariance)
+    np.testing.assert_allclose(
+        aucs,
+        [roc_auc_score(y_true, prediction) for prediction in predictions],
+    )
+    assert _roc._delong_roc_test(
+        y_true, predictions[0], predictions[1]
+    ) == pytest.approx(0.39926914317106565)
+
+
+def test_delong_handles_zero_variance_comparisons() -> None:
+    y_true = np.array([0, 0, 1, 1])
+    scores = np.array([0.1, 0.2, 0.8, 0.9])
+
+    assert _roc._delong_roc_test(y_true, scores, scores) == 1
+    assert _roc._delong_roc_test(y_true, y_true, 1 - y_true) == 0
+
+
+def test_delong_handles_floating_point_covariance_noise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _roc,
+        "_delong_auc_covariance",
+        lambda y_true, predictions: (
+            np.array([0.5, 0.5]),
+            np.array([[-1e-16, 0.0], [0.0, 0.0]]),
+        ),
+    )
+
+    assert _roc._delong_roc_test(np.array([]), np.array([]), np.array([])) == 1
+
+
+def test_delong_rejects_negative_contrast_variance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        _roc,
+        "_delong_auc_covariance",
+        lambda y_true, predictions: (
+            np.array([0.5, 0.5]),
+            np.array([[-1.0, 0.0], [0.0, 0.0]]),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="variance must be non-negative"):
+        _roc._delong_roc_test(np.array([]), np.array([]), np.array([]))
+
+
+def test_rocplot_runs_requested_delong_comparison(roc_df: pd.DataFrame) -> None:
+    ax = cns.rocplot(
+        roc_df,
+        "truth",
+        ["model_a", "model_b"],
+        pairs=[("model_a", "model_b")],
+    )
+
+    annotation = ax.texts[0]
+    assert annotation.get_text() == (
+        "DeLong test\nmodel_a vs model_b: P = $1$"
+    )
+    assert annotation.get_position() == (0.02, 0.02)
+    assert annotation.get_transform() is ax.transAxes
+    assert annotation.get_horizontalalignment() == "left"
+    assert annotation.get_verticalalignment() == "bottom"
+
+
+@pytest.mark.parametrize(
+    "p_adjust",
+    ["bonferroni", "holm", "fdr_bh", "fdr_by"],
+)
+def test_rocplot_resolves_all_pairs_and_applies_correction(
+    roc_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+    p_adjust: str,
+) -> None:
+    data = roc_df.assign(model_c=[0.3, 0.2, 0.1, 0.7, 0.8, 0.9])
+    delong_calls: list[tuple[np.ndarray, np.ndarray]] = []
+    correction_calls: list[tuple[list[float], str]] = []
+
+    def fake_delong(
+        y_true: np.ndarray,
+        first_scores: np.ndarray,
+        second_scores: np.ndarray,
+    ) -> float:
+        delong_calls.append((first_scores, second_scores))
+        return 0.05
+
+    def fake_multipletests(
+        pvalues: list[float], *, method: str
+    ) -> tuple[None, np.ndarray]:
+        correction_calls.append((pvalues, method))
+        return None, np.array([0.01, 0.02, 0.03])
+
+    monkeypatch.setattr(_roc, "_delong_roc_test", fake_delong)
+    monkeypatch.setattr(_specialized, "multipletests", fake_multipletests)
+
+    ax = cns.rocplot(
+        data,
+        "truth",
+        ["model_a", "model_b", "model_c"],
+        pairs="all",
+        p_adjust=cast(Any, p_adjust),
+    )
+
+    assert len(delong_calls) == 3
+    assert correction_calls == [([0.05, 0.05, 0.05], p_adjust)]
+    assert ax.texts[0].get_text().splitlines() == [
+        f"DeLong test ({p_adjust}-adjusted)",
+        "model_a vs model_b: P = $0.01$",
+        "model_a vs model_c: P = $0.02$",
+        "model_b vs model_c: P = $0.03$",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("pred_prob_cols", "pairs", "message"),
+    [
+        (["model_a", "model_a"], "all", "Prediction columns must be unique"),
+        (["model_a"], "all", "requires at least two prediction columns"),
+        (["model_a", "model_b"], "invalid", "must be a list of tuples"),
+        (["model_a", "model_b"], ["model_a"], "exactly two prediction columns"),
+        (
+            ["model_a", "model_b"],
+            [("model_a", "model_a")],
+            "two distinct prediction columns",
+        ),
+        (
+            ["model_a", "model_b"],
+            [("model_a", "missing")],
+            "not plotted",
+        ),
+        (
+            ["model_a", "model_b"],
+            [("model_a", "model_b"), ("model_b", "model_a")],
+            "unique regardless of order",
+        ),
+    ],
+)
+def test_rocplot_validates_comparison_pairs(
+    roc_df: pd.DataFrame,
+    pred_prob_cols: list[str],
+    pairs: object,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        cns.rocplot(
+            roc_df,
+            "truth",
+            pred_prob_cols,
+            pairs=cast(Any, pairs),
+        )
+
+
+def test_rocplot_accepts_an_empty_pair_list(roc_df: pd.DataFrame) -> None:
+    ax = cns.rocplot(
+        roc_df,
+        "truth",
+        ["model_a", "model_b"],
+        pairs=[],
+        p_adjust="holm",
+    )
+
+    assert len(ax.texts) == 0
+
+
+@pytest.mark.parametrize(
+    ("scores", "message"),
+    [
+        ([0.1, 0.2, None, 0.6, 0.8, 0.9], "Null values"),
+        (["low", "low", "low", "high", "high", "high"], "real numeric scores"),
+        ([False, False, False, True, True, True], "real numeric scores"),
+        ([0.1 + 1j, 0.2, 0.3, 0.6, 0.8, 0.9], "real numeric scores"),
+        ([0.1, 0.2, 0.3, 0.6, 0.8, np.inf], "finite scores"),
+    ],
+)
+def test_rocplot_validates_prediction_scores(
+    roc_df: pd.DataFrame,
+    scores: list[object],
+    message: str,
+) -> None:
+    data = roc_df.assign(invalid=scores)
+
+    with pytest.raises(ValueError, match=message):
+        cns.rocplot(data, "truth", "invalid")
+
+
+def test_rocplot_rejects_null_true_labels(roc_df: pd.DataFrame) -> None:
+    data = roc_df.astype({"truth": float})
+    data.loc[0, "truth"] = np.nan
+
+    with pytest.raises(ValueError, match="Null values"):
+        cns.rocplot(data, "truth", "model_a")
+
+
+def test_rocplot_requires_two_observations_per_class_for_delong() -> None:
+    data = pd.DataFrame(
+        {
+            "truth": [0, 1, 1],
+            "first": [0.1, 0.7, 0.8],
+            "second": [0.2, 0.6, 0.9],
+        }
+    )
+
+    with pytest.raises(ValueError, match="at least two positive and two negative"):
+        cns.rocplot(data, "truth", ["first", "second"], pairs="all")
+
+
+def test_rocplot_rejects_unknown_pvalue_correction(roc_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="'p_adjust' must be one of"):
+        cns.rocplot(
+            roc_df,
+            "truth",
+            ["model_a", "model_b"],
+            p_adjust=cast(Any, "BH"),
+        )

--- a/tests/test_roc_features.py
+++ b/tests/test_roc_features.py
@@ -4,7 +4,6 @@ import inspect
 from typing import Any, cast
 
 import matplotlib.colors as mcolors
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
@@ -97,16 +96,15 @@ def _slow_delong_reference(
     negative_placements = np.empty_like(negative, dtype=float)
     for model_index in range(predictions.shape[0]):
         placements = (
-            (positive[model_index, :, None] > negative[model_index, None, :])
-            + 0.5
-            * (positive[model_index, :, None] == negative[model_index, None, :])
-        )
+            positive[model_index, :, None] > negative[model_index, None, :]
+        ) + 0.5 * (positive[model_index, :, None] == negative[model_index, None, :])
         positive_placements[model_index] = placements.mean(axis=1)
         negative_placements[model_index] = placements.mean(axis=0)
     aucs = positive_placements.mean(axis=1)
-    covariance = np.cov(positive_placements) / positive.shape[1] + np.cov(
-        negative_placements
-    ) / negative.shape[1]
+    covariance = (
+        np.cov(positive_placements) / positive.shape[1]
+        + np.cov(negative_placements) / negative.shape[1]
+    )
     return aucs, covariance
 
 
@@ -181,9 +179,7 @@ def test_rocplot_runs_requested_delong_comparison(roc_df: pd.DataFrame) -> None:
     )
 
     annotation = ax.texts[0]
-    assert annotation.get_text() == (
-        "DeLong test\nmodel_a vs model_b: P = $1$"
-    )
+    assert annotation.get_text() == ("DeLong test\nmodel_a vs model_b: P = $1$")
     assert annotation.get_position() == (0.02, 0.02)
     assert annotation.get_transform() is ax.transAxes
     assert annotation.get_horizontalalignment() == "left"


### PR DESCRIPTION
## Goal

Add uncertainty visualization and paired AUC comparisons to rocplot without changing its default output or Axes return type.

## What changed

- Added opt-in 95% stratified bootstrap confidence bands.
- Added paired, two-sided DeLong tests for selected or all prediction pairs.
- Added optional Bonferroni, Holm, FDR-BH, and FDR-BY corrections.
- Added score and comparison validation, focused tests, and documentation.

## Testing

- make test — 506 passed with 100% coverage.
- make lint — all configured hooks passed.

## Risks and follow-ups

- Confidence bands use 1,000 deterministic bootstrap samples and add runtime only when enabled.
- No dependency, migration, or public return-type changes.