### PR TITLE
💥 Support ordered multistage Sankey

### DIFF
--- a/examples/sankeyplot.py
+++ b/examples/sankeyplot.py
@@ -4,9 +4,9 @@ Sankey Diagram
 
 Create Sankey diagrams for visualizing flows between categories.
 
-Sankey diagrams show how quantities flow from one set of categories
-to another, useful for visualizing transitions, migrations, or
-relationships between categorical variables.
+Sankey diagrams show how quantities flow across ordered sets of categories,
+which is useful for visualizing transitions, migrations, or relationships
+between categorical variables.
 """
 
 # %%
@@ -33,7 +33,7 @@ data = pd.DataFrame(
 # ~~~~~~~~~~~~~~~~~~~~
 # Show flows from categories A, B, C to X, Y, Z.
 cns.figure(80, 100)
-ax = cns.sankeyplot(data=data, x="x", y="y")
+ax = cns.sankeyplot(data=data, x=["x", "y"])
 ax.set_title("Basic Sankey")
 
 
@@ -63,7 +63,7 @@ rotated_label_data = pd.DataFrame(
 )
 
 cns.figure(110, 90)
-ax = cns.sankeyplot(data=rotated_label_data, x="source", y="target", label_rotation=45)
+ax = cns.sankeyplot(data=rotated_label_data, x=["source", "target"], label_rotation=45)
 ax.set_title("Rotated Labels")
 
 
@@ -85,20 +85,25 @@ treatment_data = pd.DataFrame(
 )
 
 cns.figure(100, 120)
-ax = cns.sankeyplot(data=treatment_data, x="treatment", y="outcome")
+ax = cns.sankeyplot(data=treatment_data, x=["treatment", "outcome"])
 ax.set_title("Treatment to Outcome")
 
 
 # %%
-# Disease stage progression
-# ~~~~~~~~~~~~~~~~~~~~~~~~~
-# Show how patients transition between stages.
+# Multi-stage disease progression
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Show how patients transition across three observations.
 stage_data = pd.DataFrame(
     {
         "baseline": np.random.choice(
             ["Stage I", "Stage II", "Stage III"], 100, p=[0.4, 0.35, 0.25]
         ),
-        "followup": np.random.choice(
+        "week_4": np.random.choice(
+            ["Stage I", "Stage II", "Stage III", "Stage IV"],
+            100,
+            p=[0.3, 0.3, 0.25, 0.15],
+        ),
+        "week_12": np.random.choice(
             ["Stage I", "Stage II", "Stage III", "Stage IV"],
             100,
             p=[0.25, 0.3, 0.25, 0.2],
@@ -106,8 +111,8 @@ stage_data = pd.DataFrame(
     }
 )
 
-cns.figure(100, 140)
-ax = cns.sankeyplot(data=stage_data, x="baseline", y="followup")
+cns.figure(150, 140)
+ax = cns.sankeyplot(data=stage_data, x=["baseline", "week_4", "week_12"])
 ax.set_title("Disease Stage Progression")
 
 
@@ -127,7 +132,7 @@ cell_transition = pd.DataFrame(
 )
 
 cns.figure(100, 120)
-ax = cns.sankeyplot(data=cell_transition, x="initial", y="final")
+ax = cns.sankeyplot(data=cell_transition, x=["initial", "final"])
 ax.set_title("Cell Differentiation")
 
 
@@ -147,7 +152,7 @@ cluster_comparison = pd.DataFrame(
 )
 
 cns.figure(100, 140)
-ax = cns.sankeyplot(data=cluster_comparison, x="method_A", y="method_B")
+ax = cns.sankeyplot(data=cluster_comparison, x=["method_A", "method_B"])
 ax.set_title("Clustering Comparison")
 
 
@@ -165,7 +170,7 @@ response_flow = pd.DataFrame(
 )
 
 cns.figure(100, 120)
-ax = cns.sankeyplot(data=response_flow, x="week_0", y="week_12")
+ax = cns.sankeyplot(data=response_flow, x=["week_0", "week_12"])
 ax.set_title("Response at Week 0 to Week 12")
 
 
@@ -181,7 +186,7 @@ binary_data = pd.DataFrame(
 )
 
 cns.figure(80, 100)
-ax = cns.sankeyplot(data=binary_data, x="before", y="after")
+ax = cns.sankeyplot(data=binary_data, x=["before", "after"])
 ax.set_title("Treatment Success")
 
 
@@ -197,5 +202,5 @@ biomarker_data = pd.DataFrame(
 )
 
 cns.figure(90, 120)
-ax = cns.sankeyplot(data=biomarker_data, x="biomarker", y="phenotype")
+ax = cns.sankeyplot(data=biomarker_data, x=["biomarker", "phenotype"])
 ax.set_title("Biomarker to Phenotype")

--- a/examples/showcase.py
+++ b/examples/showcase.py
@@ -215,7 +215,7 @@ ax.set_title("Rocplot")
 
 # Panel N: sankeyplot
 mp.panel("N", 30, 100, pad_left=-30, color_cycle="Ecotyper4")
-ax = cns.sankeyplot(tips_df, x="day", y="sex", label_rotation=90)
+ax = cns.sankeyplot(tips_df, x=["day", "sex"], label_rotation=90)
 ax.set_title("Sankeyplot")
 
 # Panel O: ridgeplot

--- a/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
+++ b/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
@@ -39,7 +39,7 @@ plain Matplotlib `Axes`.
 - `pieplot` and `donutplot`: parts of a whole when few categories are present.
 - `vennplot`: overlap among a small number of sets.
 - `upsetplot`: scalable set intersections.
-- `sankeyplot`: flow between source and target categories.
+- `sankeyplot`: flow across two or more ordered categorical stages.
 
 `upsetplot` returns panel axes and `vennplot` returns a matplotlib-venn diagram
 object.

--- a/src/cnsplots/helpers/_sankey.py
+++ b/src/cnsplots/helpers/_sankey.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from matplotlib.axes import Axes
 
 from cnsplots._validation import (
     validate_column_type,
@@ -142,6 +143,146 @@ def sankeyplot(
         plt.gcf().set_size_inches(figSize)
     if closePlot:
         plt.close()
+    return ax
+
+
+def multistage_sankeyplot(
+    data: pd.DataFrame,
+    columns: list[str],
+    colorDict: dict[str, str] | None = None,
+    fontsize: int | float = 14,
+    label_rotation: float = 0,
+    aspect: int = 4,
+    ax: Axes | None = None,
+) -> Axes:
+    """Draw a Sankey diagram across three or more categorical columns."""
+    if len(columns) < 3:
+        raise ValueError("multistage_sankeyplot requires at least three columns")
+    if ax is None:
+        ax = plt.gca()
+
+    stage_labels = [data[column].unique().tolist() for column in columns]
+    all_labels = pd.unique(
+        pd.concat([data[column] for column in columns], ignore_index=True)
+    )
+    colors = create_colors(all_labels, colorDict)
+
+    gap = 0.02 * len(data)
+    stage_positions: list[dict[str, dict[str, float]]] = []
+    top_edges: list[float] = []
+    for column, labels in zip(columns, stage_labels):
+        counts = data[column].value_counts(sort=False)
+        positions: dict[str, dict[str, float]] = {}
+        bottom = 0.0
+        for label in labels:
+            width = float(counts[label])
+            top = bottom + width
+            positions[label] = {"bottom": bottom, "top": top, "width": width}
+            bottom = top + gap
+        stage_positions.append(positions)
+        top_edges.append(positions[labels[-1]]["top"])
+
+    x_step = max(top_edges) / aspect
+    x_positions = np.arange(len(columns)) * x_step
+    smoothing_kernel = 0.05 * np.ones(20)
+
+    # Draw links first so opaque nodes cover their endpoints.
+    for stage_index, (left_column, right_column) in enumerate(
+        zip(columns, columns[1:])
+    ):
+        grouped = cast(
+            "pd.Series",
+            data.groupby([left_column, right_column], sort=False, observed=True).size(),
+        )
+        links_by_left: dict[str, list[tuple[str, float]]] = defaultdict(list)
+        for pair, width in grouped.items():
+            left_label, right_label = cast("tuple[str, str]", pair)
+            links_by_left[left_label].append((right_label, float(width)))
+
+        right_order = {
+            label: index for index, label in enumerate(stage_labels[stage_index + 1])
+        }
+        for links in links_by_left.values():
+            links.sort(key=lambda link: right_order[link[0]])
+
+        left_cursor = {
+            label: stage_positions[stage_index][label]["bottom"]
+            for label in stage_labels[stage_index]
+        }
+        right_cursor = {
+            label: stage_positions[stage_index + 1][label]["bottom"]
+            for label in stage_labels[stage_index + 1]
+        }
+        for left_label in stage_labels[stage_index]:
+            for right_label, width in links_by_left[left_label]:
+                lower = np.array(
+                    50 * [left_cursor[left_label]] + 50 * [right_cursor[right_label]]
+                )
+                lower = np.convolve(lower, smoothing_kernel, mode="valid")
+                lower = np.convolve(lower, smoothing_kernel, mode="valid")
+                upper = np.array(
+                    50 * [left_cursor[left_label] + width]
+                    + 50 * [right_cursor[right_label] + width]
+                )
+                upper = np.convolve(upper, smoothing_kernel, mode="valid")
+                upper = np.convolve(upper, smoothing_kernel, mode="valid")
+
+                left_cursor[left_label] += width
+                right_cursor[right_label] += width
+                ax.fill_between(
+                    np.linspace(
+                        x_positions[stage_index],
+                        x_positions[stage_index + 1],
+                        len(lower),
+                    ),
+                    lower,
+                    upper,
+                    alpha=0.65,
+                    color=colors[left_label],
+                )
+
+    rotation_padding = fontsize * abs(np.sin(np.deg2rad(label_rotation)))
+    last_stage = len(columns) - 1
+    for stage_index, labels in enumerate(stage_labels):
+        x_position = x_positions[stage_index]
+        if stage_index == 0:
+            bar_x = [x_position - 0.02 * x_step, x_position]
+            label_x = x_position - 0.05 * x_step
+            text_offset = (-rotation_padding, 0)
+            horizontal_alignment = "right"
+        elif stage_index == last_stage:
+            bar_x = [x_position, x_position + 0.02 * x_step]
+            label_x = x_position + 0.05 * x_step
+            text_offset = (rotation_padding, 0)
+            horizontal_alignment = "left"
+        else:
+            bar_x = [x_position - 0.01 * x_step, x_position + 0.01 * x_step]
+            label_x = x_position
+            text_offset = (0, 0)
+            horizontal_alignment = "center"
+
+        for label in labels:
+            position = stage_positions[stage_index][label]
+            ax.fill_between(
+                bar_x,
+                2 * [position["bottom"]],
+                2 * [position["top"]],
+                color=colors[label],
+                alpha=1,
+            )
+            ax.annotate(
+                label,
+                xy=(label_x, position["bottom"] + 0.5 * position["width"]),
+                xytext=text_offset,
+                textcoords="offset points",
+                ha=horizontal_alignment,
+                va="center",
+                fontsize=fontsize,
+                rotation=label_rotation,
+                rotation_mode="anchor",
+            )
+
+    ax.axis("off")
     return ax
 
 

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -161,29 +161,25 @@ def placeholderplot(description: str, *, ax: Axes | None = None) -> Axes:
 
 def sankeyplot(
     data: pd.DataFrame,
-    x: str,
-    y: str,
+    x: list[str],
     label_rotation: float = 0,
     *,
     ax: Axes | None = None,
 ) -> Axes:
     """
-    Create a Sankey diagram showing flows between two categorical variables.
+    Create a Sankey diagram showing flows across categorical variables.
 
     This function generates a Sankey (alluvial) diagram visualizing the flow
-    and connections between categories in two variables.
+    and connections between categories in two or more ordered stages.
 
     Parameters
     ----------
     data : pd.DataFrame
         The input DataFrame containing the data to visualize.
-    x : str
-        Column name for the source (left-side) categorical variable.
-    y : str
-        Column name for the target (right-side) categorical variable.
+    x : list of str
+        Ordered list of two or more stage columns.
     label_rotation : float, default: 0
-        Rotation angle, in degrees, applied to both left and right Sankey
-        labels.
+        Rotation angle, in degrees, applied to all Sankey category labels.
     ax : matplotlib.axes.Axes, optional
         Axes to draw on. If None, uses the current axes.
 
@@ -200,35 +196,56 @@ def sankeyplot(
     Examples
     --------
     >>> import cnsplots as cns
-    >>> ax = cns.sankeyplot(data=df, x="initial_diagnosis", y="final_diagnosis")
+    >>> ax = cns.sankeyplot(data=df, x=["initial_diagnosis", "final_diagnosis"])
     >>> ax.set_title("Diagnosis Flow")
 
     >>> # Patient flow across treatment stages
     >>> ax = cns.sankeyplot(
     ...     data=df,
-    ...     x="stage_1_response",
-    ...     y="stage_2_response",
+    ...     x=["baseline_response", "week_4_response", "week_12_response"],
     ...     label_rotation=90,
     ... )
     """
     # Validate inputs
     validate_dataframe(data, "data", "sankeyplot")
-    validate_columns_exist(data, [x, y], "sankeyplot")
     validate_dataframe_not_empty(data, "sankeyplot")
+
+    if not isinstance(x, list):
+        raise TypeError("[sankeyplot] 'x' must be a list of column names.")
+    if len(x) < 2:
+        raise ValueError("[sankeyplot] 'x' must contain at least two stage columns.")
+    if not all(isinstance(column, str) for column in x):
+        raise TypeError("[sankeyplot] Every stage column in 'x' must be a string.")
+
+    validate_columns_exist(data, x, "sankeyplot")
 
     if ax is None:
         ax = plt.gca()
-    keys = np.union1d(data[x].unique(), data[y].unique())
+    if len(x) == 2:
+        keys = np.union1d(data[x[0]].unique(), data[x[1]].unique())
+    else:
+        validate_no_nulls(data, x, "sankeyplot")
+        keys = pd.unique(pd.concat([data[column] for column in x], ignore_index=True))
     colors = sns.color_palette(n_colors=len(keys))
     color_dict = dict(zip(keys, colors))
-    helper_sankey.sankeyplot(
-        data[x],
-        data[y],
-        fontsize=_legend_fontsize(),
-        colorDict=color_dict,
-        label_rotation=label_rotation,
-        ax=ax,
-    )
+    if len(x) == 2:
+        helper_sankey.sankeyplot(
+            data[x[0]],
+            data[x[1]],
+            fontsize=_legend_fontsize(),
+            colorDict=color_dict,
+            label_rotation=label_rotation,
+            ax=ax,
+        )
+    else:
+        helper_sankey.multistage_sankeyplot(
+            data,
+            x,
+            fontsize=_legend_fontsize(),
+            colorDict=color_dict,
+            label_rotation=label_rotation,
+            ax=ax,
+        )
     return ax
 
 

--- a/tests/test_palette_sankey_defects.py
+++ b/tests/test_palette_sankey_defects.py
@@ -50,7 +50,7 @@ def test_sankeyplot_assigns_color_to_every_label(
     monkeypatch.setattr(_specialized.helper_sankey, "sankeyplot", capture_colors)
 
     with plt.rc_context({"axes.prop_cycle": cycler(color=["#111111", "#eeeeee"])}):
-        _specialized.sankeyplot(data, x="source", y="target")
+        _specialized.sankeyplot(data, x=["source", "target"])
 
     assert set(captured_colors) == {
         "source_a",

--- a/tests/test_plots_basic.py
+++ b/tests/test_plots_basic.py
@@ -709,7 +709,7 @@ def test_sets_and_specialized_plots(
     ]
 
     cns.figure(120, 120)
-    ax = cns.sankeyplot(sankey_df, x="source", y="target")
+    ax = cns.sankeyplot(sankey_df, x=["source", "target"])
     assert ax is plt.gca()
     assert (
         len(ax.texts) == sankey_df["source"].nunique() + sankey_df["target"].nunique()
@@ -717,7 +717,7 @@ def test_sets_and_specialized_plots(
     assert all(text.get_rotation() == 0 for text in ax.texts)
 
     cns.figure(120, 120)
-    ax_rotated = cns.sankeyplot(sankey_df, x="source", y="target", label_rotation=90)
+    ax_rotated = cns.sankeyplot(sankey_df, x=["source", "target"], label_rotation=90)
     assert ax_rotated is plt.gca()
     assert len(ax_rotated.texts) == len(ax.texts)
     assert all(text.get_rotation() == 90 for text in ax_rotated.texts)
@@ -759,12 +759,12 @@ def test_sets_and_specialized_plots(
 def test_sankey_annotations_use_legend_fontsize(sankey_df: pd.DataFrame) -> None:
     with cns.settings.context(legend_fontsize=13):
         cns.figure(120, 120)
-        ax = cns.sankeyplot(sankey_df, x="source", y="target")
+        ax = cns.sankeyplot(sankey_df, x=["source", "target"])
         assert ax.texts
         assert {text.get_fontsize() for text in ax.texts} == {13}
 
     with cns.settings.context(legend_fontsize=None, title_fontsize=12):
         cns.figure(120, 120)
-        ax = cns.sankeyplot(sankey_df, x="source", y="target")
+        ax = cns.sankeyplot(sankey_df, x=["source", "target"])
         assert ax.texts
         assert {text.get_fontsize() for text in ax.texts} == {12}

--- a/tests/test_sankey_multistage.py
+++ b/tests/test_sankey_multistage.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, cast
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+from cnsplots.plots import _specialized
+
+
+@pytest.fixture
+def multistage_data() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "baseline": ["A", "A", "B", "B"],
+            "week_4": ["C", "D", "C", "D"],
+            "week_12": ["E", "E", "F", "F"],
+        }
+    )
+
+
+def test_sankeyplot_delegates_ordered_stages(
+    multistage_data: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def capture_multistage(*args: Any, **kwargs: Any) -> None:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        _specialized.helper_sankey, "multistage_sankeyplot", capture_multistage
+    )
+    _, ax = plt.subplots()
+
+    with cns.settings.context(legend_fontsize=13):
+        result = cns.sankeyplot(
+            multistage_data,
+            x=["baseline", "week_4", "week_12"],
+            label_rotation=30,
+            ax=ax,
+        )
+
+    assert result is ax
+    args = captured["args"]
+    assert args[0] is multistage_data
+    assert args[1] == ["baseline", "week_4", "week_12"]
+    kwargs = captured["kwargs"]
+    assert kwargs["ax"] is ax
+    assert kwargs["fontsize"] == 13
+    assert kwargs["label_rotation"] == 30
+    assert set(kwargs["colorDict"]) == {"A", "B", "C", "D", "E", "F"}
+
+
+def test_sankeyplot_two_stage_list_uses_legacy_renderer(
+    multistage_data: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def capture_legacy(*args: Any, **kwargs: Any) -> None:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(_specialized.helper_sankey, "sankeyplot", capture_legacy)
+    monkeypatch.setattr(
+        _specialized.helper_sankey,
+        "multistage_sankeyplot",
+        lambda *args, **kwargs: pytest.fail("unexpected multistage renderer"),
+    )
+
+    cns.sankeyplot(multistage_data, x=["baseline", "week_4"])
+
+    left, right = captured["args"]
+    pd.testing.assert_series_equal(left, multistage_data["baseline"])
+    pd.testing.assert_series_equal(right, multistage_data["week_4"])
+
+
+def test_sankeyplot_uses_single_stage_list_parameter() -> None:
+    assert tuple(inspect.signature(cns.sankeyplot).parameters) == (
+        "data",
+        "x",
+        "label_rotation",
+        "ax",
+    )
+
+
+@pytest.mark.parametrize(
+    ("x", "exception", "message"),
+    [
+        (["baseline"], ValueError, "at least two stage columns"),
+        (["baseline", 4], TypeError, "Every stage column"),
+        ("baseline", TypeError, "must be a list"),
+        (("baseline", "week_4"), TypeError, "must be a list"),
+    ],
+)
+def test_sankeyplot_validates_stage_arguments(
+    multistage_data: pd.DataFrame,
+    x: object,
+    exception: type[Exception],
+    message: str,
+) -> None:
+    with pytest.raises(exception, match=message):
+        cast(Any, cns.sankeyplot)(multistage_data, x=x)
+
+
+def test_sankeyplot_validates_every_stage_column(
+    multistage_data: pd.DataFrame,
+) -> None:
+    with pytest.raises(ValueError, match="missing"):
+        cns.sankeyplot(multistage_data, x=["baseline", "week_4", "missing"])
+
+    data_with_null = multistage_data.copy()
+    data_with_null.loc[0, "week_4"] = None
+    with pytest.raises(ValueError, match="week_4"):
+        cns.sankeyplot(
+            data_with_null,
+            x=["baseline", "week_4", "week_12"],
+        )

--- a/tests/test_sankey_multistage_helper.py
+++ b/tests/test_sankey_multistage_helper.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.colors import to_rgba
+import numpy as np
+import pandas as pd
+import pytest
+
+from cnsplots.helpers import _sankey
+
+
+def _capture_fill_between(
+    monkeypatch: pytest.MonkeyPatch, ax: Axes
+) -> list[tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, Any]]]:
+    calls: list[tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, Any]]] = []
+    original_fill_between = ax.fill_between
+
+    def capture(x: Any, y1: Any, y2: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(
+            (
+                np.asarray(x),
+                np.asarray(y1),
+                np.asarray(y2),
+                kwargs,
+            )
+        )
+        return original_fill_between(x, y1, y2, *args, **kwargs)
+
+    monkeypatch.setattr(ax, "fill_between", capture)
+    return calls
+
+
+def test_multistage_sankeyplot_stacks_sparse_links_and_nodes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "first": ["B", "A", "B", "A", "B"],
+            "second": ["Y", "Y", "X", "Y", "X"],
+            "third": ["Q", "P", "Q", "P", "Q"],
+        }
+    )
+    colors = {
+        "A": "blue",
+        "B": "red",
+        "X": "purple",
+        "Y": "green",
+        "P": "black",
+        "Q": "orange",
+    }
+    fig, ax = plt.subplots()
+    fill_calls = _capture_fill_between(monkeypatch, ax)
+
+    result = _sankey.multistage_sankeyplot(
+        data,
+        ["first", "second", "third"],
+        colorDict=colors,
+        fontsize=11,
+        label_rotation=30,
+        ax=ax,
+    )
+
+    assert result is ax
+    assert ax.axison is False
+    assert len(fill_calls) == 12
+    assert len(ax.collections) == 12
+
+    ribbon_calls = fill_calls[:6]
+    node_calls = fill_calls[6:]
+    assert all(len(call[0]) == 62 for call in ribbon_calls)
+    assert all(len(call[0]) == 2 for call in node_calls)
+    assert [call[3]["alpha"] for call in ribbon_calls] == [0.65] * 6
+    assert [call[3]["alpha"] for call in node_calls] == [1] * 6
+
+    assert [to_rgba(call[3]["color"]) for call in ribbon_calls] == [
+        to_rgba(colors[label]) for label in ["B", "B", "A", "Y", "Y", "X"]
+    ]
+    ribbon_edges = [
+        (call[1][0], call[1][-1], call[2][0], call[2][-1]) for call in ribbon_calls
+    ]
+    np.testing.assert_allclose(
+        ribbon_edges,
+        [
+            (0.0, 0.0, 1.0, 1.0),
+            (1.0, 3.1, 3.0, 5.1),
+            (3.1, 1.0, 5.1, 3.0),
+            (0.0, 0.0, 1.0, 1.0),
+            (1.0, 3.1, 3.0, 5.1),
+            (3.1, 1.0, 5.1, 3.0),
+        ],
+    )
+    np.testing.assert_allclose(
+        [(call[0][0], call[0][-1]) for call in ribbon_calls],
+        [(0.0, 1.275)] * 3 + [(1.275, 2.55)] * 3,
+    )
+
+    assert [text.get_text() for text in ax.texts] == ["B", "A", "Y", "X", "Q", "P"]
+    assert [text.get_rotation() for text in ax.texts] == [30] * 6
+    assert [text.get_fontsize() for text in ax.texts] == [11] * 6
+    assert [text.get_horizontalalignment() for text in ax.texts] == [
+        "right",
+        "right",
+        "center",
+        "center",
+        "left",
+        "left",
+    ]
+    assert [cast(Any, text).xy[0] for text in ax.texts] == pytest.approx(
+        [-0.06375, -0.06375, 1.275, 1.275, 2.61375, 2.61375]
+    )
+    np.testing.assert_allclose(
+        [(call[1][0], call[2][0]) for call in node_calls],
+        [(0.0, 3.0), (3.1, 5.1)] * 3,
+    )
+
+
+def test_multistage_sankeyplot_uses_current_axes_and_observed_categories() -> None:
+    data = pd.DataFrame(
+        {
+            "one": pd.Categorical(["same", "same"], categories=["same", "unused1"]),
+            "two": pd.Categorical(["same", "same"], categories=["same", "unused2"]),
+            "three": pd.Categorical(["C", "C"], categories=["C", "unused3"]),
+            "four": pd.Categorical(["D", "D"], categories=["D", "unused4"]),
+        }
+    )
+    fig, ax = plt.subplots()
+    plt.sca(ax)
+
+    result = _sankey.multistage_sankeyplot(
+        data,
+        ["one", "two", "three", "four"],
+        label_rotation=45,
+        aspect=2,
+    )
+
+    assert result is ax
+    assert len(ax.collections) == 7
+    assert [text.get_text() for text in ax.texts] == ["same", "same", "C", "D"]
+    assert all(text.get_rotation() == 45 for text in ax.texts)
+    first_node_color = ax.collections[3].get_facecolor()[0]
+    second_node_color = ax.collections[4].get_facecolor()[0]
+    assert first_node_color == pytest.approx(second_node_color)
+
+
+def test_multistage_sankeyplot_requires_three_columns() -> None:
+    with pytest.raises(ValueError, match="at least three columns"):
+        _sankey.multistage_sankeyplot(
+            pd.DataFrame({"one": ["A"], "two": ["B"]}),
+            ["one", "two"],
+        )

--- a/tests/test_special_axes.py
+++ b/tests/test_special_axes.py
@@ -98,7 +98,7 @@ def test_single_axes_special_plots_use_supplied_axes(
     )
     plotters = [
         lambda ax: cns.placeholderplot("Reserved", ax=ax),
-        lambda ax: cns.sankeyplot(sankey_df, x="source", y="target", ax=ax),
+        lambda ax: cns.sankeyplot(sankey_df, x=["source", "target"], ax=ax),
         lambda ax: cns.rocplot(roc_df, "truth", "model_a", ax=ax),
         lambda ax: cns.volcanoplot(volcano_df, n_show=1, ax=ax),
         lambda ax: cns.survivalplot(

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
         assert_type(cns.histplot(data, x="x", ax=ax), Axes)
         assert_type(cns.lineplot(data, x="x", y="y", ax=ax), Axes)
         assert_type(cns.regplot(data, x="x", y="y", color=(0.1, 0.2, 0.3)), Axes)
+        assert_type(cns.sankeyplot(data, x=["source", "target"], ax=ax), Axes)
+        assert_type(cns.sankeyplot(data, x=["baseline", "week_4", "week_12"]), Axes)
         assert_type(
             cns.dumbbellplot(data, x="value", y="group", hue="condition", ax=ax),
             Axes,


### PR DESCRIPTION
## Goal

Allow `sankeyplot` to represent two or more ordered categorical stages through one consistent `x=[...]` API.

## What changed

- Require `x` to be an ordered list of at least two DataFrame columns and remove the public `y` parameter.
- Add a sparse adjacent-stage renderer for multistage flows while preserving existing two-stage geometry through the internal renderer.
- Migrate the gallery, showcase, tests, typing contract, and agent plot catalog to the new schema.

## How it was tested

- `make test` — 517 passed with 100% coverage.
- `make lint` — all lint, formatting, typing, and documentation hooks passed.
- Focused Sankey and axes suite — 58 passed.
- Rendered and visually inspected a four-stage Sankey plot.

## Risks or follow-ups

- Breaking change: callers must replace `x="source", y="target"` with `x=["source", "target"]`.
- No known follow-up work is required.