### PR TITLE
✨ Add ridgeplot hue and overlap

### DIFF
--- a/examples/ridgeplot.py
+++ b/examples/ridgeplot.py
@@ -39,6 +39,23 @@ ax.set_title("Total Bill by Day (plasma cmap)")
 
 
 # %%
+# Ridge plot with hue and custom overlap
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Overlay distributions within each ridge and customize the filled curves.
+cns.figure(150, 150)
+ax = cns.ridgeplot(
+    data=tips,
+    x="total_bill",
+    y="day",
+    hue="sex",
+    overlap=0.7,
+    alpha=0.65,
+    linewidth=0.8,
+)
+ax.set_title("Total Bill by Day and Sex")
+
+
+# %%
 # Ridge plot for iris data
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 # Compare species distributions.

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from numbers import Real
 from typing import Any, Literal
 
 import matplotlib as mpl
@@ -733,7 +734,10 @@ def ridgeplot(
     y: str,
     cmap: str = "viridis",
     *,
+    hue: str | None = None,
+    overlap: float = 0.5,
     ax: Axes | None = None,
+    **kwargs: Any,
 ) -> Axes:
     """
     Create a ridge plot (joyplot) showing distributions across categories.
@@ -752,8 +756,16 @@ def ridgeplot(
     cmap : str, optional
         Name of a matplotlib colormap to use for coloring the ridges.
         Default is ``"viridis"``.
+    hue : str, optional
+        Column name for grouping density estimates within each ridge. Each observed
+        hue level is drawn at the same vertical offset and included in a legend.
+    overlap : float, default: 0.5
+        Fractional overlap between adjacent ridges. Must be between 0 and 1,
+        inclusive. Zero makes adjacent ridges touch and one fully aligns them.
     ax : matplotlib.axes.Axes, optional
         Axes on which to draw the plot. Defaults to the current Axes.
+    **kwargs
+        Additional keyword arguments passed to `matplotlib.axes.Axes.fill_between`.
 
     Returns
     -------
@@ -774,62 +786,117 @@ def ridgeplot(
 
     >>> # Time series data with a custom colormap
     >>> ax = cns.ridgeplot(data=df, x="temperature", y="month", cmap="plasma")
+
+    >>> # Compare groups within each ridge and adjust their overlap
+    >>> ax = cns.ridgeplot(
+    ...     data=df,
+    ...     x="expression",
+    ...     y="tissue_type",
+    ...     hue="treatment",
+    ...     overlap=0.7,
+    ...     alpha=0.6,
+    ... )
     """
     # Validate inputs
     validate_dataframe(data, "data", "ridgeplot")
-    validate_columns_exist(data, [x, y], "ridgeplot")
+    columns = [x, y] if hue is None else [x, y, hue]
+    validate_columns_exist(data, columns, "ridgeplot")
     validate_dataframe_not_empty(data, "ridgeplot")
-    validate_no_nulls(data, [x, y], "ridgeplot")
+    validate_no_nulls(data, columns, "ridgeplot")
 
-    categories = data[y].unique()
-    grouped_values: list[tuple[Any, np.ndarray]] = []
-    for category in categories:
-        values = data.loc[data[y] == category, x].to_numpy()
-        if values.size < 2:
-            raise ValueError(
-                f"[ridgeplot] Group {category!r} must contain at least two "
-                "observations."
+    if isinstance(overlap, (bool, np.bool_)) or not isinstance(overlap, Real):
+        raise TypeError(
+            "[ridgeplot] Parameter 'overlap' must be a number between 0 and 1"
+        )
+    if not np.isfinite(overlap) or not 0 <= overlap <= 1:
+        raise ValueError(
+            "[ridgeplot] Parameter 'overlap' must be finite and between 0 and 1"
+        )
+
+    categories = list(data[y].unique())
+    hue_levels = [] if hue is None else list(data[hue].unique())
+    grouped_values: list[tuple[int, Any, Any | None, np.ndarray]] = []
+    for category_index, category in enumerate(categories):
+        category_data = data.loc[data[y] == category]
+        group_hues: list[Any | None] = [None] if hue is None else hue_levels
+        for hue_value in group_hues:
+            values = (
+                category_data[x].to_numpy()
+                if hue is None
+                else category_data.loc[category_data[hue] == hue_value, x].to_numpy()
             )
-        if pd.Series(values).nunique() < 2:
-            raise ValueError(
-                f"[ridgeplot] Group {category!r} is constant; kernel density "
-                "estimation requires varying values."
+            if values.size == 0:
+                continue
+            group_description = (
+                f"{category!r}"
+                if hue is None
+                else f"{category!r} with {hue}={hue_value!r}"
             )
-        grouped_values.append((category, values))
+            if values.size < 2:
+                raise ValueError(
+                    f"[ridgeplot] Group {group_description} must contain at least two "
+                    "observations."
+                )
+            if pd.Series(values).nunique() < 2:
+                raise ValueError(
+                    f"[ridgeplot] Group {group_description} is constant; kernel "
+                    "density estimation requires varying values."
+                )
+            grouped_values.append((category_index, category, hue_value, values))
 
     n = len(categories)
-    colors = utils._get_hex_colors_from_colorbar(cmap, n)
+    color_levels = categories if hue is None else hue_levels
+    colors = utils._get_hex_colors_from_colorbar(cmap, len(color_levels))
+    color_map = dict(zip(color_levels, colors))
     if ax is None:
         ax = plt.gca()
 
     from scipy.stats import gaussian_kde
 
-    overlap = 0.5
     x_min, x_max = data[x].min(), data[x].max()
     x_grid = np.linspace(x_min, x_max, 200)
+    hue_handles: dict[Any, Any] = {}
 
-    for i, (cat, x_v) in enumerate(grouped_values):
+    for category_index, _, hue_value, x_v in grouped_values:
         kde = gaussian_kde(x_v)
         y_vals = kde(x_grid)
         y_vals = y_vals / y_vals.max()
-        offset = (n - 1 - i) * (1 - overlap)
-        ax.fill_between(
+        offset = (n - 1 - category_index) * (1 - overlap)
+        color_level = categories[category_index] if hue is None else hue_value
+        color = color_map[color_level]
+        fill_kwargs: dict[str, Any] = {
+            "alpha": 1,
+            "color": color,
+            "zorder": category_index,
+            "linewidth": 0.5,
+            "edgecolor": color,
+        }
+        fill_kwargs.update(kwargs)
+        collection = ax.fill_between(
             x_grid,
             offset,
             y_vals + offset,
-            alpha=1,
-            color=colors[i],
-            zorder=i,
-            linewidth=0.5,
-            edgecolor=colors[i],
+            **fill_kwargs,
         )
+        if hue is not None and hue_value not in hue_handles:
+            hue_handles[hue_value] = collection
+
+    for category_index, category in enumerate(categories):
+        offset = (n - 1 - category_index) * (1 - overlap)
         ax.text(
             x_min,
             offset + 0.05,
-            cat,
+            category,
             ha="right",
             va="bottom",
             fontsize=_legend_fontsize(),
+        )
+
+    if hue is not None:
+        ax.legend(
+            [hue_handles[hue_value] for hue_value in hue_levels],
+            [str(hue_value) for hue_value in hue_levels],
+            title=hue,
         )
 
     ax.set_xlim(x_min, x_max)

--- a/tests/test_ridgeplot_defects.py
+++ b/tests/test_ridgeplot_defects.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import inspect
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import pytest
 import scipy.stats
@@ -47,3 +52,179 @@ def test_ridgeplot_rejects_null_group_labels() -> None:
 
     with pytest.raises(ValueError, match="Null values"):
         cns.ridgeplot(data, x="value", y="group")
+
+
+def test_ridgeplot_customization_parameters_are_keyword_only() -> None:
+    parameters = inspect.signature(cns.ridgeplot).parameters
+
+    assert parameters["hue"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["overlap"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["overlap"].default == 0.5
+
+
+@pytest.mark.parametrize(
+    ("overlap", "expected_offsets"),
+    [
+        (None, [1.0, 0.5, 0.0]),
+        (0.0, [2.0, 1.0, 0.0]),
+        (0.25, [1.5, 0.75, 0.0]),
+        (1.0, [0.0, 0.0, 0.0]),
+    ],
+)
+def test_ridgeplot_uses_configurable_overlap(
+    overlap: float | None,
+    expected_offsets: list[float],
+) -> None:
+    data = pd.DataFrame(
+        {
+            "value": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            "group": ["A", "A", "B", "B", "C", "C"],
+        }
+    )
+    _, ax = plt.subplots()
+
+    if overlap is None:
+        cns.ridgeplot(data, x="value", y="group", ax=ax)
+    else:
+        cns.ridgeplot(data, x="value", y="group", ax=ax, overlap=overlap)
+
+    offsets = [
+        np.asarray(collection.get_paths()[0].vertices)[:, 1].min()
+        for collection in ax.collections
+    ]
+    assert offsets == pytest.approx(expected_offsets)
+
+
+def test_ridgeplot_overlays_observed_hues_and_forwards_fill_kwargs() -> None:
+    data = pd.DataFrame(
+        {
+            "value": [0.0, 0.5, 1.0, 2.0, 2.5, 3.0, 4.0, 4.5, 5.0],
+            "group": ["A"] * 6 + ["B"] * 3,
+            "condition": ["H2"] * 3 + ["H1"] * 6,
+        }
+    )
+    _, ax = plt.subplots()
+
+    cns.ridgeplot(
+        data,
+        x="value",
+        y="group",
+        hue="condition",
+        ax=ax,
+        alpha=0.35,
+        linewidth=2.0,
+        edgecolor="black",
+        zorder=9,
+    )
+
+    assert len(ax.collections) == 3
+    facecolors = [collection.get_facecolor()[0] for collection in ax.collections]
+    assert not np.allclose(facecolors[0], facecolors[1])
+    assert np.allclose(facecolors[1], facecolors[2])
+    for collection in ax.collections:
+        assert collection.get_alpha() == pytest.approx(0.35)
+        assert collection.get_linewidth() == pytest.approx([2.0])
+        assert np.allclose(
+            collection.get_edgecolor(), [mcolors.to_rgba("black", alpha=0.35)]
+        )
+        assert collection.get_zorder() == 9
+
+    assert [text.get_text() for text in ax.texts] == ["A", "B"]
+    legend = ax.get_legend()
+    assert legend is not None
+    assert legend.get_title().get_text() == "condition"
+    assert [text.get_text() for text in legend.get_texts()] == ["H2", "H1"]
+
+
+def test_ridgeplot_fill_kwargs_override_default_color() -> None:
+    data = pd.DataFrame(
+        {
+            "value": [0.0, 1.0, 2.0, 3.0],
+            "group": ["A", "A", "B", "B"],
+        }
+    )
+
+    ax = cns.ridgeplot(data, x="value", y="group", color="magenta")
+
+    for collection in ax.collections:
+        assert np.allclose(collection.get_facecolor(), [mcolors.to_rgba("magenta")])
+
+
+@pytest.mark.parametrize(
+    ("overlap", "error"),
+    [
+        (True, TypeError),
+        ("0.5", TypeError),
+        (-0.1, ValueError),
+        (1.1, ValueError),
+        (np.nan, ValueError),
+        (np.inf, ValueError),
+    ],
+)
+def test_ridgeplot_rejects_invalid_overlap_before_kde(
+    monkeypatch: pytest.MonkeyPatch,
+    overlap: object,
+    error: type[Exception],
+) -> None:
+    data = pd.DataFrame({"value": [0.0, 1.0], "group": ["A", "A"]})
+
+    def unexpected_kde(*args: object, **kwargs: object) -> None:
+        raise AssertionError("gaussian_kde should not be called")
+
+    monkeypatch.setattr(scipy.stats, "gaussian_kde", unexpected_kde)
+
+    with pytest.raises(error, match="overlap"):
+        cns.ridgeplot(
+            data,
+            x="value",
+            y="group",
+            overlap=overlap,  # ty: ignore[invalid-argument-type]
+        )
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (
+            pd.DataFrame(
+                {
+                    "value": [0.0, 1.0, 2.0, 3.0],
+                    "group": ["A", "A", "B", "B"],
+                }
+            ),
+            "Column",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "value": [0.0, 1.0, 2.0, 3.0],
+                    "group": ["A", "A", "B", "B"],
+                    "condition": ["H1", None, "H1", "H1"],
+                }
+            ),
+            "Null values",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "value": [0.0, 1.0, 2.0, 3.0],
+                    "group": ["A", "A", "B", "B"],
+                    "condition": ["H1", "H2", "H1", "H1"],
+                }
+            ),
+            "at least two observations",
+        ),
+    ],
+)
+def test_ridgeplot_rejects_invalid_hue_groups_before_kde(
+    monkeypatch: pytest.MonkeyPatch,
+    data: pd.DataFrame,
+    message: str,
+) -> None:
+    def unexpected_kde(*args: object, **kwargs: object) -> None:
+        raise AssertionError("gaussian_kde should not be called")
+
+    monkeypatch.setattr(scipy.stats, "gaussian_kde", unexpected_kde)
+
+    with pytest.raises(ValueError, match=message):
+        cns.ridgeplot(data, x="value", y="group", hue="condition")


### PR DESCRIPTION
## Goal

Make ridgeplot overlap configurable and support overlaid hue distributions with Matplotlib styling passthrough.

## What changed

- Added keyword-only hue and overlap parameters while preserving the existing default rendering.
- Overlaid observed hue groups at each ridge offset with consistent colors and a legend.
- Forwarded additional styling keywords to Axes.fill_between with caller values taking precedence.
- Added validation, regression coverage, and a gallery example.

## Testing

- make test: 533 passed with 100% coverage.
- make lint: passed.
- MPLBACKEND=Agg uv run python examples/ridgeplot.py: passed.

## Risks and follow-ups

The new parameters are keyword-only, so existing positional calls remain compatible. Each observed hue subset must contain at least two varying values for KDE estimation. No follow-up work is required.