### PR TITLE
🐛 Inherit panel label fonts

### DIFF
--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -334,7 +334,8 @@ class multipanel:
         self.fig = None
         self.axes = []
         self._created_axes = {}
-        self._label_texts = {}
+        self._label_texts: dict[str, Text] = {}
+        self._label_inherited_fontfamilies: dict[str, list[str]] = {}
         self._title_text: Text | None = None
         self._labels = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         self._panel_index = 0
@@ -471,6 +472,7 @@ class multipanel:
             return None
         if label_text.figure is not self.fig or label_text.axes is not ax:
             self._label_texts.pop(label, None)
+            self._label_inherited_fontfamilies.pop(label, None)
             return None
         return label_text
 
@@ -847,9 +849,6 @@ class multipanel:
                 top_label_offset,
             )
             if label_text is None:
-                font_kwargs: dict[str, Any] = {}
-                if settings.panel_label_fontname is not None:
-                    font_kwargs["fontname"] = settings.panel_label_fontname
                 label_text = ax.text(
                     0,
                     1,
@@ -859,8 +858,12 @@ class multipanel:
                     fontweight=settings.panel_label_fontweight,
                     ha="right",
                     va="bottom",
-                    **font_kwargs,
                 )
+                if settings.panel_label_fontname is not None:
+                    self._label_inherited_fontfamilies[label] = (
+                        label_text.get_fontfamily()
+                    )
+                    label_text.set_fontname(settings.panel_label_fontname)
                 self._label_texts[label] = label_text
             else:
                 label_text.set_position((0, 1))
@@ -869,7 +872,18 @@ class multipanel:
                 label_text.set_fontsize(settings.title_fontsize)
                 label_text.set_fontweight(settings.panel_label_fontweight)
                 if settings.panel_label_fontname is not None:
+                    self._label_inherited_fontfamilies.setdefault(
+                        label,
+                        label_text.get_fontfamily(),
+                    )
                     label_text.set_fontname(settings.panel_label_fontname)
+                else:
+                    inherited_fontfamily = self._label_inherited_fontfamilies.pop(
+                        label,
+                        None,
+                    )
+                    if inherited_fontfamily is not None:
+                        label_text.set_fontfamily(inherited_fontfamily)
                 label_text.set_horizontalalignment("right")
                 label_text.set_verticalalignment("bottom")
 

--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -847,6 +847,9 @@ class multipanel:
                 top_label_offset,
             )
             if label_text is None:
+                font_kwargs: dict[str, Any] = {}
+                if settings.panel_label_fontname is not None:
+                    font_kwargs["fontname"] = settings.panel_label_fontname
                 label_text = ax.text(
                     0,
                     1,
@@ -854,9 +857,9 @@ class multipanel:
                     transform=label_transform,
                     fontsize=settings.title_fontsize,
                     fontweight=settings.panel_label_fontweight,
-                    fontname=settings.panel_label_fontname,
                     ha="right",
                     va="bottom",
+                    **font_kwargs,
                 )
                 self._label_texts[label] = label_text
             else:
@@ -865,7 +868,10 @@ class multipanel:
                 label_text.set_transform(label_transform)
                 label_text.set_fontsize(settings.title_fontsize)
                 label_text.set_fontweight(settings.panel_label_fontweight)
-                label_text.set_fontname(settings.panel_label_fontname)
+                if settings.panel_label_fontname is None:
+                    label_text.set_fontfamily(plt.rcParams["font.family"])
+                else:
+                    label_text.set_fontname(settings.panel_label_fontname)
                 label_text.set_horizontalalignment("right")
                 label_text.set_verticalalignment("bottom")
 

--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -868,9 +868,7 @@ class multipanel:
                 label_text.set_transform(label_transform)
                 label_text.set_fontsize(settings.title_fontsize)
                 label_text.set_fontweight(settings.panel_label_fontweight)
-                if settings.panel_label_fontname is None:
-                    label_text.set_fontfamily(plt.rcParams["font.family"])
-                else:
+                if settings.panel_label_fontname is not None:
                     label_text.set_fontname(settings.panel_label_fontname)
                 label_text.set_horizontalalignment("right")
                 label_text.set_verticalalignment("bottom")

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -95,6 +95,12 @@ def _validate_string(name: str, value: Any) -> str:
     return value
 
 
+def _validate_optional_string(name: str, value: Any) -> str | None:
+    if value is None:
+        return None
+    return _validate_string(name, value)
+
+
 def _validate_string_choice(name: str, value: Any, choices: Sequence[str]) -> str:
     value = _validate_string(name, value)
     if value not in choices:
@@ -263,6 +269,8 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
             "Helvetica",
             "Helvetica Neue",
             "Arial",
+            "Nimbus Sans",
+            "Liberation Sans",
             "DejaVu Sans",
         ),
         lambda value: _validate_string_sequence("font_sans_serif", value),
@@ -599,9 +607,9 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
         "Default right margin in pixels for multipanel.panel().",
     ),
     "panel_label_fontname": _spec(
-        "Helvetica",
-        lambda value: _validate_string("panel_label_fontname", value),
-        "Font name used for panel labels.",
+        None,
+        lambda value: _validate_optional_string("panel_label_fontname", value),
+        "Optional font name for panel labels. Use None to inherit the configured font family and sans-serif fallbacks.",
     ),
     "panel_label_fontweight": _spec(
         "bold",
@@ -741,7 +749,7 @@ class CNSSettings:
         panel_margin_bottom: _Number
         panel_margin_left: _Number
         panel_margin_right: _Number
-        panel_label_fontname: str
+        panel_label_fontname: str | None
         panel_label_fontweight: str | int
 
         @property

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -603,8 +603,9 @@ def add_panel_label(
     Unlike ``multipanel.panel()``, this helper does not measure rendered axis
     decorations or relayout the figure. It is purely an axes-relative offset.
 
-    The label uses Arial font (bold) at 8pt size (`title_fontsize`) for
-    consistency with publication standards.
+    The label uses the configured font family (bold) at 8pt size
+    (``title_fontsize``) for consistency with publication standards. Set
+    ``panel_label_fontname`` to explicitly override the family.
 
     Examples
     --------
@@ -631,16 +632,20 @@ def add_panel_label(
         fig.dpi_scale_trans,
     )
 
+    font_kwargs: dict[str, Any] = {}
+    if settings.panel_label_fontname is not None:
+        font_kwargs["fontname"] = settings.panel_label_fontname
+
     ax.text(
         0,
         1,
         name,
         transform=transform,
         fontsize=settings.title_fontsize,
-        fontname=settings.panel_label_fontname,
         fontweight=settings.panel_label_fontweight,
         ha="right",
         va="bottom",
+        **font_kwargs,
     )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1376,6 +1376,25 @@ def test_panel_labels_inherit_configured_sans_serif_by_default() -> None:
         assert multipanel_label.get_fontproperties().get_name() == "DejaVu Sans"
 
 
+def test_multipanel_relayout_preserves_inherited_font_across_figures() -> None:
+    with cns.settings.context(
+        font_family="sans-serif",
+        font_sans_serif=("DejaVu Sans",),
+        panel_label_fontname=None,
+    ):
+        mp = cns.multipanel(max_width=300)
+        mp.panel("A", 90, 90)
+        panel_label = mp._label_texts["A"]
+        inherited_family = panel_label.get_fontfamily()
+
+        with cns.settings.context(font_family="serif"):
+            cns.figure()
+            assert plt.rcParams["font.family"] == ["serif"]
+            mp._create_or_update_figure()
+
+        assert panel_label.get_fontfamily() == inherited_family
+
+
 def test_figure_keeps_fixed_size_with_overflowing_artists() -> None:
     cns.figure(100, 120)
     fig = plt.gcf()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1395,6 +1395,25 @@ def test_multipanel_relayout_preserves_inherited_font_across_figures() -> None:
         assert panel_label.get_fontfamily() == inherited_family
 
 
+def test_multipanel_relayout_restores_inherited_font_after_override() -> None:
+    with cns.settings.context(
+        font_family="sans-serif",
+        font_sans_serif=("DejaVu Sans",),
+        panel_label_fontname=None,
+    ):
+        mp = cns.multipanel(max_width=300)
+        with cns.settings.context(panel_label_fontname="DejaVu Serif"):
+            mp.panel("A", 90, 90)
+            first_label = mp._label_texts["A"]
+            assert first_label.get_fontfamily() == ["DejaVu Serif"]
+
+        mp.panel("B", 90, 90)
+        second_label = mp._label_texts["B"]
+
+        assert first_label.get_fontfamily() == ["sans-serif"]
+        assert second_label.get_fontfamily() == ["sans-serif"]
+
+
 def test_figure_keeps_fixed_size_with_overflowing_artists() -> None:
     cns.figure(100, 120)
     fig = plt.gcf()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -390,9 +390,11 @@ def test_settings_behavior() -> None:
         "Helvetica",
         "Helvetica Neue",
         "Arial",
+        "Nimbus Sans",
+        "Liberation Sans",
         "DejaVu Sans",
     )
-    assert settings.panel_label_fontname == "Helvetica"
+    assert settings.panel_label_fontname is None
 
 
 def test_settings_validation_errors() -> None:
@@ -454,6 +456,9 @@ def test_settings_validation_errors() -> None:
         setattr(settings, "font_sans_serif", ["Arial", 1])
     with pytest.raises(ValueError):
         settings.font_sans_serif = []
+    settings.panel_label_fontname = None
+    with pytest.raises(TypeError):
+        setattr(settings, "panel_label_fontname", 1)
     with pytest.raises(TypeError):
         setattr(settings, "scanpy_figsize", "big")
     with pytest.raises(ValueError):
@@ -1348,6 +1353,27 @@ def test_utils_helpers_and_showcase_data(
     assert isinstance(data[12], dict)
     assert len(data_with_assets) == 14
     assert data_with_assets[-1].name == "showcase"
+
+
+def test_panel_labels_inherit_configured_sans_serif_by_default() -> None:
+    with cns.settings.context(
+        font_family="sans-serif",
+        font_sans_serif=("DejaVu Sans",),
+        panel_label_fontname=None,
+    ):
+        cns.figure()
+        cns.add_panel_label("A")
+        helper_label = plt.gca().texts[-1]
+
+        assert helper_label.get_fontfamily() == ["sans-serif"]
+        assert helper_label.get_fontproperties().get_name() == "DejaVu Sans"
+
+        mp = cns.multipanel(max_width=300)
+        mp.panel("B", 90, 90)
+        multipanel_label = mp._label_texts["B"]
+
+        assert multipanel_label.get_fontfamily() == ["sans-serif"]
+        assert multipanel_label.get_fontproperties().get_name() == "DejaVu Sans"
 
 
 def test_figure_keeps_fixed_size_with_overflowing_artists() -> None:

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         assert_type(cns.settings.legend_fontsize, int | float | None)
         assert_type(cns.settings.savefig_transparent, bool)
         assert_type(cns.settings.font_sans_serif, tuple[str, ...])
+        assert_type(cns.settings.panel_label_fontname, str | None)
 
         assert_type(cns.figure(width=120, height=80), None)
         assert_type(cns.savefig("figure.svg"), None)


### PR DESCRIPTION
## Purpose
Fix #118 by making panel labels inherit the configured sans-serif fallback chain.

## Changes
Default `panel_label_fontname` to `None`, add Linux-friendly fallbacks, and cover both label APIs with regression tests.

## Testing
- `make test` — 534 passed
- `make lint` — passed

## Risks
Low; explicit font overrides remain supported.