### PR TITLE
💚 Align docs font expectations

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -55,9 +55,11 @@ jobs:
               "Helvetica",
               "Helvetica Neue",
               "Arial",
+              "Nimbus Sans",
+              "Liberation Sans",
               "DejaVu Sans",
           )
-          assert cns.settings.panel_label_fontname == "Helvetica"
+          assert cns.settings.panel_label_fontname is None
           font_props = fm.FontProperties(
               family=mpl.rcParams["font.family"],
               style="normal",


### PR DESCRIPTION
## Goal

Restore the docs workflow after the panel-label font defaults changed in PR #119.

## What changed

- Include Nimbus Sans and Liberation Sans in the expected sans-serif fallback tuple.
- Expect panel labels to inherit the configured family by default via `panel_label_fontname is None`.

## Testing

- Exact `Verify docs font` script — passed; resolved Helvetica on macOS.
- `make test` — 536 passed with 100% coverage.
- `make lint` — passed.
- Versioned docs link check — passed.
- Versioned docs `main`-mode build — passed.

## Risks and follow-ups

Low risk: this changes only the inline CI assertions to match tested application defaults. No follow-up is required.
