### PR TITLE
👽️ Prevent dependency deprecation failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ addopts = "--cov=cnsplots --cov-report=term-missing --cov-fail-under=100"
 filterwarnings = [
   "error",
   "ignore:Could not find the number of physical cores.*:UserWarning:joblib[.]externals[.]loky[.]backend[.]context",
+  "ignore:Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future[.] Ensure you extract a single element from your array before performing this operation[.] [(]Deprecated NumPy 1[.]25[.][)]:DeprecationWarning:lifelines[.]plotting",
   "ignore:vert.*bool will be deprecated in a future version[.] Use orientation.*instead[.]:PendingDeprecationWarning:seaborn[.]categorical",
   "ignore:vert.*bool was deprecated in Matplotlib 3[.]11 and will be removed in 3[.]13[.] Use orientation.*instead[.]:matplotlib.MatplotlibDeprecationWarning:seaborn[.]categorical",
   "ignore:Downcasting object dtype arrays on .* is deprecated and will change in a future version[.].*:FutureWarning:upsetplot[.]data",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ filterwarnings = [
   "error",
   "ignore:Could not find the number of physical cores.*:UserWarning:joblib[.]externals[.]loky[.]backend[.]context",
   "ignore:vert.*bool will be deprecated in a future version[.] Use orientation.*instead[.]:PendingDeprecationWarning:seaborn[.]categorical",
+  "ignore:vert.*bool was deprecated in Matplotlib 3[.]11 and will be removed in 3[.]13[.] Use orientation.*instead[.]:matplotlib.MatplotlibDeprecationWarning:seaborn[.]categorical",
   "ignore:Downcasting object dtype arrays on .* is deprecated and will change in a future version[.].*:FutureWarning:upsetplot[.]data",
   "ignore:A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method[.]:FutureWarning:upsetplot[.]plotting",
   "ignore:The default of observed=False is deprecated and will be changed to True in a future version of pandas[.].*:FutureWarning:PyComplexHeatmap[.]clustermap",
@@ -128,6 +129,7 @@ filterwarnings = [
   "ignore:The provided callable .* is currently using DataFrameGroupBy[.]mean[.].*:FutureWarning:PyComplexHeatmap[.]dotHeatmap",
   "ignore:DataFrame[.]applymap has been deprecated[.] Use DataFrame[.]map instead[.]:FutureWarning:PyComplexHeatmap[.]dotHeatmap",
   "ignore:The previous implementation of stack is deprecated and will be removed in a future version of pandas[.].*:FutureWarning:PyComplexHeatmap[.]dotHeatmap",
+  "ignore:The set_bad function will be deprecated in a future version[.] Use cmap[.]with_extremes[(]bad=[.]{3}[)] or Colormap[(]bad=[.]{3}[)] instead[.]:PendingDeprecationWarning:PyComplexHeatmap[.]utils",
   "ignore:This figure was using a layout engine that is incompatible with subplots_adjust and/or tight_layout; not calling subplots_adjust[.]:UserWarning:PyComplexHeatmap[.]utils",
 ]
 mpl-default-style = "default"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,19 @@ fail_under = 100
 
 [tool.pytest.ini_options]
 addopts = "--cov=cnsplots --cov-report=term-missing --cov-fail-under=100"
+filterwarnings = [
+  "error",
+  "ignore:Could not find the number of physical cores.*:UserWarning:joblib[.]externals[.]loky[.]backend[.]context",
+  "ignore:vert.*bool will be deprecated in a future version[.] Use orientation.*instead[.]:PendingDeprecationWarning:seaborn[.]categorical",
+  "ignore:Downcasting object dtype arrays on .* is deprecated and will change in a future version[.].*:FutureWarning:upsetplot[.]data",
+  "ignore:A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method[.]:FutureWarning:upsetplot[.]plotting",
+  "ignore:The default of observed=False is deprecated and will be changed to True in a future version of pandas[.].*:FutureWarning:PyComplexHeatmap[.]clustermap",
+  "ignore:DataFrameGroupBy[.]apply operated on the grouping columns[.].*:FutureWarning:PyComplexHeatmap[.]clustermap",
+  "ignore:The provided callable .* is currently using DataFrameGroupBy[.]mean[.].*:FutureWarning:PyComplexHeatmap[.]dotHeatmap",
+  "ignore:DataFrame[.]applymap has been deprecated[.] Use DataFrame[.]map instead[.]:FutureWarning:PyComplexHeatmap[.]dotHeatmap",
+  "ignore:The previous implementation of stack is deprecated and will be removed in a future version of pandas[.].*:FutureWarning:PyComplexHeatmap[.]dotHeatmap",
+  "ignore:This figure was using a layout engine that is incompatible with subplots_adjust and/or tight_layout; not calling subplots_adjust[.]:UserWarning:PyComplexHeatmap[.]utils",
+]
 mpl-default-style = "default"
 mpl-deterministic = true
 mpl-generate-summary = "html"

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     import numpy as np
     import pandas as pd
 
+import inspect
 import re
 import warnings
 
@@ -444,6 +445,12 @@ class LogisticModel:
 
         df = self.data.copy()
         all_results = []
+        regularization_options: dict[str, Any] = (
+            {"l1_ratios": (1,), "use_legacy_attributes": False}
+            if "use_legacy_attributes"
+            in inspect.signature(LogisticRegressionCV).parameters
+            else {"penalty": "l1"}
+        )
 
         if self.hue is None:
             hue_groups = [("All", df)]
@@ -494,10 +501,10 @@ class LogisticModel:
                         StandardScaler(),
                         LogisticRegressionCV(
                             cv=n_splits,
-                            penalty="l1",
                             solver="liblinear",
                             random_state=42,
                             scoring="roc_auc",
+                            **regularization_options,
                         ),
                     )
                     y_pred_proba = cross_val_predict(

--- a/src/cnsplots/_validation.py
+++ b/src/cnsplots/_validation.py
@@ -383,7 +383,7 @@ def validate_column_type(
         if (
             not pd.api.types.is_object_dtype(dtype)
             and not pd.api.types.is_string_dtype(dtype)
-            and not pd.api.types.is_categorical_dtype(dtype)
+            and not isinstance(dtype, pd.CategoricalDtype)
         ):
             raise ValueError(
                 f"[{function_name}] Column '{column}' must be categorical/string, "

--- a/src/cnsplots/helpers/_phylo.py
+++ b/src/cnsplots/helpers/_phylo.py
@@ -182,7 +182,7 @@ def _heatmap(
     vfunc = np.vectorize(mapper)
 
     if isinstance(data, pd.DataFrame):
-        numerical_data = data.applymap(mapper)
+        numerical_data = data.map(mapper)
     elif isinstance(data, pd.Series):
         numerical_data = data.map(mapper).to_frame()
     elif isinstance(data, np.ndarray):

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -358,7 +358,16 @@ def barplot(
     plotting.update(kwargs)
     if ax is None:
         ax = plt.gca()
-    ax = sns.barplot(ax=ax, **plotting)
+    seaborn_plotting = plotting
+    if palette is not None and hue is None:
+        category_column = y if pd.api.types.is_numeric_dtype(data[x]) else x
+        seaborn_plotting = {
+            **plotting,
+            "hue": category_column,
+            "hue_order": order,
+            "legend": False,
+        }
+    ax = sns.barplot(ax=ax, **seaborn_plotting)
     bar_labels = []
     if add_tip:
         for container in (
@@ -575,11 +584,9 @@ def lollipopplot(
     else:
         resolved_colors = sns.color_palette(n_colors=len(categories))
 
-    agg_func = np.median if estimator == "median" else np.mean
-
     if hue is None:
         grouped = data.groupby(cat_col, sort=False)[val_col]
-        means = grouped.agg(agg_func).reindex(categories)
+        means = grouped.agg(estimator).reindex(categories)
         errors = _lollipop_errors(
             grouped,
             categories,
@@ -617,7 +624,7 @@ def lollipopplot(
         for i, hue_val in enumerate(hue_levels):
             subset = data[data[hue] == hue_val]
             grouped = subset.groupby(cat_col, sort=False)[val_col]
-            means = grouped.agg(agg_func).reindex(categories)
+            means = grouped.agg(estimator).reindex(categories)
             positions = cat_positions + offsets[i]
             errors = _lollipop_errors(
                 grouped,

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -582,7 +582,7 @@ def _draw_forestplot(
         ax.errorbar(
             estimates,
             y_coords,
-            xerr=[lower_errors, upper_errors],
+            xerr=np.vstack((lower_errors, upper_errors)),
             fmt="s",
             color=color_map[hue_value],
             markeredgewidth=0.8,

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -737,6 +737,7 @@ def cumulativeincidenceplot(
         finally:
             np.random.set_state(random_state)
         fitters.append(fitter)
+        df = df.astype({duration: float})
         df = pd.merge(
             fitter.cumulative_density_.reset_index(drop=False),
             df,
@@ -745,7 +746,7 @@ def cumulativeincidenceplot(
             right_on=duration,
         )
         df = df.loc[df[event] == 0].copy()
-        fitter.plot(ax=ax, linewidth=1, ci_show=False)
+        fitter.plot_cumulative_density(ax=ax, linewidth=1, ci_show=False)
         line_color = ax.get_lines()[-1].get_color()
         group_censor_mark_position = _resolve_censor_mark_position(
             censor_mark_position, i

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -439,6 +439,7 @@ def test_utils_internal_coverage(
 
     fig, ax = plt.subplots()
     plt.sca(ax)
+    ax.plot([], [], label="series")
     _utils.take_legend_out()
     legend = ax.get_legend()
     assert legend is not None

--- a/tests/test_methods_and_helpers.py
+++ b/tests/test_methods_and_helpers.py
@@ -205,15 +205,16 @@ def test_sankey_helpers(sankey_df: pd.DataFrame) -> None:
         )
 
     fig2, ax2 = plt.subplots()
-    result_ax = _sankey.sankeyplot(
-        sankey_df["source"],
-        sankey_df["target"],
-        label_rotation=90,
-        figureName="figure",
-        closePlot=True,
-        figSize=(2, 2),
-        ax=ax2,
-    )
+    with pytest.warns(DeprecationWarning):
+        result_ax = _sankey.sankeyplot(
+            sankey_df["source"],
+            sankey_df["target"],
+            label_rotation=90,
+            figureName="figure",
+            closePlot=True,
+            figSize=(2, 2),
+            ax=ax2,
+        )
     assert result_ax is ax2
     assert len(ax2.texts) == len(left_labels) + len(right_labels)
     assert all(text.get_rotation() == 90 for text in ax2.texts)

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -8,6 +8,7 @@ import lifelines as ll
 import numpy as np
 import pandas as pd
 import pytest
+from lifelines.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegressionCV
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
@@ -98,7 +99,11 @@ def test_logistic_model_uses_scaled_out_of_fold_predictions(
         scaler, classifier = (step for _, step in estimator.steps)
         assert isinstance(scaler, StandardScaler)
         assert isinstance(classifier, LogisticRegressionCV)
-        assert classifier.penalty == "l1"
+        if classifier.penalty == "deprecated":
+            assert classifier.l1_ratios == (1,)
+            assert classifier.use_legacy_attributes is False
+        else:
+            assert classifier.penalty == "l1"
         assert classifier.solver == "liblinear"
         assert classifier.cv == 5
 
@@ -155,9 +160,12 @@ def test_logistic_model_validates_each_nested_cv_layer(
     data = pd.DataFrame({"event": event, "score": np.arange(len(event))})
     model = cns.LogisticModel(data, event="event", variates=["score"])
 
-    with pytest.warns(RuntimeWarning, match=message):
+    with pytest.warns(RuntimeWarning) as caught:
         model.fit()
 
+    messages = [str(warning.message) for warning in caught]
+    assert any(message in warning_message for warning_message in messages)
+    assert "No successful model fits" in messages
     assert model.results is None
 
 
@@ -165,9 +173,15 @@ def test_logistic_model_rejects_more_than_two_outcome_classes() -> None:
     data = pd.DataFrame({"event": [0, 1, 2] * 7, "score": np.arange(21, dtype=float)})
     model = cns.LogisticModel(data, event="event", variates=["score"])
 
-    with pytest.warns(RuntimeWarning, match="requires exactly two outcome classes"):
+    with pytest.warns(RuntimeWarning) as caught:
         model.fit()
 
+    messages = [str(warning.message) for warning in caught]
+    assert any(
+        "requires exactly two outcome classes" in warning_message
+        for warning_message in messages
+    )
+    assert "No successful model fits" in messages
     assert model.results is None
 
 
@@ -234,7 +248,8 @@ def test_cox_model_retains_all_categorical_formula_coefficients(
         variates=["C(stage)"],
     )
 
-    model.fit()
+    with pytest.warns(ConvergenceWarning):
+        model.fit()
 
     assert model.results is not None
     results = model.results.sort_values("covariate").reset_index(drop=True)

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import seaborn as sns
+from lifelines.exceptions import ConvergenceWarning
 from matplotlib.axes import Axes
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.text import Text
@@ -598,7 +599,8 @@ def test_public_cox_model_and_forestplot_contract(
         event="event",
         variates=["age", "C(stage)"],
     )
-    model.fit()
+    with pytest.warns(ConvergenceWarning):
+        model.fit()
     assert model.results is not None
     assert set(model.results.columns) == {
         "display_label",
@@ -621,7 +623,8 @@ def test_public_cox_model_and_forestplot_contract(
         variates=["age"],
         hue="group",
     )
-    model_hue.fit()
+    with pytest.warns(ConvergenceWarning):
+        model_hue.fit()
     cns.figure(120, 120)
     ax = cns.forestplot(model_hue)
     assert ax.get_xlabel() == "Hazard ratio (95% CI)"

--- a/tests/test_survival_hardening.py
+++ b/tests/test_survival_hardening.py
@@ -27,7 +27,7 @@ def test_survivalplot_requires_valid_durations(
     invalid_duration: float,
     message: str,
 ) -> None:
-    invalid = survival_df.copy()
+    invalid = survival_df.astype({"time": float})
     invalid.loc[0, "time"] = invalid_duration
 
     with pytest.raises(ValueError, match=message):
@@ -54,7 +54,7 @@ def test_cumulativeincidenceplot_requires_valid_event_codes(
     competing_risk_df: pd.DataFrame,
     invalid_code: float,
 ) -> None:
-    invalid = competing_risk_df.copy()
+    invalid = competing_risk_df.astype({"event": float})
     invalid.loc[0, "event"] = invalid_code
 
     with pytest.raises(ValueError, match="non-negative integer event codes"):

--- a/uv.lock
+++ b/uv.lock
@@ -145,15 +145,15 @@ wheels = [
 
 [[package]]
 name = "autograd"
-version = "1.8.0"
+version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/1c/3c24ec03c8ba4decc742b1df5a10c52f98c84ca8797757f313e7bdcdf276/autograd-1.8.0.tar.gz", hash = "sha256:107374ded5b09fc8643ac925348c0369e7b0e73bbed9565ffd61b8fd04425683", size = 2562146, upload-time = "2025-05-05T12:49:02.502Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/ac/4a8b58364ba865ab545251edbe475e5a35326814a5d274a2211d33ed8a5d/autograd-1.9.1.tar.gz", hash = "sha256:7818c5c69ddf9efb7da74097bd741a4c7920133f41966f68537223a15ef798bc", size = 2566975, upload-time = "2026-07-02T07:43:58.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/ea/e16f0c423f7d83cf8b79cae9452040fb7b2e020c7439a167ee7c317de448/autograd-1.8.0-py3-none-any.whl", hash = "sha256:4ab9084294f814cf56c280adbe19612546a35574d67c574b04933c7d2ecb7d78", size = 51478, upload-time = "2025-05-05T12:49:00.585Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ce/8c98e6604bb1ec9d03c8493c328185b69bb7533fe08f3640f0f3641bd9d1/autograd-1.9.1-py3-none-any.whl", hash = "sha256:b788bae3fa010cbffb4cfb7b8ba2a3f0daa6072a8506da6164c779fe9cf3e05a", size = 54387, upload-time = "2026-07-02T07:43:56.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Goal

Prevent upcoming dependency releases from breaking plotting and model paths, and make new warnings fail during tests.

## What changed

- Replaced deprecated pandas elementwise mapping and callable aggregation APIs.
- Updated seaborn, lifelines, pandas dtype validation, merge handling, and scikit-learn compatibility paths.
- Enabled warnings as errors with narrowly scoped third-party filters for joblib, seaborn, upsetplot, and PyComplexHeatmap.
- Updated tests to assert intentional warnings and exercise version-dependent model configuration.

## Testing

- make test: 569 passed with 100% coverage.
- make lint: all hooks passed.
- make test-visual: invoked; all 32 hash checks skipped on macOS arm64 by the expected Linux x86_64 platform gate.
- git diff --check: passed.

## Risks and follow-ups

- Third-party warning filters intentionally match both module and message; upstream wording changes will fail the suite and require review.
- Manually dispatch the latest-dependencies workflow after merge to establish its warnings-as-errors baseline.