### PR TITLE
🦺 Validate malformed distribution plot data

### DIFF
--- a/src/cnsplots/_validation.py
+++ b/src/cnsplots/_validation.py
@@ -127,7 +127,8 @@ def validate_columns_exist(
     Raises
     ------
     ValueError
-        If any column does not exist in the DataFrame.
+        If any column does not exist or a requested column name is duplicated in
+        the DataFrame.
     """
     missing = [col for col in columns if col not in data.columns]
     if missing:
@@ -140,6 +141,14 @@ def validate_columns_exist(
         raise ValueError(
             f"[{function_name}] Column(s) {missing} not found in data. "
             f"Available columns: {available_str}"
+        )
+
+    duplicate_labels = data.columns[data.columns.duplicated(keep=False)]
+    duplicates = [col for col in dict.fromkeys(columns) if col in duplicate_labels]
+    if duplicates:
+        raise ValueError(
+            f"[{function_name}] Duplicate column name(s) {duplicates} found in data. "
+            "Referenced columns must have unique names."
         )
 
 
@@ -308,7 +317,8 @@ def validate_no_nulls(
     function_name : str
         The name of the calling function for error messages.
     allow_partial : bool, default False
-        If True, only warn if ALL values are null. If False, raise error if ANY null exists.
+        If True, allow nulls when every column has valid values and at least one
+        complete row remains. If False, raise an error if any null exists.
 
     Raises
     ------
@@ -340,6 +350,11 @@ def validate_no_nulls(
                 raise ValueError(
                     f"[{function_name}] Column(s) {all_null_cols} contain only null values. "
                     "At least some valid data is required."
+                )
+            if data[columns].dropna().empty:
+                raise ValueError(
+                    f"[{function_name}] Columns {columns} contain no complete rows. "
+                    "At least one row without null values is required."
                 )
 
 

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -1129,6 +1129,7 @@ def stripplot(
     columns = [x, y] if hue is None else [x, y, hue]
     validate_columns_exist(data, columns, "stripplot")
     validate_dataframe_not_empty(data, "stripplot")
+    validate_no_nulls(data, columns, "stripplot", allow_partial=True)
 
     if "addcount" in kwargs:
         raise TypeError(

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -115,6 +115,7 @@ def boxplot(
     columns = [x, y] if hue is None else [x, y, hue]
     validate_columns_exist(data, columns, "boxplot")
     validate_dataframe_not_empty(data, "boxplot")
+    validate_no_nulls(data, columns, "boxplot", allow_partial=True)
     utils._validate_statistical_options(
         test,
         p_adjust,
@@ -301,6 +302,7 @@ def violinplot(
     columns = [x, y] if hue is None else [x, y, hue]
     validate_columns_exist(data, columns, "violinplot")
     validate_dataframe_not_empty(data, "violinplot")
+    validate_no_nulls(data, columns, "violinplot", allow_partial=True)
     utils._validate_statistical_options(
         test,
         p_adjust,
@@ -802,7 +804,8 @@ def ridgeplot(
     columns = [x, y] if hue is None else [x, y, hue]
     validate_columns_exist(data, columns, "ridgeplot")
     validate_dataframe_not_empty(data, "ridgeplot")
-    validate_no_nulls(data, columns, "ridgeplot")
+    validate_no_nulls(data, columns, "ridgeplot", allow_partial=True)
+    data = data.dropna(subset=columns)
 
     if isinstance(overlap, (bool, np.bool_)) or not isinstance(overlap, Real):
         raise TypeError(

--- a/tests/test_distribution_plot_defects.py
+++ b/tests/test_distribution_plot_defects.py
@@ -1,0 +1,95 @@
+"""Regression tests for distribution plot validation."""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize(
+    ("plotter", "function_name"),
+    [
+        (cns.boxplot, "boxplot"),
+        (cns.violinplot, "violinplot"),
+        (cns.stripplot, "stripplot"),
+        (cns.ridgeplot, "ridgeplot"),
+    ],
+)
+def test_distribution_plot_rejects_all_null_values(
+    plotter: Any, function_name: str
+) -> None:
+    data = pd.DataFrame({"group": ["A", "A", "B"], "value": [np.nan] * 3})
+
+    with pytest.raises(
+        ValueError, match=rf"\[{function_name}\].*contain only null values"
+    ):
+        plotter(data, x="group", y="value")
+
+
+@pytest.mark.parametrize(
+    ("plotter", "function_name"),
+    [
+        (cns.boxplot, "boxplot"),
+        (cns.violinplot, "violinplot"),
+        (cns.stripplot, "stripplot"),
+        (cns.ridgeplot, "ridgeplot"),
+    ],
+)
+def test_distribution_plot_rejects_data_without_complete_rows(
+    plotter: Any, function_name: str
+) -> None:
+    data = pd.DataFrame({"group": ["A", None], "value": [None, 1.0]})
+
+    with pytest.raises(ValueError, match=rf"\[{function_name}\].*no complete rows"):
+        plotter(data, x="group", y="value")
+
+
+@pytest.mark.parametrize(
+    ("plotter", "x", "y"),
+    [
+        (cns.boxplot, "group", "value"),
+        (cns.violinplot, "group", "value"),
+        (cns.stripplot, "group", "value"),
+        (cns.barplot, "group", "value"),
+        (cns.ridgeplot, "value", "group"),
+    ],
+)
+def test_distribution_plot_allows_partial_null_values(
+    plotter: Any, x: str, y: str
+) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A", "A", "A", "B", "B", "B"],
+            "value": [1.0, np.nan, 1.2, 2.0, 2.2, np.nan],
+        }
+    )
+
+    ax = plotter(data, x=x, y=y)
+
+    assert ax.has_data()
+
+
+@pytest.mark.parametrize(
+    ("plotter", "function_name"),
+    [
+        (cns.boxplot, "boxplot"),
+        (cns.violinplot, "violinplot"),
+        (cns.stripplot, "stripplot"),
+        (cns.ridgeplot, "ridgeplot"),
+    ],
+)
+def test_distribution_plot_rejects_duplicate_column_names(
+    plotter: Any, function_name: str
+) -> None:
+    data = pd.DataFrame(
+        [["A", 1.0, 2.0], ["A", 2.0, 3.0], ["B", 3.0, 4.0]],
+        columns=pd.Index(["group", "value", "value"]),
+    )
+
+    with pytest.raises(
+        ValueError, match=rf"\[{function_name}\] Duplicate column name"
+    ):
+        plotter(data, x="group", y="value")

--- a/tests/test_distribution_plot_defects.py
+++ b/tests/test_distribution_plot_defects.py
@@ -89,7 +89,5 @@ def test_distribution_plot_rejects_duplicate_column_names(
         columns=pd.Index(["group", "value", "value"]),
     )
 
-    with pytest.raises(
-        ValueError, match=rf"\[{function_name}\] Duplicate column name"
-    ):
+    with pytest.raises(ValueError, match=rf"\[{function_name}\] Duplicate column name"):
         plotter(data, x="group", y="value")

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -463,8 +463,16 @@ def test_public_validation_contract(heatmap_adata: object) -> None:
         cns.validation.validate_column_exists(df, "missing", "x", "func")
 
     cns.validation.validate_columns_exist(df, ["a", "b"], "func")
+    cns.validation.validate_columns_exist(df, ["a", "a"], "func")
     with pytest.raises(ValueError, match="Column\\(s\\)"):
         cns.validation.validate_columns_exist(df, ["a", "missing"], "func")
+    duplicate_columns = pd.DataFrame([[1, 2]], columns=pd.Index(["a", "a"]))
+    with pytest.raises(ValueError) as exc_info:
+        cns.validation.validate_columns_exist(duplicate_columns, ["a", "a"], "func")
+    assert str(exc_info.value) == (
+        "[func] Duplicate column name(s) ['a'] found in data. "
+        "Referenced columns must have unique names."
+    )
 
     cns.validation.validate_adata_layer(heatmap_adata, "scaled", "func")
     with pytest.raises(ValueError, match="Available layers"):

--- a/tests/test_ridgeplot_defects.py
+++ b/tests/test_ridgeplot_defects.py
@@ -16,12 +16,6 @@ import cnsplots as cns
     ("data", "message"),
     [
         (
-            pd.DataFrame(
-                {"value": [1.0, None, 2.0, 3.0], "group": ["A", "A", "B", "B"]}
-            ),
-            "Null values",
-        ),
-        (
             pd.DataFrame({"value": [2.0, 3.0, 1.0], "group": ["B", "B", "A"]}),
             "at least two observations",
         ),
@@ -47,11 +41,26 @@ def test_ridgeplot_rejects_invalid_groups_before_kde(
         cns.ridgeplot(data, x="value", y="group")
 
 
-def test_ridgeplot_rejects_null_group_labels() -> None:
-    data = pd.DataFrame({"value": [1.0, 2.0, 3.0, 4.0], "group": ["A", "A", None, "B"]})
+@pytest.mark.parametrize("categorical_dtype", [False, True])
+def test_ridgeplot_drops_incomplete_rows(categorical_dtype: bool) -> None:
+    data = pd.DataFrame(
+        {
+            "value": [0.0, 1.0, 2.0, np.nan, 99.0, 3.0, 4.0, 5.0, 100.0],
+            "group": ["A", "A", "A", "A", None, "B", "B", "B", "B"],
+            "condition": ["H", "H", "H", "H", "H", "H", "H", "H", None],
+        }
+    )
+    if categorical_dtype:
+        data["group"] = pd.Categorical(data["group"], categories=["A", "B", "C"])
 
-    with pytest.raises(ValueError, match="Null values"):
-        cns.ridgeplot(data, x="value", y="group")
+    ax = cns.ridgeplot(data, x="value", y="group", hue="condition")
+
+    assert len(ax.collections) == 2
+    assert [text.get_text() for text in ax.texts] == ["A", "B"]
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.get_texts()] == ["H"]
+    assert ax.get_xlim() == pytest.approx((0.0, 5.0))
 
 
 def test_ridgeplot_customization_parameters_are_keyword_only() -> None:
@@ -202,7 +211,7 @@ def test_ridgeplot_rejects_invalid_overlap_before_kde(
                     "condition": ["H1", None, "H1", "H1"],
                 }
             ),
-            "Null values",
+            "at least two observations",
         ),
         (
             pd.DataFrame(


### PR DESCRIPTION
## Goal

Prevent distribution plots from leaking raw seaborn or matplotlib errors for malformed data while preserving partial-null rendering.

## Changes

- Reject duplicate referenced column names through shared validation.
- Validate null inputs for boxplot, violinplot, stripplot, and ridgeplot.
- Drop incomplete ridgeplot rows before density calculation.
- Add regressions for null handling, duplicate columns, repeated references, and unused categorical levels.

## Testing

- `make test` — 586 passed with 100% coverage
- `make lint` — passed

## Risks / follow-ups

Ridgeplot now excludes incomplete rows before KDE, and duplicate referenced columns are rejected library-wide. No known follow-ups.