### PR TITLE
🦺 Validate CoxModel survival inputs

### DIFF
--- a/examples/forestplot.py
+++ b/examples/forestplot.py
@@ -80,8 +80,8 @@ liver.head()
 # Display hazard ratios stratified by a grouping variable.
 model = cns.methods.CoxModel(
     data=liver,
-    duration="Event",
-    event="Survival",
+    duration="Survival",
+    event="Event",
     variates=[
         "C(Predictor, levels=['low risk', 'high risk'])",
         "C(AFP_cat, levels=['<=300 ng/mL', '>300 ng/mL'])",
@@ -296,8 +296,8 @@ ax.set_title("Univariate Logistic Regression")
 # Use different colors for effect estimates.
 model = cns.methods.CoxModel(
     data=liver,
-    duration="Event",
-    event="Survival",
+    duration="Survival",
+    event="Event",
     variates=[
         "C(Predictor, levels=['low risk', 'high risk'])",
         "C(AFP_cat, levels=['<=300 ng/mL', '>300 ng/mL'])",

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -42,8 +42,10 @@ class CoxModel:
         Input DataFrame containing survival data and covariates.
     duration : str
         Column name for the time-to-event or time-to-censoring variable.
+        Values must be finite, real, non-negative numbers, excluding booleans.
     event : str
-        Column name for the event indicator (1 = event occurred, 0 = censored).
+        Column name for the event indicator (1 or True = event occurred,
+        0 or False = censored). Cohorts with all events observed are supported.
     variates : list of str
         List of formula strings specifying the covariates to test. Each formula
         can be a simple variable name or a Patsy formula (e.g., 'age',
@@ -136,6 +138,13 @@ class CoxModel:
         None
             Results are stored in self.results as a DataFrame.
 
+        Raises
+        ------
+        ValueError
+            If durations or event indicators are invalid. Input validation
+            occurs before fitting any models; individual fitting failures
+            instead emit RuntimeWarning.
+
         Notes
         -----
         The results DataFrame contains:
@@ -171,6 +180,32 @@ class CoxModel:
         validate_columns_exist(self.data, required_columns, "CoxModel.fit")
         validate_no_nulls(self.data, required_columns, "CoxModel.fit")
         validate_column_type(self.data, self.duration, ["numeric"], "CoxModel.fit")
+
+        durations = self.data[self.duration]
+        if pd.api.types.is_complex_dtype(durations.dtype) or pd.api.types.is_bool_dtype(
+            durations.dtype
+        ):
+            raise ValueError(
+                f"[CoxModel.fit] Column '{self.duration}' must contain real-valued "
+                "numeric durations."
+            )
+        if not np.isfinite(durations).all():
+            raise ValueError(
+                f"[CoxModel.fit] Column '{self.duration}' must contain only finite "
+                "durations."
+            )
+        if (durations < 0).any():
+            raise ValueError(
+                f"[CoxModel.fit] Column '{self.duration}' must contain only "
+                "non-negative durations."
+            )
+
+        events = self.data[self.event]
+        if np.iscomplexobj(events.to_numpy()) or not events.isin([0, 1]).all():
+            raise ValueError(
+                f"[CoxModel.fit] Column '{self.event}' must contain only 0 and 1 "
+                "event indicators (False = censored, True = event occurred)."
+            )
 
         df = self.data.copy()
         all_results = []

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import Mock
+import warnings
 
 import lifelines as ll
 import numpy as np
@@ -183,6 +185,112 @@ def test_logistic_model_rejects_more_than_two_outcome_classes() -> None:
     )
     assert "No successful model fits" in messages
     assert model.results is None
+
+
+@pytest.fixture
+def cox_df() -> pd.DataFrame:
+    rng = np.random.default_rng(123)
+    n = 80
+    return pd.DataFrame(
+        {
+            "time": rng.exponential(10, n),
+            "event": rng.integers(0, 2, n),
+            "x": rng.normal(size=n),
+            "group": ["A"] * (n // 2) + ["B"] * (n // 2),
+        }
+    )
+
+
+@pytest.mark.parametrize("hue", [None, "group"])
+@pytest.mark.parametrize(
+    ("column", "values", "message"),
+    [
+        ("event", [0, 2], "only 0 and 1"),
+        ("event", [0, -1], "only 0 and 1"),
+        ("event", [0, 0.5], "only 0 and 1"),
+        ("event", [0, np.inf], "only 0 and 1"),
+        ("event", [0, -np.inf], "only 0 and 1"),
+        ("event", [0, np.nan], "Null values"),
+        ("event", ["0", "1"], "only 0 and 1"),
+        ("event", [0j, 1 + 0j], "only 0 and 1"),
+        ("time", [1, -1], "non-negative durations"),
+        ("time", [1, np.inf], "finite durations"),
+        ("time", [1, -np.inf], "finite durations"),
+        ("time", [1, np.nan], "Null values"),
+        ("time", [1 + 0j, 2 + 0j], "real-valued numeric durations"),
+        ("time", [False, True], "real-valued numeric durations"),
+        ("time", ["1", "2"], "must be numeric"),
+    ],
+)
+def test_cox_model_rejects_invalid_survival_inputs_before_fitting(
+    cox_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+    hue: str | None,
+    column: str,
+    values: list[Any],
+    message: str,
+) -> None:
+    data = cox_df.copy()
+    # Put invalid input in the last group to catch partial fitting as well.
+    data[column] = pd.Series([values[0]] * (len(data) - 1) + [values[1]])
+    fitter = Mock()
+    monkeypatch.setattr(ll, "CoxPHFitter", fitter)
+    model = cns.CoxModel(data, "time", "event", ["x"], hue=hue)
+    model.results = pd.DataFrame({"stale": [True]})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError, match=message) as exc_info:
+            model.fit()
+
+    assert "[CoxModel.fit]" in str(exc_info.value)
+    assert f"'{column}'" in str(exc_info.value)
+    assert not caught
+    fitter.assert_not_called()
+    assert model.results is None
+
+
+@pytest.mark.parametrize("event_dtype", ["int64", "float64", "bool", "boolean"])
+@pytest.mark.parametrize("uncensored", [False, True])
+def test_cox_model_preserves_valid_event_encodings(
+    cox_df: pd.DataFrame, event_dtype: str, uncensored: bool
+) -> None:
+    data = cox_df.copy()
+    if uncensored:
+        data["event"] = 1
+    reference = ll.CoxPHFitter().fit(
+        data, duration_col="time", event_col="event", formula="x"
+    )
+    data["event"] = data["event"].astype(event_dtype)
+    original = data.copy(deep=True)
+    model = cns.CoxModel(data, "time", "event", ["x"])
+
+    model.fit()
+
+    assert model.results is not None
+    columns = ["exp(coef)", "exp(coef) lower 95%", "exp(coef) upper 95%", "p"]
+    pd.testing.assert_frame_equal(
+        model.results.set_index("covariate")[columns], reference.summary[columns]
+    )
+    if not uncensored:
+        assert model.results["exp(coef)"].iloc[0] == pytest.approx(0.855151, abs=1e-6)
+    pd.testing.assert_frame_equal(data, original)
+
+
+@pytest.mark.parametrize("duration_dtype", ["int64", "float64", "Int64", "Float64"])
+def test_cox_model_accepts_zero_and_nullable_durations(
+    cox_df: pd.DataFrame, duration_dtype: str
+) -> None:
+    data = cox_df.copy()
+    # Keep lifelines' median duration representable as a nullable integer.
+    data["time"] = (2 * data["time"].astype("int64")).astype(duration_dtype)
+    assert (data["time"] == 0).any()
+    model = cns.CoxModel(data, "time", "event", ["x"])
+
+    model.fit()
+
+    assert model.results is not None
+    assert np.isfinite(model.results["exp(coef)"]).all()
 
 
 def test_cox_model_warns_for_failed_unstratified_fit(


### PR DESCRIPTION
## What changed

Reject malformed survival inputs before `CoxModel.fit` fits any formula or hue group. Event code 2 and negative durations previously produced plausible model results; invalid inputs now raise `ValueError` with the method and column names.

Require finite, real, non-negative numeric durations, excluding booleans, and event indicators containing only 0/1 or False/True. Preserve uncensored cohorts, zero durations, valid fitted results, and per-formula fitting warnings. Document the input contract and add 42 regression cases.

Correct the two forest-plot gallery examples that reversed the duration and event arguments, which the new validation exposed during the docs build.

## How it was tested

- Confirmed the invalid-event regression fails before the fix, with and without hue grouping.
- `make test`: 628 passed, 100% coverage.
- `make lint`: passed, using `UV_SYSTEM_CERTS=true` to resolve a local certificate error fetching the configured type checker.
- `make -C docs html`: passed with all 37 gallery examples executed.
- Compared valid numeric and boolean event encodings against lifelines, including uncensored cohorts and the issue's reference hazard ratio.

## Risks or follow-ups

Callers passing malformed survival data will now receive input errors. An existing lifelines limitation with nullable integer durations whose median is fractional remains outside this fix.

## Related issue

Closes #126

## Release Notes Label

`bug`
