### PR TITLE
🐛 Isolate LogisticModel cross-validation preprocessing

### DIFF
--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -479,6 +479,7 @@ class LogisticModel:
         - hue_group: Group name (or 'All' if no grouping)
 
         For each model:
+
         1. Stateful Patsy transforms are rejected before learning any design state.
            A stateless formula evaluation identifies complete predictor rows and
            aligns their outcomes; its design information is discarded.

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -13,9 +13,13 @@ import warnings
 import numpy as np
 import pandas as pd
 import sklearn as skl
+from patsy.build import build_design_matrices
+from patsy.desc import ModelDesc
+from patsy.eval import EvalEnvironment
 from patsy.highlevel import dmatrix
-from sklearn.linear_model import LogisticRegressionCV
-from sklearn.model_selection import cross_val_predict
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV, cross_val_predict
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 
@@ -302,13 +306,31 @@ class CoxModel:
         ]
 
 
+class _LogisticDesign(TransformerMixin, BaseEstimator):
+    """Learn Patsy encoding on training rows and reuse it for held-out rows."""
+
+    def __init__(self, formula: str) -> None:
+        self.formula = formula
+
+    def fit(self, X: pd.DataFrame, y: np.ndarray | None = None) -> _LogisticDesign:
+        design = dmatrix(self.formula, X, return_type="dataframe", NA_action="raise")
+        self.design_info_ = design.design_info
+        return self
+
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        design = build_design_matrices(
+            [self.design_info_], X, return_type="dataframe", NA_action="raise"
+        )[0]
+        return design.drop("Intercept", axis=1)
+
+
 class LogisticModel:
     """
     Logistic regression model with cross-validation for binary classification.
 
-    This class fits L1-regularized logistic regression models with 5-fold
-    cross-validation to predict binary outcomes and assess predictor performance
-    using ROC-AUC with bootstrap confidence intervals.
+    This class fits L1-regularized logistic regression models with nested
+    5-fold cross-validation to predict binary outcomes and assess predictor
+    performance using ROC-AUC with bootstrap confidence intervals.
 
     Parameters
     ----------
@@ -319,7 +341,8 @@ class LogisticModel:
     variates : list of str
         List of formula strings specifying the predictors to test. Each formula
         can be a simple variable name or a Patsy formula (e.g., 'age',
-        'C(treatment)', 'age + stage').
+        'C(treatment)', 'age + stage'). Stateful Patsy transforms such as
+        ``bs``, ``cr``, ``center``, and ``standardize`` are not supported.
     hue : str, optional
         Column name for grouping variable. If provided, fits separate models
         for each group. Default is None (single model for all data).
@@ -341,12 +364,13 @@ class LogisticModel:
     Notes
     -----
     The fit() method performs:
-    - L1-regularized logistic regression with 5-fold cross-validation
-    - Automatic penalty parameter selection via cross-validation
+    - Outer 5-fold cross-validation for out-of-fold predictions
+    - Inner 5-fold ROC-AUC tuning of the complete preprocessing/model pipeline
     - Bootstrap confidence intervals for AUC (1000 iterations, alpha=0.05)
 
     Models use the liblinear solver optimized for L1 regularization and are
-    scored using ROC-AUC during cross-validation.
+    scored using ROC-AUC during cross-validation. See :meth:`fit` for the
+    preprocessing boundaries and supported formula behavior.
 
     AUC interpretation:
     - AUC = 1.0: Perfect discrimination
@@ -437,7 +461,7 @@ class LogisticModel:
         Fit logistic regression models for all specified variates.
 
         This method fits a separate L1-regularized logistic regression model
-        with 5-fold cross-validation for each variate, optionally stratified
+        with nested 5-fold cross-validation for each variate, optionally stratified
         by hue groups. Results are stored in the results attribute.
 
         Returns
@@ -455,10 +479,26 @@ class LogisticModel:
         - hue_group: Group name (or 'All' if no grouping)
 
         For each model:
-        1. Design matrix is created using Patsy (supports formulas)
-        2. Predictors are standardized within each cross-validation fold
-        3. LogisticRegressionCV fits with L1 penalty and 5-fold CV
-        4. AUC is computed from all out-of-fold predictions, with a bootstrap 95% CI
+        1. Stateful Patsy transforms are rejected before learning any design state.
+           A stateless formula evaluation identifies complete predictor rows and
+           aligns their outcomes; its design information is discarded.
+        2. Outer 5-fold stratified CV holds out each row once. Within each outer
+           training fold, inner 5-fold stratified CV tunes 10 values of C,
+           logarithmically spaced from 1e-4 to 1e4, using ROC-AUC.
+        3. Each inner fit learns Patsy encoding and standardization on its training
+           rows only, followed by L1 logistic regression. The selected pipeline
+           is refitted on the outer training rows to predict the outer held-out
+           rows. Both CV levels use unshuffled folds; the solver seed is 42.
+        4. AUC is computed from all out-of-fold predictions. The existing 1000
+           bootstrap resamples of these predictions provide the 95% CI.
+
+        Formulas must use row-wise expressions. Stateful Patsy transforms
+        (including splines, centering, and standardization) are unsupported until
+        fold-local state and missing-value handling are implemented together.
+        Categorical levels are learned from training rows and reused for
+        validation. An unseen validation level causes a fitting warning; known
+        levels can be declared in advance with ``C(column, levels=[...])`` or a
+        pandas categorical dtype.
 
         Runtime warnings are emitted for hue groups with no outcome variance.
         Errors during fitting are caught and surfaced as warnings.
@@ -481,9 +521,8 @@ class LogisticModel:
         df = self.data.copy()
         all_results = []
         regularization_options: dict[str, Any] = (
-            {"l1_ratios": (1,), "use_legacy_attributes": False}
-            if "use_legacy_attributes"
-            in inspect.signature(LogisticRegressionCV).parameters
+            {"l1_ratio": 1}
+            if inspect.signature(LogisticRegression).parameters["l1_ratio"].default == 0
             else {"penalty": "l1"}
         )
 
@@ -499,10 +538,24 @@ class LogisticModel:
             hue_data = hue_data.reset_index(drop=True)
             for var in self.variates:
                 try:
-                    X = dmatrix(var, hue_data, return_type="dataframe").drop(
-                        "Intercept", axis=1
+                    formula = ModelDesc.from_formula(var)
+                    eval_env = EvalEnvironment.capture(0)
+                    for term in formula.rhs_termlist:
+                        for factor in term.factors:
+                            if factor.memorize_passes_needed({}, eval_env):
+                                raise ValueError(
+                                    "Stateful Patsy transforms are not supported by "
+                                    "LogisticModel; use a formula with row-wise "
+                                    "predictor expressions"
+                                )
+                    # Use this evaluation only for row selection, never encoding.
+                    complete_rows = (
+                        dmatrix(var, hue_data, return_type="dataframe")
+                        .drop("Intercept", axis=1)
+                        .index
                     )
-                    y = hue_data.loc[X.index, self.event].to_numpy()
+                    X = hue_data.loc[complete_rows]
+                    y = X[self.event].to_numpy()
                     class_counts = pd.Series(y).value_counts()
                     if len(class_counts) < 2:
                         warnings.warn(
@@ -532,15 +585,20 @@ class LogisticModel:
                             "observations in each outcome class in every outer training "
                             "fold; at least 7 observations per class are required"
                         )
-                    model = make_pipeline(
-                        StandardScaler(),
-                        LogisticRegressionCV(
-                            cv=n_splits,
-                            solver="liblinear",
-                            random_state=42,
-                            scoring="roc_auc",
-                            **regularization_options,
+                    model = GridSearchCV(
+                        make_pipeline(
+                            _LogisticDesign(var),
+                            StandardScaler(),
+                            LogisticRegression(
+                                solver="liblinear",
+                                random_state=42,
+                                **regularization_options,
+                            ),
                         ),
+                        {"logisticregression__C": np.logspace(-4, 4, 10)},
+                        cv=n_splits,
+                        scoring="roc_auc",
+                        error_score="raise",
                     )
                     y_pred_proba = cross_val_predict(
                         model, X, y, cv=n_splits, method="predict_proba"

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 from unittest.mock import Mock
 import warnings
@@ -11,8 +12,10 @@ import numpy as np
 import pandas as pd
 import pytest
 from lifelines.exceptions import ConvergenceWarning
-from sklearn.linear_model import LogisticRegressionCV
-from sklearn.pipeline import Pipeline
+from patsy import PatsyError
+from patsy.splines import BS
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV, StratifiedKFold
 from sklearn.preprocessing import StandardScaler
 
 import cnsplots as cns
@@ -68,10 +71,10 @@ def test_logistic_model_uses_scaled_out_of_fold_predictions(
             "group": ["A"] * 14 + ["B"] * 14,
         }
     )
-    seen_estimators: list[Pipeline] = []
+    seen_estimators: list[GridSearchCV] = []
 
     def fake_cross_val_predict(
-        estimator: Pipeline,
+        estimator: GridSearchCV,
         X: pd.DataFrame,
         y: np.ndarray,
         *,
@@ -98,32 +101,42 @@ def test_logistic_model_uses_scaled_out_of_fold_predictions(
 
     assert len(seen_estimators) == (1 if hue is None else 2)
     for estimator in seen_estimators:
-        scaler, classifier = (step for _, step in estimator.steps)
+        assert isinstance(estimator, GridSearchCV)
+        design, scaler, classifier = (step for _, step in estimator.estimator.steps)
+        assert design.formula == "score"
         assert isinstance(scaler, StandardScaler)
-        assert isinstance(classifier, LogisticRegressionCV)
+        assert isinstance(classifier, LogisticRegression)
         if classifier.penalty == "deprecated":
-            assert classifier.l1_ratios == (1,)
-            assert classifier.use_legacy_attributes is False
+            assert classifier.l1_ratio == 1
         else:
             assert classifier.penalty == "l1"
         assert classifier.solver == "liblinear"
-        assert classifier.cv == 5
+        assert classifier.random_state == 42
+        assert estimator.cv == 5
+        assert estimator.scoring == "roc_auc"
+        assert estimator.error_score == "raise"
+        np.testing.assert_array_equal(
+            estimator.param_grid["logisticregression__C"], np.logspace(-4, 4, 10)
+        )
 
 
+@pytest.mark.parametrize("formula", ["score", 'Q("score") + C(group)', "I(score ** 2)"])
 def test_logistic_model_aligns_outcome_after_patsy_drops_rows(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, formula: str
 ) -> None:
     data = pd.DataFrame(
         {
             "event": [0, 1] * 8,
             "score": np.arange(16, dtype=float),
+            "group": ["A", "B"] * 8,
+            "unused": [np.nan] * 16,
         },
-        index=np.arange(100, 116),
+        index=np.full(16, 100),
     )
-    data.loc[[100, 101], "score"] = np.nan
+    data.iloc[:2, data.columns.get_loc("score")] = np.nan
 
     def fake_cross_val_predict(
-        estimator: Pipeline,
+        estimator: GridSearchCV,
         X: pd.DataFrame,
         y: np.ndarray,
         *,
@@ -142,10 +155,170 @@ def test_logistic_model_aligns_outcome_after_patsy_drops_rows(
         lambda self, y, predictions: (0.5, 0.4, 0.6),
     )
 
-    model = cns.LogisticModel(data, event="event", variates=["score"])
+    model = cns.LogisticModel(data, event="event", variates=[formula])
     model.fit()
 
     assert model.results is not None
+
+
+def test_logistic_model_scaler_fits_only_nested_training_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame({"event": [0, 1] * 30, "score": np.arange(60, dtype=float)})
+    fitted_rows: list[tuple[int, ...]] = []
+    design_rows: list[tuple[int, ...]] = []
+    original_fit = _methods._LogisticDesign.fit
+
+    def track_design_fit(self, X, y=None):
+        design_rows.append(tuple(X.index))
+        return original_fit(self, X, y)
+
+    monkeypatch.setattr(_methods._LogisticDesign, "fit", track_design_fit)
+
+    class TrackingScaler(StandardScaler):
+        def fit(self, X, y=None, sample_weight=None):
+            fitted_rows.append(tuple(X.index))
+            return super().fit(X, y, sample_weight=sample_weight)
+
+    monkeypatch.setattr(_methods, "StandardScaler", TrackingScaler)
+    predictions: list[np.ndarray] = []
+
+    def capture_auc(self, y, probabilities):
+        np.testing.assert_array_equal(y, data["event"])
+        predictions.append(probabilities.copy())
+        return 0.5, 0.4, 0.6
+
+    monkeypatch.setattr(cns.LogisticModel, "_compute_auc_ci", capture_auc)
+    model = cns.LogisticModel(data, event="event", variates=["score"])
+    model.fit()
+
+    expected_rows: Counter[tuple[int, ...]] = Counter()
+    for outer_train, outer_test in StratifiedKFold(5).split(data, data["event"]):
+        expected_rows[tuple(outer_train)] += 1
+        for inner_train, inner_test in StratifiedKFold(5).split(
+            data.iloc[outer_train], data["event"].iloc[outer_train]
+        ):
+            training_rows = tuple(outer_train[inner_train])
+            assert set(training_rows).isdisjoint(outer_test)
+            assert set(training_rows).isdisjoint(outer_train[inner_test])
+            expected_rows[training_rows] += 10
+
+    assert Counter(fitted_rows) == expected_rows
+    assert Counter(design_rows) == expected_rows
+    assert len(fitted_rows) == 255
+    assert model.results is not None
+    assert len(predictions) == 1
+    assert predictions[0].shape == (60,)
+    assert np.isfinite(predictions[0]).all()
+
+    model.fit()
+    np.testing.assert_array_equal(predictions[0], predictions[1])
+
+
+@pytest.mark.parametrize(
+    "formula",
+    ["bs(score, df=4)", "cr(score, df=4)", "center(score)", "standardize(score)"],
+)
+def test_logistic_model_rejects_stateful_formulas_before_learning(
+    monkeypatch: pytest.MonkeyPatch, formula: str
+) -> None:
+    data = pd.DataFrame({"event": [0, 1] * 30, "score": np.arange(60, dtype=float)})
+    memorize = Mock(side_effect=AssertionError("Spline knots must not be learned"))
+    design = Mock(
+        side_effect=AssertionError("Formula must be rejected before evaluation")
+    )
+    monkeypatch.setattr(BS, "memorize_chunk", memorize)
+    monkeypatch.setattr(_methods, "dmatrix", design)
+    model = cns.LogisticModel(data, event="event", variates=[formula])
+
+    with pytest.warns(RuntimeWarning) as caught:
+        model.fit()
+
+    assert any(
+        "Stateful Patsy transforms are not supported" in str(w.message) for w in caught
+    )
+    memorize.assert_not_called()
+    design.assert_not_called()
+    assert model.results is None
+
+
+def test_logistic_design_reuses_training_categorical_encoding() -> None:
+    training = pd.DataFrame({"group": ["B", "A", "B", "A"]})
+    validation = pd.DataFrame({"group": ["B", "B"]}, index=np.array([10, 11]))
+    design = _methods._LogisticDesign("C(group)").fit(training)
+
+    encoded = design.transform(validation)
+
+    assert encoded.columns.tolist() == ["C(group)[T.B]"]
+    assert encoded.index.tolist() == [10, 11]
+    np.testing.assert_array_equal(encoded.to_numpy(), [[1], [1]])
+    with pytest.raises(PatsyError, match="does not match any of the expected levels"):
+        design.transform(pd.DataFrame({"group": ["new"]}))
+
+
+@pytest.mark.parametrize("declared_levels", [None, "formula", "dtype"])
+def test_logistic_model_handles_held_out_categorical_levels(
+    monkeypatch: pytest.MonkeyPatch, declared_levels: str | None
+) -> None:
+    data = pd.DataFrame(
+        {
+            "event": [0, 1] * 30,
+            "score": np.arange(60, dtype=float),
+            "group": ["A", "B"] * 30,
+        }
+    )
+    data.loc[0, "group"] = "new"
+    formula = "score + C(group)"
+    if declared_levels == "formula":
+        formula = "score + C(group, levels=['A', 'B', 'new'])"
+    elif declared_levels == "dtype":
+        data["group"] = pd.Categorical(data["group"], categories=["A", "B", "new"])
+    monkeypatch.setattr(
+        cns.LogisticModel, "_compute_auc_ci", lambda self, y, p: (0.5, 0.4, 0.6)
+    )
+    model = cns.LogisticModel(data, event="event", variates=[formula])
+
+    if declared_levels is None:
+        with pytest.warns(RuntimeWarning) as caught:
+            model.fit()
+        assert any("expected levels" in str(w.message) for w in caught)
+        assert model.results is None
+    else:
+        model.fit()
+        assert model.results is not None
+
+
+def test_logistic_model_fits_stateless_formula_with_missing_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "event": [0, 1] * 30,
+            "score": np.linspace(0.1, 1, 60),
+            "group": ["A", "B", "B", "A"] * 15,
+            "unused": [np.nan] * 60,
+        },
+        index=np.full(60, 5),
+    )
+    data.iloc[:2, data.columns.get_loc("score")] = np.nan
+    data.iloc[2:4, data.columns.get_loc("group")] = None
+    received_predictions = []
+
+    def capture_auc(self, y, probabilities):
+        np.testing.assert_array_equal(y, data["event"].iloc[4:])
+        assert probabilities.shape == (56,)
+        assert np.isfinite(probabilities).all()
+        received_predictions.append(probabilities)
+        return 0.5, 0.4, 0.6
+
+    monkeypatch.setattr(cns.LogisticModel, "_compute_auc_ci", capture_auc)
+    model = cns.LogisticModel(
+        data, event="event", variates=['np.log(Q("score")) * C(group)']
+    )
+    model.fit()
+
+    assert model.results is not None
+    assert len(received_predictions) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #127.

`LogisticModel` now isolates preprocessing at both levels of its nested 5-fold evaluation. Inner `GridSearchCV` tunes the complete Patsy encoding, scaling, and L1 logistic regression pipeline; outer folds still produce the out-of-fold probabilities used for AUC. The C grid, ROC-AUC scoring, liblinear solver, deterministic defaults, and bootstrap confidence-interval method are preserved.

Patsy design information is learned on training rows and reused for validation. A separate stateless evaluation selects complete predictor rows and discards its encoding. Stateful Patsy transforms are rejected before evaluation, following the option allowed in #127. The model documentation explains the procedure and formula restrictions.

Validation:
- `make test`: 640 passed, 100% coverage.
- `make lint`: passed.
- Strict documentation build (`make -C docs html`) and `make doc-linkcheck`: passed.
- Instrumentation checks the exact training-row sets for all 255 scaler and design fits on 60 observations, including every inner candidate fit and outer refit.
- Regressions cover deterministic predictions, stateful-formula rejection before learning spline knots, missing numeric/categorical predictors, duplicate indices, quoted names, interactions, and categorical levels.

Compatibility and follow-ups: stateful formulas such as `bs`, `cr`, `center`, and `standardize` now warn and skip the fit until safe support is implemented. Validation categories absent from training also warn unless their levels were declared in advance. Repeated preprocessing increases fitting work, and corrected tuning can change reported AUC values.
