### PR TITLE
💚 Remove unused SciPy inventory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,6 @@ _intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/docs/", None),
     "seaborn": ("https://seaborn.pydata.org/", None),
     "anndata": ("https://anndata.readthedocs.io/en/latest/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
 }
 intersphinx_mapping = _intersphinx_mapping if _docs_online else {}
 # This image target is emitted as a valid HTML anchor, but linkcheck interprets


### PR DESCRIPTION
## What changed

Stop documentation link checks from fetching the unused SciPy intersphinx inventory. After #205 merged, both the [Tests workflow](https://github.com/faridrashidi/cnsplots/actions/runs/33937997182) and the [Docs workflow](https://github.com/faridrashidi/cnsplots/actions/runs/33937997185) failed because `docs.scipy.org` timed out while serving `objects.inv`.

Remove the single SciPy mapping from `docs/conf.py`. The current documentation does not use it, and all other inventories and strict link checks remain enabled.

## How it was tested

- `make doc-linkcheck`: passed. Compared its output with the failed CI run: the same 23 external URLs are checked, with none added or removed.
- `make test`: 628 passed, 100% coverage.
- `make lint`: passed.

## Risks or follow-ups

Future documentation that adds SciPy object cross-references will need an appropriate inventory mapping. This change does not make the remaining external documentation services available offline.

## Related issue

Follow-up to #205.

## Release Notes Label

`maintenance`
