### PR TITLE
🐛 Preserve survival when inference fails

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -100,60 +100,6 @@ composed into an existing Matplotlib layout. Most return the target
 retain their backend-native return objects so callers can access their
 multi-panel layout or diagram elements.
 
-## Descriptive Survival Curves
-
-Use `descriptive_only=True` to draw survival curves without statistical tests or
-Cox model fitting. This mode supports a single group, groups with only censored
-observations, and cohorts in which every event was observed. Confidence bands,
-risk tables, median survival, landmark survival estimates, and restricted mean
-survival time (RMST) remain available.
-
-```python
-import pandas as pd
-
-survival_data = pd.DataFrame(
-    {
-        "time": [1, 2, 3, 4, 1, 2, 3, 4],
-        "event": [0, 0, 0, 0, 1, 0, 1, 0],
-        "group": ["A"] * 4 + ["B"] * 4,
-    }
-)
-cns.figure(180, 150)
-cns.survivalplot(
-    survival_data,
-    "time",
-    "event",
-    "group",
-    descriptive_only=True,
-    show_risk_table=True,
-)
-```
-
-`survivalplot` accepts event codes 0 (censored) and 1 (event observed); either
-code may be absent. Durations must still be finite, non-negative real numbers,
-and duration, event, and group values cannot be missing.
-
-`cumulativeincidenceplot(..., descriptive_only=True)` similarly skips Gray's
-test while drawing Aalen–Johansen estimates. Its event codes always mean
-0 = censored, 1 = event of interest, and 2 or higher = competing events.
-These meanings do not change when a code is absent: a group with no events of
-interest has a flat cumulative-incidence curve at zero. Competing events are
-never recoded as censoring.
-
-With the default `descriptive_only=False`, each requested comparison checks
-whether it can be estimated. Unavailable results are marked `unavailable` on
-the plot, and a `UserWarning` explains why; valid curves and other comparisons
-are retained. Log-rank and Gray's tests require multiple groups, events of
-interest, and a nonsingular comparison variance. An all-censored group can
-still contribute to these tests. Cox results require a converged fit and finite
-estimates; a two-group contrast with no events in one group is unavailable.
-The two-group landmark test requires survival estimates strictly between 0
-and 1. Pairwise Cox p-values remain unadjusted.
-
-For `survivalplot`, `show_hazard_ratio=False` skips pairwise Cox fitting while
-retaining the overall test. `descriptive_only=True` skips all tests, including
-the landmark test, and ignores `overall_test`, `pairs`, and `show_hazard_ratio`.
-
 ## Saving Figures
 
 For publication, save figures in vector formats:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -100,6 +100,60 @@ composed into an existing Matplotlib layout. Most return the target
 retain their backend-native return objects so callers can access their
 multi-panel layout or diagram elements.
 
+## Descriptive Survival Curves
+
+Use `descriptive_only=True` to draw survival curves without statistical tests or
+Cox model fitting. This mode supports a single group, groups with only censored
+observations, and cohorts in which every event was observed. Confidence bands,
+risk tables, median survival, landmark survival estimates, and restricted mean
+survival time (RMST) remain available.
+
+```python
+import pandas as pd
+
+survival_data = pd.DataFrame(
+    {
+        "time": [1, 2, 3, 4, 1, 2, 3, 4],
+        "event": [0, 0, 0, 0, 1, 0, 1, 0],
+        "group": ["A"] * 4 + ["B"] * 4,
+    }
+)
+cns.figure(180, 150)
+cns.survivalplot(
+    survival_data,
+    "time",
+    "event",
+    "group",
+    descriptive_only=True,
+    show_risk_table=True,
+)
+```
+
+`survivalplot` accepts event codes 0 (censored) and 1 (event observed); either
+code may be absent. Durations must still be finite, non-negative real numbers,
+and duration, event, and group values cannot be missing.
+
+`cumulativeincidenceplot(..., descriptive_only=True)` similarly skips Gray's
+test while drawing Aalen–Johansen estimates. Its event codes always mean
+0 = censored, 1 = event of interest, and 2 or higher = competing events.
+These meanings do not change when a code is absent: a group with no events of
+interest has a flat cumulative-incidence curve at zero. Competing events are
+never recoded as censoring.
+
+With the default `descriptive_only=False`, each requested comparison checks
+whether it can be estimated. Unavailable results are marked `unavailable` on
+the plot, and a `UserWarning` explains why; valid curves and other comparisons
+are retained. Log-rank and Gray's tests require multiple groups, events of
+interest, and a nonsingular comparison variance. An all-censored group can
+still contribute to these tests. Cox results require a converged fit and finite
+estimates; a two-group contrast with no events in one group is unavailable.
+The two-group landmark test requires survival estimates strictly between 0
+and 1. Pairwise Cox p-values remain unadjusted.
+
+For `survivalplot`, `show_hazard_ratio=False` skips pairwise Cox fitting while
+retaining the overall test. `descriptive_only=True` skips all tests, including
+the landmark test, and ignores `overall_test`, `pairs`, and `show_hazard_ratio`.
+
 ## Saving Figures
 
 For publication, save figures in vector formats:

--- a/src/cnsplots/_validation.py
+++ b/src/cnsplots/_validation.py
@@ -470,9 +470,8 @@ def validate_time_to_event_data(
     function_name: str,
     *,
     competing_risks: bool = False,
-    min_groups: int = 1,
 ) -> None:
-    """Validate durations, event codes, and per-group sample adequacy."""
+    """Validate the data domain for descriptive time-to-event estimates."""
     validate_column_type(data, duration, ["numeric"], function_name)
     validate_no_nulls(data, [duration, event, group], function_name)
 
@@ -516,35 +515,12 @@ def validate_time_to_event_data(
                 "events)."
             )
     else:
-        validate_binary_column(data, event, function_name)
-
-    group_sizes = data.groupby(group, observed=True).size()
-    if len(group_sizes) < min_groups:
-        raise ValueError(
-            f"[{function_name}] Column '{group}' must contain at least {min_groups} "
-            f"groups, found {len(group_sizes)}."
-        )
-
-    small_groups = group_sizes[group_sizes < 2]
-    if not small_groups.empty:
-        raise ValueError(
-            f"[{function_name}] Each group in column '{group}' must contain at least 2 "
-            f"observations; insufficient groups: {list(small_groups.index)}."
-        )
-
-    event_counts = (
-        data.loc[data[event] == 1]
-        .groupby(group, observed=True)
-        .size()
-        .reindex(group_sizes.index, fill_value=0)
-    )
-    groups_without_events = event_counts[event_counts < 1]
-    if not groups_without_events.empty:
-        raise ValueError(
-            f"[{function_name}] Each group in column '{group}' must contain at least one "
-            f"event of interest (event code 1); groups without events: "
-            f"{list(groups_without_events.index)}."
-        )
+        event_values = data[event].to_numpy()
+        if np.iscomplexobj(event_values) or not data[event].isin([0, 1]).all():
+            raise ValueError(
+                f"[{function_name}] Column '{event}' must contain only event codes "
+                "0 and 1 (0 = censored, 1 = event)."
+            )
 
 
 def validate_categorical_has_levels(

--- a/src/cnsplots/helpers/_cmprsk.py
+++ b/src/cnsplots/helpers/_cmprsk.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pandas import Series
 
+import numpy as np
 import pandas as pd
 
 from cnsplots._validation import (
@@ -56,4 +57,9 @@ def cuminc(
         rho=0.0,
     )
 
+    if (
+        not np.isfinite(result.var).all()
+        or np.linalg.matrix_rank(result.var) < result.df
+    ):
+        raise ValueError("Gray's test comparison variance is zero or singular")
     return float(result.pvalue)

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Sequence
 from typing import Any, Literal
 
@@ -54,6 +55,71 @@ _PVALUE_LOCATIONS: dict[
     "lower center": (0.5, 0.02, "center", "bottom"),
     "lower right": (0.98, 0.02, "right", "bottom"),
 }
+
+
+def _unavailable_inference(function_name: str, label: str, reason: Exception) -> str:
+    """Report failed optional inference without discarding descriptive estimates."""
+    warnings.warn(
+        f"[{function_name}] {label} unavailable: {reason}", UserWarning, stacklevel=3
+    )
+    return f"{label} unavailable"
+
+
+def _format_inference_pvalue(pvalue: float) -> str:
+    if not np.isfinite(pvalue) or not 0 <= pvalue <= 1:
+        raise ValueError("the test did not return a finite p-value between 0 and 1")
+    p = num2tex.num2tex(pvalue, precision=2)
+    return rf"${p:.2g}$"
+
+
+def _validate_comparison(data: pd.DataFrame, event: str, group: str) -> None:
+    if data[group].nunique() < 2:
+        raise ValueError("at least two groups are required")
+    if not (data[event] == 1).any():
+        raise ValueError("there are no events of interest (event code 1)")
+
+
+def _validate_logrank_variance(
+    data: pd.DataFrame, duration: str, event: str, group: str
+) -> None:
+    from lifelines.utils import group_survival_table_from_events
+
+    _validate_comparison(data, event, group)
+    _, removed, observed, _ = group_survival_table_from_events(
+        data[group], data[duration], data[event]
+    )
+    at_risk = removed.sum().to_numpy() - removed.cumsum().shift(fill_value=0).to_numpy()
+    total_at_risk = at_risk.sum(axis=1)
+    events = observed.sum(axis=1).to_numpy()
+    # Hypergeometric covariance of group event counts at each pooled event time.
+    weight = events * (total_at_risk - events) / np.maximum(total_at_risk - 1, 1)
+    proportions = at_risk / total_at_risk[:, None]
+    weighted = weight[:, None] * proportions
+    covariance = np.diag(weighted.sum(axis=0)) - proportions.T @ weighted
+    if np.linalg.matrix_rank(covariance[:-1, :-1]) < at_risk.shape[1] - 1:
+        raise ValueError("the log-rank comparison variance is zero or singular")
+
+
+def _fit_cox_inference(data: pd.DataFrame, covariate: str) -> Any:
+    import lifelines as ll
+
+    _validate_comparison(data, "_event", covariate)
+    if (
+        data[covariate].nunique() == 2
+        and (data.groupby(covariate, observed=True)["_event"].sum() == 0).any()
+    ):
+        raise ValueError("a comparison group has no observed events")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        cph = ll.CoxPHFitter()
+        cph.fit(data, duration_col="_duration", event_col="_event")
+        summary = cph.summary.loc[covariate]
+    estimates = summary[
+        ["se(coef)", "exp(coef)", "exp(coef) lower 95%", "exp(coef) upper 95%"]
+    ].to_numpy(dtype=float)
+    if not np.isfinite(estimates).all() or (estimates <= 0).any():
+        raise ValueError("the Cox model did not return finite positive estimates")
+    return cph
 
 
 def _add_pvalue_annotation(
@@ -184,6 +250,7 @@ def survivalplot(
     overall_test: Literal["logrank", "trend"] = "logrank",
     pairs: list[tuple[str, str]] | None = None,
     show_hazard_ratio: bool = True,
+    descriptive_only: bool = False,
     pvalue_loc: PValueLoc = "lower left",
     ax: Axes | None = None,
 ) -> Axes:
@@ -247,6 +314,13 @@ def survivalplot(
         Whether to show pairwise hazard ratios, confidence intervals, and Cox
         p-values. If False, pairwise Cox inference is skipped and only the overall
         log-rank or trend p-value is shown. Any value passed to ``pairs`` is ignored.
+    descriptive_only : bool, default: False
+        Skip all statistical tests and Cox fitting, ignoring ``overall_test``,
+        ``pairs``, and ``show_hazard_ratio``. Curves, confidence bands, risk tables,
+        medians, landmark estimates, and RMST remain available, including for a
+        single group or an all-censored cohort. Otherwise, unavailable inference
+        emits a UserWarning with the reason and is annotated as ``unavailable``;
+        valid curves and other estimates are retained.
     pvalue_loc : str, default: 'lower left'
         Axes-relative location for the p-value and hazard-ratio annotation. Accepts
         the fixed Matplotlib legend locations: ``'upper left'``, ``'upper center'``,
@@ -296,7 +370,6 @@ def survivalplot(
         event,
         hue,
         "survivalplot",
-        min_groups=2,
     )
 
     import lifelines as ll
@@ -314,12 +387,12 @@ def survivalplot(
         and len(hue_order) == len(observed_groups)
         and set(hue_order) == set(observed_groups)
     )
-    if overall_test not in {"logrank", "trend"}:
+    if not descriptive_only and overall_test not in {"logrank", "trend"}:
         raise ValueError(
             "[survivalplot] Parameter 'overall_test' must be one of "
             "'logrank' or 'trend'."
         )
-    if overall_test == "trend" and not has_explicit_order:
+    if not descriptive_only and overall_test == "trend" and not has_explicit_order:
         raise ValueError(
             "[survivalplot] The trend test requires a complete explicit 'hue_order' "
             "because category order defines the trend scores."
@@ -352,7 +425,7 @@ def survivalplot(
             )
 
     resolved_pairs: list[tuple[str, str]] = []
-    if show_hazard_ratio:
+    if show_hazard_ratio and not descriptive_only:
         resolved_pairs = (
             [(hue_order[0], hue_order[1])]
             if pairs is None and len(hue_order) == 2
@@ -411,20 +484,24 @@ def survivalplot(
                 max(current_xlim[1], specified_xticks.max()),
             )
 
-    if overall_test == "logrank":
+    annotation_lines = []
+    if not descriptive_only and overall_test == "logrank":
         try:
-            logrank_result = multivariate_logrank_test(
-                data[duration], data[hue], data[event]
+            _validate_logrank_variance(data, duration, event, hue)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", RuntimeWarning)
+                logrank_result = multivariate_logrank_test(
+                    data[duration], data[hue], data[event]
+                )
+            annotation_lines.append(
+                "Log-rank P = " + _format_inference_pvalue(logrank_result.p_value)
             )
-            overall_p = num2tex.num2tex(logrank_result.p_value, precision=2)
-            overall_label = "Log-rank"
             logger.info("P-value was determined by two-sided omnibus log-rank test.")
-        except Exception as e:
-            raise RuntimeError(
-                "[survivalplot] Log-rank test failed. This may indicate insufficient data "
-                f"or invalid event/duration values. Details: {e}"
-            ) from e
-    else:
+        except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
+            annotation_lines.append(
+                _unavailable_inference("survivalplot", "Log-rank", e)
+            )
+    elif not descriptive_only:
         trend_data = pd.DataFrame(
             {
                 "_duration": data[duration].to_numpy(),
@@ -433,22 +510,20 @@ def survivalplot(
             }
         )
         try:
-            cph = ll.CoxPHFitter()
-            cph.fit(trend_data, duration_col="_duration", event_col="_event")
+            cph = _fit_cox_inference(trend_data, "_group_score")
             trend_result = cph.log_likelihood_ratio_test()
-            overall_p = num2tex.num2tex(trend_result.p_value, precision=2)
-            overall_label = "Cox trend"
+            annotation_lines.append(
+                "Cox trend P = " + _format_inference_pvalue(trend_result.p_value)
+            )
             logger.info(
                 "P-value was determined by a one-degree-of-freedom Cox proportional "
                 "hazards trend test using hue_order scores."
             )
-        except Exception as e:
-            raise RuntimeError(
-                "[survivalplot] Cox proportional hazards model failed. This may indicate "
-                f"insufficient data or model convergence issues. Details: {e}"
-            ) from e
+        except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
+            annotation_lines.append(
+                _unavailable_inference("survivalplot", "Cox trend", e)
+            )
 
-    annotation_lines = [f"{overall_label} P = " + rf"${overall_p:.2g}$"]
     for reference, comparison in resolved_pairs:
         pair_data = data[data[hue].isin([reference, comparison])]
         cox_data = pd.DataFrame(
@@ -459,29 +534,28 @@ def survivalplot(
             }
         )
         try:
-            cph = ll.CoxPHFitter()
-            cph.fit(cox_data, duration_col="_duration", event_col="_event")
+            cph = _fit_cox_inference(cox_data, "_comparison")
             summary = cph.summary.loc["_comparison"]
             hazard_ratio = summary["exp(coef)"]
             ci1 = summary["exp(coef) lower 95%"]
             ci2 = summary["exp(coef) upper 95%"]
-            pair_p = num2tex.num2tex(summary["p"], precision=2)
-        except Exception as e:
-            raise RuntimeError(
-                "[survivalplot] Could not compute hazard ratios for contrast "
-                f"{comparison!r} vs {reference!r}. This may indicate insufficient "
-                f"data or model convergence issues. Details: {e}"
-            ) from e
+            pair_p = _format_inference_pvalue(summary["p"])
+        except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
+            annotation_lines.append(
+                _unavailable_inference(
+                    "survivalplot", f"Cox HR ({comparison} vs {reference})", e
+                )
+            )
+            continue
         if len(hue_order) > 2:
             annotation_lines.append(f"{comparison} vs {reference}")
         annotation_lines.extend(
             [
                 f"HR = {hazard_ratio:.2f}",
                 f"95% CI {ci1:.2f}-{ci2:.2f}",
-                "Cox P = " + rf"${pair_p:.2g}$",
+                "Cox P = " + pair_p,
             ]
         )
-    if resolved_pairs:
         logger.info(
             "Pairwise hazard ratios and unadjusted two-sided P-values were determined "
             "by Cox proportional hazards models."
@@ -531,18 +605,28 @@ def survivalplot(
                 s=12,
                 zorder=3,
             )
-        if len(fitters) == 2 and all(
-            0 < estimate < 1 for estimate in landmark_estimates
-        ):
-            landmark_result = survival_difference_at_fixed_point_in_time_test(
-                landmark_time, fitters[0], fitters[1]
-            )
-            landmark_p = num2tex.num2tex(landmark_result.p_value, precision=2)
-            annotation_lines.append("Landmark P = " + rf"${landmark_p:.2g}$")
-            logger.info(
-                "Landmark P-value was determined by a two-sided fixed-time "
-                "log-minus-log test."
-            )
+        if not descriptive_only and len(fitters) == 2:
+            try:
+                if not all(0 < estimate < 1 for estimate in landmark_estimates):
+                    raise ValueError(
+                        "survival estimates must be strictly between 0 and 1"
+                    )
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", RuntimeWarning)
+                    landmark_result = survival_difference_at_fixed_point_in_time_test(
+                        landmark_time, fitters[0], fitters[1]
+                    )
+                annotation_lines.append(
+                    "Landmark P = " + _format_inference_pvalue(landmark_result.p_value)
+                )
+                logger.info(
+                    "Landmark P-value was determined by a two-sided fixed-time "
+                    "log-minus-log test."
+                )
+            except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
+                annotation_lines.append(
+                    _unavailable_inference("survivalplot", "Landmark test", e)
+                )
 
     if rmst_time is not None:
         rmst_time = float(rmst_time)
@@ -555,7 +639,8 @@ def survivalplot(
     for analysis_time in sorted(analysis_guide_times):
         ax.axvline(analysis_time, color="0.5", linestyle="--", linewidth=0.8)
 
-    _add_pvalue_annotation(ax, "\n".join(annotation_lines), pvalue_loc)
+    if annotation_lines:
+        _add_pvalue_annotation(ax, "\n".join(annotation_lines), pvalue_loc)
 
     legend = ax.get_legend()
     if legend is not None:
@@ -599,6 +684,7 @@ def cumulativeincidenceplot(
     time_label: str = "Time",
     seed: int | None = 0,
     *,
+    descriptive_only: bool = False,
     pvalue_loc: PValueLoc = "center left",
     ax: Axes | None = None,
 ) -> Axes:
@@ -649,6 +735,13 @@ def cumulativeincidenceplot(
         Seed used by lifelines when tied event times require jittering. The default
         makes tied-data plots deterministic. The caller's NumPy random state is
         restored after fitting.
+    descriptive_only : bool, default: False
+        Skip Gray's test and its annotation. Single groups, all-censored groups,
+        and groups without the event of interest have valid descriptive curves.
+        Event code 0 always means censored, 1 is the event of interest, and all
+        higher codes remain competing events, even when code 0 or 1 is absent.
+        Otherwise, unavailable inference emits a UserWarning with the reason and
+        is annotated as ``unavailable`` while preserving the curves.
     pvalue_loc : str, default: 'center left'
         Axes-relative location for the Gray's test p-value. Accepts the fixed
         Matplotlib legend locations: ``'upper left'``, ``'upper center'``,
@@ -781,15 +874,23 @@ def cumulativeincidenceplot(
                 max(current_xlim[1], specified_xticks.max()),
             )
             ax.set_xlim(new_xlim)
-    if data[hue].nunique() > 1:
-        pvalue = helper_cmprsk.cuminc(
-            data[duration], data[event], group=data[hue].cat.codes
-        )
-        p = num2tex.num2tex(pvalue, precision=2)
-        logger.info("P-value was determined by Gray's K-sample test.")
+    if not descriptive_only:
+        try:
+            _validate_comparison(data, event, hue)
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", RuntimeWarning)
+                pvalue = helper_cmprsk.cuminc(
+                    data[duration], data[event], group=data[hue].cat.codes
+                )
+            annotation = "P = " + _format_inference_pvalue(pvalue)
+            logger.info("P-value was determined by Gray's K-sample test.")
+        except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
+            annotation = _unavailable_inference(
+                "cumulativeincidenceplot", "Gray's test", e
+            )
         _add_pvalue_annotation(
             ax,
-            "P = " + rf"${p:.2g}$",
+            annotation,
             pvalue_loc,
             data_position=pvalue_position,
         )

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -1092,7 +1092,7 @@ def test_plot_internal_coverage(
         "multivariate_logrank_test",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("bad")),
     )
-    with pytest.raises(RuntimeError, match="Log-rank test failed"):
+    with pytest.warns(UserWarning, match="Log-rank unavailable: bad"):
         cns.survivalplot(survival_df, "time", "event", "group")
     monkeypatch.setattr(
         lifelines_statistics,
@@ -1105,7 +1105,7 @@ def test_plot_internal_coverage(
             raise RuntimeError("bad")
 
     monkeypatch.setattr(lifelines, "CoxPHFitter", BadCox)
-    with pytest.raises(RuntimeError, match="Cox proportional hazards model failed"):
+    with pytest.warns(UserWarning, match="Cox trend unavailable: bad"):
         cns.survivalplot(
             pd.DataFrame(
                 {
@@ -1120,7 +1120,7 @@ def test_plot_internal_coverage(
             hue_order=["A", "B", "C"],
             overall_test="trend",
         )
-    with pytest.raises(RuntimeError, match="Could not compute hazard ratios"):
+    with pytest.warns(UserWarning, match="Cox HR.*unavailable: bad"):
         cns.survivalplot(survival_df, "time", "event", "group")
 
     cns.figure(120, 120)

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -225,8 +225,12 @@ def test_survival_plots(
 
     cns.figure(120, 120)
     single_group = competing_risk_df[competing_risk_df["group"] == "A"].copy()
-    ax4 = cns.cumulativeincidenceplot(single_group, "time", "event", "group")
+    with pytest.warns(
+        UserWarning, match="Gray's test unavailable.*at least two groups"
+    ):
+        ax4 = cns.cumulativeincidenceplot(single_group, "time", "event", "group")
     assert ax4 is plt.gca()
+    assert ax4.texts[0].get_text() == "Gray's test unavailable"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_survival_descriptive.py
+++ b/tests/test_survival_descriptive.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from lifelines import AalenJohansenFitter, KaplanMeierFitter
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize("plot_name", ["survivalplot", "cumulativeincidenceplot"])
+@pytest.mark.parametrize("event_code", [0, 1])
+@pytest.mark.parametrize("single_group", [False, True])
+def test_descriptive_curves_match_lifelines(
+    plot_name: str, event_code: int, single_group: bool
+) -> None:
+    data = pd.DataFrame(
+        {
+            "time": [1, 2, 3, 4, 1, 2, 3, 4],
+            "event": event_code,
+            "group": ["A"] * 4 + ["A" if single_group else "B"] * 4,
+        }
+    )
+    original = data.copy(deep=True)
+    ax = getattr(cns, plot_name)(data, "time", "event", "group", descriptive_only=True)
+    curves = [line for line in ax.lines if line.get_drawstyle() == "steps-post"]
+    assert len(curves) == data["group"].nunique()
+    assert not ax.texts
+    for curve, (_, group) in zip(curves, data.groupby("group"), strict=True):
+        if plot_name == "survivalplot":
+            reference = KaplanMeierFitter().fit(group["time"], group["event"])
+            expected = reference.survival_function_
+        else:
+            reference = AalenJohansenFitter().fit(
+                group["time"], group["event"], event_of_interest=1
+            )
+            expected = reference.cumulative_density_
+        np.testing.assert_allclose(curve.get_xdata(), expected.index)
+        np.testing.assert_allclose(curve.get_ydata(), expected.iloc[:, 0])
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_descriptive_mode_skips_all_inference(
+    survival_df: pd.DataFrame,
+    competing_risk_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import lifelines
+    import lifelines.statistics
+
+    from cnsplots.helpers import _cmprsk
+
+    def unexpected(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("Descriptive mode must not run inference")
+
+    monkeypatch.setattr(lifelines, "CoxPHFitter", unexpected)
+    monkeypatch.setattr(lifelines.statistics, "multivariate_logrank_test", unexpected)
+    monkeypatch.setattr(
+        lifelines.statistics,
+        "survival_difference_at_fixed_point_in_time_test",
+        unexpected,
+    )
+    monkeypatch.setattr(_cmprsk, "cuminc", unexpected)
+    ax = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        descriptive_only=True,
+        overall_test="trend",
+        pairs=[("missing", "ignored")],
+        landmark_time=6,
+        rmst_time=8,
+        show_median_survival=True,
+        show_risk_table=True,
+        ci_show=True,
+    )
+    annotation = ax.texts[0].get_text()
+    assert "Survival at 6" in annotation
+    assert "RMST to 8" in annotation
+    assert "Median survival" in annotation
+    assert "P =" not in annotation
+    assert "HR" not in annotation
+    assert len(ax.figure.axes) == 2
+    _, cif_ax = plt.subplots()
+    cns.cumulativeincidenceplot(
+        competing_risk_df,
+        "time",
+        "event",
+        "group",
+        descriptive_only=True,
+        ax=cif_ax,
+    )
+    assert not cif_ax.texts
+
+
+def test_all_censored_group_keeps_logrank_and_reports_unavailable_cox() -> None:
+    data = pd.DataFrame(
+        {
+            "time": [1, 2, 3, 4, 1, 2, 3, 4],
+            "event": [0, 0, 0, 0, 1, 0, 1, 0],
+            "group": ["A"] * 4 + ["B"] * 4,
+        }
+    )
+    with pytest.warns(UserWarning, match="Cox HR.*unavailable"):
+        ax = cns.survivalplot(data, "time", "event", "group")
+    assert "Log-rank P =" in ax.texts[0].get_text()
+    assert "Cox HR (B vs A) unavailable" in ax.texts[0].get_text()
+    assert "HR =" not in ax.texts[0].get_text()
+    curve = next(line for line in ax.lines if line.get_label() == "A (n=4)")
+    np.testing.assert_array_equal(curve.get_ydata(), np.ones(5))
+    _, ax = plt.subplots()
+    cns.survivalplot(data, "time", "event", "group", show_hazard_ratio=False, ax=ax)
+    assert ax.texts[0].get_text().startswith("Log-rank P =")
+
+
+@pytest.mark.parametrize("event_code", [0, 2, 3])
+def test_cumulative_incidence_without_primary_events(event_code: int) -> None:
+    data = pd.DataFrame(
+        {"time": [1, 2, 3, 4], "event": event_code, "group": ["A", "A", "B", "B"]}
+    )
+    with pytest.warns(
+        UserWarning, match="Gray's test unavailable.*no events of interest"
+    ):
+        ax = cns.cumulativeincidenceplot(data, "time", "event", "group")
+    for line in ax.lines:
+        np.testing.assert_array_equal(line.get_ydata(), np.zeros(3))
+    assert "Gray's test unavailable" in ax.texts[0].get_text()
+    assert len(ax.collections) == (2 if event_code == 0 else 0)
+
+
+@pytest.mark.parametrize("plot_name", ["survivalplot", "cumulativeincidenceplot"])
+@pytest.mark.parametrize("event_code", [0, 1])
+def test_descriptive_single_observation(plot_name: str, event_code: int) -> None:
+    data = pd.DataFrame({"time": [2], "event": [event_code], "group": ["A"]})
+    _, target = plt.subplots()
+    ax = getattr(cns, plot_name)(
+        data,
+        "time",
+        "event",
+        "group",
+        descriptive_only=True,
+        show_risk_table=True,
+        ax=target,
+    )
+    assert ax is target
+    assert len(ax.figure.axes) == 2
+
+
+def test_entirely_uncensored_cohort_keeps_estimable_inference(
+    survival_df: pd.DataFrame,
+) -> None:
+    from lifelines import CoxPHFitter
+    from lifelines.statistics import multivariate_logrank_test
+
+    data = survival_df.assign(event=1)
+    ax = cns.survivalplot(data, "time", "event", "group")
+    logrank = multivariate_logrank_test(data["time"], data["group"], data["event"])
+    cox_data = data[["time", "event"]].assign(
+        comparison=(data["group"] == "Treatment").astype(int)
+    )
+    model = CoxPHFitter().fit(cox_data, "time", "event")
+    assert f"Log-rank P = ${logrank.p_value:.2g}$" in ax.texts[0].get_text()
+    assert f"HR = {model.hazard_ratios_.iloc[0]:.2f}" in ax.texts[0].get_text()
+    assert "unavailable" not in ax.texts[0].get_text()
+
+
+def test_all_censored_cohort_reports_each_unavailable_comparison(
+    survival_df: pd.DataFrame,
+) -> None:
+    with pytest.warns(UserWarning) as recorded:
+        ax = cns.survivalplot(survival_df.assign(event=0), "time", "event", "group")
+    assert len(recorded) == 2
+    assert ax.texts[0].get_text().splitlines() == [
+        "Log-rank unavailable",
+        "Cox HR (Treatment vs Control) unavailable",
+    ]
+    for curve in ax.lines:
+        np.testing.assert_allclose(np.asarray(curve.get_ydata()), 1)
+
+
+@pytest.mark.parametrize("plot_name", ["survivalplot", "cumulativeincidenceplot"])
+def test_zero_comparison_variance_is_unavailable(plot_name: str) -> None:
+    data = pd.DataFrame(
+        {"time": [1] * 4, "event": [1] * 4, "group": ["A", "A", "B", "B"]}
+    )
+    kwargs = {"show_hazard_ratio": False} if plot_name == "survivalplot" else {}
+    with pytest.warns(UserWarning, match="unavailable.*variance is zero or singular"):
+        ax = getattr(cns, plot_name)(data, "time", "event", "group", **kwargs)
+    assert "P =" not in ax.texts[0].get_text()
+    assert len(ax.lines) == 2
+
+
+@pytest.mark.parametrize("overall_test", ["logrank", "trend"])
+def test_cox_separation_preserves_curves(overall_test: Any) -> None:
+    data = pd.DataFrame(
+        {"time": list(range(1, 9)), "event": [1] * 8, "group": ["A"] * 4 + ["B"] * 4}
+    )
+    with pytest.warns(UserWarning, match="Cox.*unavailable"):
+        ax = cns.survivalplot(
+            data,
+            "time",
+            "event",
+            "group",
+            overall_test=overall_test,
+            hue_order=["A", "B"],
+        )
+    assert len(ax.lines) == 2
+    assert "HR =" not in ax.texts[0].get_text()
+
+
+@pytest.mark.parametrize("event_code", [0, 2])
+def test_gray_test_allows_a_group_without_primary_events(
+    competing_risk_df: pd.DataFrame, event_code: int
+) -> None:
+    from comprisk import gray_test
+
+    data = competing_risk_df.copy()
+    data.loc[data["group"] == "A", "event"] = event_code
+    original = data.copy(deep=True)
+    ax = cns.cumulativeincidenceplot(data, "time", "event", "group")
+    expected = gray_test(data["time"], data["event"], data["group"], cause=1)
+    assert ax.texts[0].get_text() == f"P = ${expected.pvalue:.2g}$"
+    np.testing.assert_allclose(np.asarray(ax.lines[0].get_ydata()), 0)
+    pd.testing.assert_frame_equal(data, original)
+
+
+@pytest.mark.parametrize("plot_name", ["survivalplot", "cumulativeincidenceplot"])
+@pytest.mark.parametrize(
+    ("column", "value", "message"),
+    [
+        ("time", -1, "non-negative durations"),
+        ("time", np.inf, "finite durations"),
+        ("time", np.nan, "null"),
+        ("event", -1, "event codes"),
+        ("event", 0.5, "event codes"),
+        ("event", 1j, "event codes"),
+        ("event", np.inf, "event codes"),
+        ("event", np.nan, "null"),
+        ("group", None, "null"),
+    ],
+)
+def test_descriptive_mode_still_rejects_invalid_data(
+    plot_name: str, column: str, value: Any, message: str
+) -> None:
+    data = pd.DataFrame({"time": [1.0, 2.0], "event": [0.0, 1.0], "group": ["A", "A"]})
+    if isinstance(value, complex):
+        data[column] = data[column].astype(complex)
+    data.loc[0, column] = value
+    with pytest.raises(ValueError, match=message):
+        getattr(cns, plot_name)(data, "time", "event", "group", descriptive_only=True)
+
+
+@pytest.mark.parametrize("test_name", ["logrank", "trend", "landmark", "gray"])
+@pytest.mark.parametrize("pvalue", [np.nan, np.inf, -0.1, 1.1])
+def test_invalid_backend_pvalues_preserve_estimates(
+    test_name: str,
+    pvalue: float,
+    survival_df: pd.DataFrame,
+    competing_risk_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import lifelines.statistics
+    from lifelines.fitters.coxph_fitter import SemiParametricPHFitter
+
+    from cnsplots.helpers import _cmprsk
+
+    def invalid_result(*args: Any, **kwargs: Any) -> Any:
+        return SimpleNamespace(p_value=pvalue)
+
+    kwargs: dict[str, Any] = {}
+    if test_name == "logrank":
+        monkeypatch.setattr(
+            lifelines.statistics, "multivariate_logrank_test", invalid_result
+        )
+    elif test_name == "trend":
+        monkeypatch.setattr(
+            SemiParametricPHFitter, "log_likelihood_ratio_test", invalid_result
+        )
+        kwargs.update(overall_test="trend", hue_order=["Control", "Treatment"])
+    elif test_name == "landmark":
+        monkeypatch.setattr(
+            lifelines.statistics,
+            "survival_difference_at_fixed_point_in_time_test",
+            invalid_result,
+        )
+        kwargs.update(landmark_time=6, rmst_time=8)
+    else:
+        monkeypatch.setattr(_cmprsk, "cuminc", lambda *args, **kwargs: pvalue)
+
+    with pytest.warns(UserWarning, match="unavailable.*finite p-value"):
+        if test_name == "gray":
+            ax = cns.cumulativeincidenceplot(
+                competing_risk_df, "time", "event", "group"
+            )
+        else:
+            ax = cns.survivalplot(survival_df, "time", "event", "group", **kwargs)
+    annotation = ax.texts[0].get_text()
+    assert "unavailable" in annotation
+    assert "nan" not in annotation
+    assert "inf" not in annotation
+    if test_name != "gray":
+        assert "HR =" in annotation
+    if test_name == "landmark":
+        assert "Control = 0.67" in annotation
+        assert "RMST to 8" in annotation
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [("exp(coef)", np.inf), ("exp(coef) lower 95%", 0), ("p", np.nan)],
+)
+def test_invalid_cox_estimates_are_not_reported(
+    column: str,
+    value: float,
+    survival_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lifelines.fitters.coxph_fitter import SemiParametricPHFitter
+
+    original_summary = SemiParametricPHFitter.summary.fget
+    assert original_summary is not None
+
+    def invalid_summary(fitter: Any) -> pd.DataFrame:
+        summary = original_summary(fitter)
+        summary.loc["_comparison", column] = value
+        return summary
+
+    monkeypatch.setattr(SemiParametricPHFitter, "summary", property(invalid_summary))
+    with pytest.warns(UserWarning, match="Cox HR.*unavailable"):
+        ax = cns.survivalplot(survival_df, "time", "event", "group")
+    assert "HR =" not in ax.texts[0].get_text()
+    assert "Log-rank P =" in ax.texts[0].get_text()
+
+
+def test_failed_pair_does_not_discard_other_contrasts(
+    survival_three_group_df: pd.DataFrame,
+) -> None:
+    data = survival_three_group_df.copy()
+    data.loc[data["group"] == "Mid", "event"] = 0
+    with pytest.warns(UserWarning, match="Cox HR \\(Mid vs Low\\) unavailable"):
+        ax = cns.survivalplot(
+            data, "time", "event", "group", pairs=[("Low", "Mid"), ("Low", "High")]
+        )
+    annotation = ax.texts[0].get_text()
+    assert "Log-rank P =" in annotation
+    assert "Cox HR (Mid vs Low) unavailable" in annotation
+    assert "High vs Low\nHR = 0.38" in annotation
+
+
+def test_uncensored_competing_events_are_not_redefined_as_censoring(
+    competing_risk_df: pd.DataFrame,
+) -> None:
+    from comprisk import gray_test
+
+    data = competing_risk_df.loc[competing_risk_df["event"] != 0]
+    ax = cns.cumulativeincidenceplot(data, "time", "event", "group")
+    expected = gray_test(data["time"], data["event"], data["group"], cause=1)
+    assert ax.texts[0].get_text() == f"P = ${expected.pvalue:.2g}$"
+    assert not ax.collections
+    np.testing.assert_allclose(
+        np.asarray(ax.lines[0].get_ydata()), [0, 0.25, 0.25, 0.5, 0.5]
+    )

--- a/tests/test_survival_features.py
+++ b/tests/test_survival_features.py
@@ -105,21 +105,23 @@ def test_survivalplot_can_run_two_group_landmark_analysis(
     assert any(np.array_equal(line.get_xdata(), [6, 6]) for line in ax.lines)
 
 
-def test_survivalplot_skips_landmark_test_at_survival_boundary(
+def test_survivalplot_reports_unavailable_landmark_test_at_survival_boundary(
     survival_df: pd.DataFrame,
 ) -> None:
-    ax = cns.survivalplot(
-        survival_df,
-        "time",
-        "event",
-        "group",
-        landmark_time=1,
-    )
+    with pytest.warns(UserWarning, match="Landmark test unavailable.*between 0 and 1"):
+        ax = cns.survivalplot(
+            survival_df,
+            "time",
+            "event",
+            "group",
+            landmark_time=1,
+        )
 
-    assert ax.texts[0].get_text().splitlines()[-3:] == [
+    assert ax.texts[0].get_text().splitlines()[-4:] == [
         "Survival at 1",
         "Control = 1.00",
         "Treatment = 1.00",
+        "Landmark test unavailable",
     ]
 
 

--- a/tests/test_survival_hardening.py
+++ b/tests/test_survival_hardening.py
@@ -14,7 +14,7 @@ def test_survivalplot_requires_zero_one_event_semantics(
     invalid = survival_df.copy()
     invalid["event"] += 1
 
-    with pytest.raises(ValueError, match="specifically 0 and 1"):
+    with pytest.raises(ValueError, match="only event codes 0 and 1"):
         cns.survivalplot(invalid, "time", "event", "group")
 
 
@@ -80,17 +80,19 @@ def test_cumulativeincidenceplot_requires_numeric_event_codes(
         cns.cumulativeincidenceplot(invalid, "time", "event", "group")
 
 
-def test_survivalplot_requires_two_groups(survival_df: pd.DataFrame) -> None:
-    invalid = survival_df.assign(group="only")
+def test_survivalplot_preserves_single_group_curve(survival_df: pd.DataFrame) -> None:
+    data = survival_df.assign(group="only")
 
-    with pytest.raises(ValueError, match="at least 2 groups"):
-        cns.survivalplot(invalid, "time", "event", "group")
+    with pytest.warns(UserWarning, match="Log-rank unavailable.*at least two groups"):
+        ax = cns.survivalplot(data, "time", "event", "group")
+    assert ax.texts[0].get_text() == "Log-rank unavailable"
+    assert any(line.get_label() == "only (n=12)" for line in ax.lines)
 
 
-def test_survivalplot_requires_two_observations_per_group(
+def test_survivalplot_accepts_single_observation_groups(
     survival_df: pd.DataFrame,
 ) -> None:
-    invalid = pd.concat(
+    data = pd.concat(
         [
             survival_df[survival_df["group"] == "Control"],
             survival_df[survival_df["group"] == "Treatment"].iloc[[0]],
@@ -98,18 +100,18 @@ def test_survivalplot_requires_two_observations_per_group(
         ignore_index=True,
     )
 
-    with pytest.raises(ValueError, match="at least 2 observations"):
-        cns.survivalplot(invalid, "time", "event", "group")
+    ax = cns.survivalplot(data, "time", "event", "group", descriptive_only=True)
+    assert any(line.get_label() == "Treatment (n=1)" for line in ax.lines)
 
 
-def test_survivalplot_requires_an_event_per_group(
+def test_survivalplot_accepts_all_censored_group(
     survival_df: pd.DataFrame,
 ) -> None:
-    invalid = survival_df.copy()
-    invalid.loc[invalid["group"] == "Treatment", "event"] = 0
+    data = survival_df.copy()
+    data.loc[data["group"] == "Treatment", "event"] = 0
 
-    with pytest.raises(ValueError, match="at least one event of interest"):
-        cns.survivalplot(invalid, "time", "event", "group")
+    ax = cns.survivalplot(data, "time", "event", "group", show_hazard_ratio=False)
+    assert ax.texts[0].get_text().startswith("Log-rank P =")
 
 
 def test_survival_time_labels_are_explicit_and_endpoint_neutral(


### PR DESCRIPTION
Allow valid Kaplan–Meier and cumulative-incidence curves for all-censored groups, uncensored cohorts, and single groups. Closes #128.

- Add documented `descriptive_only=True` support to both plot functions, preserving descriptive estimates and risk tables while skipping tests and Cox fitting.
- Separate duration/event validation from inference adequacy. Check comparison variance, Cox convergence and finite estimates, and landmark boundaries; warn and annotate unavailable results while retaining valid curves and other comparisons.
- Preserve competing-event and censoring codes, and replace tests that required events in every group with numerical regression coverage.

Validation: `make test` passed (704 tests, 100% coverage), and `make lint` passed. Tests compare curves and estimable statistics with lifelines/comprisk, exercise unavailable inference, and retain invalid-input checks. Visually inspected the issue reproduction and descriptive survival/cumulative-incidence examples.

Compatibility: unavailable inference now produces a `UserWarning` and an `unavailable` annotation instead of stopping the plot. Callers that promote warnings to errors can use descriptive mode to skip inference. The structured-results interface remains a follow-up in #162.
