### PR TITLE
🐛 Align KDE comparisons with plots

### DIFF
--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -497,6 +497,18 @@ def kdeplot(
     >>> # Compare two groups with automatic statistics
     >>> ax = cns.kdeplot(data=df, x="score", hue="treatment", fill=True)
     >>> ax.set_xlabel("Score")
+
+    Notes
+    -----
+    For unweighted, univariate plots, plotting and testing use finite ``x`` values
+    with nonmissing hue labels, restricted to ``hue_order`` when supplied.
+    Logarithmic x axes additionally require positive values. Unused categorical
+    levels do not enter the test.
+    A two-sided Kolmogorov-Smirnov test is annotated only for unweighted,
+    univariate plots with exactly two observed hue groups and two drawn densities.
+    Groups with fewer than two observations or zero variance cannot produce a
+    density; seaborn's ``warn_singular`` controls their warning. If either density
+    is skipped, no comparison is annotated. Empty cleaned data produces no density.
     """
     # Validate inputs
     validate_dataframe(data, "data", "kdeplot")
@@ -507,6 +519,23 @@ def kdeplot(
     linewidth = kwargs.pop("linewidth", 1)
     if ax is None:
         ax = plt.gca()
+    unweighted_univariate = kwargs.get("weights") is None and kwargs.get("y") is None
+    if unweighted_univariate:
+        values = data[x].to_numpy(dtype=float, na_value=np.nan)
+        data = data.loc[np.isfinite(values)]
+        if hue is not None:
+            data = data.loc[data[hue].notna()]
+            if hue_order is not None:
+                data = data.loc[data[hue].isin(hue_order)]
+        log_scale = kwargs.get("log_scale")
+        log_x = log_scale[0] if isinstance(log_scale, (tuple, list)) else log_scale
+        if log_x or ax.get_xscale() == "log":
+            data = data.loc[data[x] > 0]
+        if data.empty:
+            return ax
+
+    line_count = len(ax.lines)
+    artist_count = line_count + len(ax.collections)
     ax = sns.kdeplot(
         data=data,
         x=x,
@@ -518,22 +547,28 @@ def kdeplot(
     )
     modes = []
     if hue is not None:
-        if data[hue].nunique() == 2:
-            grouped = data.groupby(hue)
-            args = [group_df[x].values for _, group_df in grouped]
-            p_value = sp.stats.ks_2samp(*args)
+        drawn_densities = len(ax.lines) + len(ax.collections) - artist_count
+        if data[hue].nunique() == 2 and drawn_densities == 2 and unweighted_univariate:
+            grouped = data.groupby(hue, observed=True, sort=False)
+            args = [group_df[x].to_numpy(dtype=float) for _, group_df in grouped]
+            p_value = sp.stats.ks_2samp(*args).pvalue
+            if not np.isfinite(p_value):
+                logger.warning(
+                    "[kdeplot] KS test returned a nonfinite p-value; omitted."
+                )
+                return ax
             x_lim = ax.get_xlim()
             y_lim = ax.get_ylim()
             ax.text(
                 x_lim[1],
                 y_lim[1],
-                rf"$P={num2tex.num2tex(p_value[-1], precision=2):.2g}$",
+                rf"$P={num2tex.num2tex(p_value, precision=2):.2g}$",
                 ha="right",
                 va="top",
             )
             logger.info("P-value was determined by two-sided Kolmogorov-Smirnov test.")
     else:
-        if add_mode and ax.get_lines():
+        if add_mode and len(ax.lines) > line_count:
             kde_data = ax.get_lines()[-1].get_data()
             x_vals = np.asarray(kde_data[0], dtype=float)
             y_vals = np.asarray(kde_data[1], dtype=float)

--- a/tests/test_distribution_plot_defects.py
+++ b/tests/test_distribution_plot_defects.py
@@ -1,12 +1,179 @@
 """Regression tests for distribution plot validation."""
 
 from typing import Any
+from types import SimpleNamespace
+from unittest.mock import patch
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.stats import ks_2samp
 
 import cnsplots as cns
+
+
+@pytest.mark.parametrize("fill", [False, True])
+@pytest.mark.parametrize("categorical", [False, True])
+def test_kdeplot_tests_exactly_the_plotted_observations(
+    fill: bool, categorical: bool
+) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A"] * 6 + ["B"] * 5 + [None],
+            "value": [1.0, 1.2, 1.4, np.nan, np.inf, -np.inf]
+            + [2.0, 2.2, 2.4, 2.6, np.nan]
+            + [100.0],
+            "unrelated": [np.nan] * 12,
+        }
+    )
+    if categorical:
+        data["group"] = pd.Categorical(data["group"], categories=["unused", "B", "A"])
+    original = data.copy(deep=True)
+    expected = data.loc[data["group"].notna() & np.isfinite(data["value"])]
+    _, (ax, reference_ax) = plt.subplots(1, 2)
+
+    with patch(
+        "cnsplots.plots._distribution.sp.stats.ks_2samp", wraps=ks_2samp
+    ) as test:
+        cns.kdeplot(data, x="value", hue="group", fill=fill, ax=ax)
+
+    test.assert_called_once()
+    samples = sorted(test.call_args.args, key=lambda sample: sample[0])
+    np.testing.assert_array_equal(samples[0], [1.0, 1.2, 1.4])
+    np.testing.assert_array_equal(samples[1], [2.0, 2.2, 2.4, 2.6])
+    assert ks_2samp(*samples).pvalue == pytest.approx(0.05714285714285715)
+    assert [text.get_text() for text in ax.texts] == [r"$P=0.057$"]
+    cns.kdeplot(expected, x="value", hue="group", fill=fill, ax=reference_ax)
+    if fill:
+        for actual, reference in zip(ax.collections, reference_ax.collections):
+            np.testing.assert_allclose(
+                actual.get_paths()[0].vertices, reference.get_paths()[0].vertices
+            )
+    else:
+        for actual, reference in zip(ax.lines, reference_ax.lines):
+            np.testing.assert_allclose(actual.get_xydata(), reference.get_xydata())
+    pd.testing.assert_frame_equal(data, original)
+
+
+@pytest.mark.parametrize("hue_order", [["B", "A"], ["A"], ["missing"], []])
+def test_kdeplot_comparison_respects_hue_subset(hue_order: list[str]) -> None:
+    data = pd.DataFrame(
+        {"group": ["A"] * 3 + ["B"] * 3 + ["C"] * 3, "value": np.arange(9.0)}
+    )
+    with patch(
+        "cnsplots.plots._distribution.sp.stats.ks_2samp", wraps=ks_2samp
+    ) as test:
+        ax = cns.kdeplot(data, x="value", hue="group", hue_order=hue_order)
+
+    if len(hue_order) == 2:
+        test.assert_called_once()
+        samples = sorted(test.call_args.args, key=lambda sample: sample[0])
+        np.testing.assert_array_equal(samples[0], [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(samples[1], [3.0, 4.0, 5.0])
+        assert len(ax.texts) == 1
+    else:
+        test.assert_not_called()
+        assert not ax.texts
+    assert len(ax.lines) == len(set(hue_order) & {"A", "B", "C"})
+
+
+@pytest.mark.parametrize("values", [[np.nan, np.inf], [2.0, np.nan], [2.0, 2.0]])
+@pytest.mark.parametrize("fill", [False, True])
+def test_kdeplot_does_not_compare_undrawn_groups(
+    values: list[float], fill: bool
+) -> None:
+    data = pd.DataFrame(
+        {"group": ["A"] * 3 + ["B"] * len(values), "value": [0.0, 0.5, 1.0] + values}
+    )
+    ax = plt.gca()
+    ax.plot([0, 1], [0, 1])
+    with patch("cnsplots.plots._distribution.sp.stats.ks_2samp") as test:
+        cns.kdeplot(data, x="value", hue="group", fill=fill, warn_singular=False, ax=ax)
+
+    test.assert_not_called()
+    assert not ax.texts
+    assert len(ax.lines) + len(ax.collections) == 2
+
+
+@pytest.mark.parametrize("values", [[np.nan, np.inf], [1.0, np.nan], [1.0, 1.0]])
+def test_kdeplot_does_not_annotate_old_lines_without_a_density(
+    values: list[float],
+) -> None:
+    ax = plt.gca()
+    ax.plot([0, 1], [0, 1])
+
+    cns.kdeplot(pd.DataFrame({"value": values}), x="value", warn_singular=False, ax=ax)
+
+    assert len(ax.lines) == 1
+    assert not ax.texts
+
+
+@pytest.mark.parametrize("log_scale", [True, (True, False), None])
+def test_kdeplot_logarithmic_comparison_uses_positive_values(log_scale: Any) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A"] * 5 + ["B"] * 5,
+            "value": [-1.0, 0.0, 1.0, 2.0, 3.0, -2.0, 0.0, 4.0, 5.0, 6.0],
+        }
+    )
+    ax = plt.gca()
+    if log_scale is None:
+        ax.set_xscale("log")
+    with patch(
+        "cnsplots.plots._distribution.sp.stats.ks_2samp", wraps=ks_2samp
+    ) as test:
+        cns.kdeplot(data, x="value", hue="group", log_scale=log_scale, ax=ax)
+
+    test.assert_called_once()
+    np.testing.assert_array_equal(test.call_args.args[0], [1.0, 2.0, 3.0])
+    np.testing.assert_array_equal(test.call_args.args[1], [4.0, 5.0, 6.0])
+    assert len(ax.texts) == 1
+
+
+def test_kdeplot_nullable_numeric_values() -> None:
+    data = pd.DataFrame(
+        {
+            "group": pd.Series(["A", "A", "A", "B", "B", None], dtype="string"),
+            "value": pd.Series([1.0, 2.0, pd.NA, 3.0, 4.0, 5.0], dtype="Float64"),
+        }
+    )
+
+    ax = cns.kdeplot(data, x="value", hue="group")
+
+    assert len(ax.lines) == 2
+    assert [text.get_text() for text in ax.texts] == [r"$P=0.33$"]
+
+
+@pytest.mark.parametrize("variable", ["weights", "y"])
+@pytest.mark.filterwarnings(
+    "ignore:The following kwargs were not used by contour.*linewidth:UserWarning"
+)
+def test_kdeplot_omits_unweighted_univariate_test_for_other_densities(
+    variable: str, numeric_df: pd.DataFrame
+) -> None:
+    # Keep vector kwargs aligned with the original rows, including missing x.
+    data = numeric_df.copy()
+    data.loc[0, "x"] = np.nan
+    with patch("cnsplots.plots._distribution.sp.stats.ks_2samp") as test:
+        ax = cns.kdeplot(data, x="x", hue="group", **{variable: data["y"].to_numpy()})
+
+    test.assert_not_called()
+    assert ax.has_data()
+    assert not ax.texts
+
+
+def test_kdeplot_omits_nonfinite_test_result(
+    numeric_df: pd.DataFrame, caplog: pytest.LogCaptureFixture
+) -> None:
+    with patch(
+        "cnsplots.plots._distribution.sp.stats.ks_2samp",
+        return_value=SimpleNamespace(pvalue=np.nan),
+    ):
+        ax = cns.kdeplot(numeric_df, x="x", hue="group")
+
+    assert not ax.texts
+    assert "nonfinite p-value; omitted" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #129.

KDE plots and their KS annotations now use the same finite observations with nonmissing hue labels, restricted to the selected hue levels and positive values on logarithmic x axes. The reported reproduction now displays `P=0.057` instead of `P=NaN`.

Unused categorical levels do not enter the test. A comparison requires exactly two observed groups and two densities drawn by this call, so insufficient or constant samples cannot produce a comparison against an invisible group. Nonfinite test results are omitted with a warning, and calls that draw no density cannot annotate a pre-existing curve. The function docstring records the sample policy.

Validation: `make test` passed all 728 tests with 100% coverage; `make lint` passed. Added 24 regression cases covering the reproduced SciPy result, plotted curve equivalence, missing/nonfinite and nullable values, unused categories, hue subsets, insufficient samples, supplied axes, filled densities, and log scales.

Risks and follow-ups: automatic KS annotations are now omitted for weighted and bivariate KDEs because the existing unweighted, one-dimensional test does not describe those distributions. Their plotting behavior is preserved, including the existing bivariate contour linewidth warning. Broader sample-policy documentation remains tracked by #177.
