### PR TITLE
🐛 Make multipanel newline force rows

### DIFF
--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -172,6 +172,14 @@ def _layout_panels(
 
     root_indices = [idx for idx, panel in enumerate(panels) if panel.below is None]
     for panel_idx in root_indices:
+        if panels[panel_idx].is_spacer:
+            if current_row:
+                rows.append(current_row)
+                row_heights.append(current_row_height)
+                current_row = []
+                current_row_width = 0.0
+                current_row_height = 0.0
+            continue
         subtree_width, subtree_height = get_subtree_size(panel_idx)
         if current_row and current_row_width + subtree_width > max_width:
             rows.append(current_row)
@@ -1091,10 +1099,13 @@ class multipanel:
 
     def newline(self) -> None:
         """
-        Force the next panel to start on a new row.
+        Force the next panel without ``below`` to start on a new row.
 
         This is useful when you want to manually control row breaks
         instead of relying on the automatic wrapping behavior.
+        Empty layouts and repeated calls do not add blank rows. Panels
+        attached with ``below`` stay with their parent, and the new row
+        starts beneath the entire stack.
 
         Examples
         --------
@@ -1103,36 +1114,18 @@ class multipanel:
         >>> mp.newline()  # Force B to start on new row
         >>> mp.panel("B", width=100, height=100)
         """
-        # Add a zero-width panel to force wrapping
-        # We do this by adding a spacer panel that takes up remaining width
-        if self._panels:
-            self._calculate_layout()
-            if self._rows:
-                # Calculate remaining width in current row
-                current_row = self._rows[-1]
-                used_width = 0
-                for idx in current_row:
-                    p = self._panels[idx]
-                    used_width += (
-                        p["margin_left"]
-                        + self._get_left_reserve_px(p)
-                        + p["width"]
-                        + p["margin_right"]
-                    )
-                remaining = self._max_width - used_width
-                if remaining > 0:
-                    # Add invisible spacer
-                    self._panels.append(
-                        _Panel(
-                            label=f"_spacer_{len(self._panels)}",
-                            width=0,
-                            height=0,
-                            pad_left=0,
-                            pad_top=0,
-                            margin_left=0,
-                            margin_top=0,
-                            margin_right=0,
-                            margin_bottom=0,
-                            _is_spacer=True,
-                        )
-                    )
+        if self._panels and not self._panels[-1].get("_is_spacer"):
+            self._panels.append(
+                _Panel(
+                    label=f"_spacer_{len(self._panels)}",
+                    width=0,
+                    height=0,
+                    pad_left=0,
+                    pad_top=0,
+                    margin_left=0,
+                    margin_top=0,
+                    margin_right=0,
+                    margin_bottom=0,
+                    _is_spacer=True,
+                )
+            )

--- a/tests/test_multipanel_defects.py
+++ b/tests/test_multipanel_defects.py
@@ -13,6 +13,84 @@ import cnsplots as cns
 from cnsplots import _multipanels as multipanel_mod
 
 
+@pytest.mark.parametrize("break_count", [1, 3])
+def test_multipanel_newline_starts_a_lower_row(break_count: int) -> None:
+    mp = cns.multipanel(max_width=400)
+    first = mp.panel("A", width=80, height=80)
+    first.set_ylabel("Measured axis decoration")
+    for _ in range(break_count):
+        mp.newline()
+    second = mp.panel("B", width=80, height=80)
+    third = mp.panel("C", width=80, height=80)
+    assert mp.fig is not None
+    mp.fig.canvas.draw()
+
+    a, b, c = (ax.get_position() for ax in (first, second, third))
+    assert b.y1 <= a.y0
+    assert b.y0 == pytest.approx(c.y0)
+    assert b.x1 <= c.x0
+    assert b.width == pytest.approx(a.width)
+    assert b.height == pytest.approx(a.height)
+    assert len(mp._rows) == 2
+
+
+def test_multipanel_newline_on_empty_layout_adds_no_blank_row() -> None:
+    mp = cns.multipanel(max_width=400)
+    mp.newline()
+    mp.newline()
+    ax = mp.panel("A", width=80, height=80)
+    assert mp.fig is not None
+    mp.fig.canvas.draw()
+
+    control = cns.multipanel(max_width=400)
+    expected = control.panel("A", width=80, height=80)
+    assert control.fig is not None
+    control.fig.canvas.draw()
+    assert ax.get_position().bounds == pytest.approx(expected.get_position().bounds)
+    assert mp.fig.get_size_inches() == pytest.approx(control.fig.get_size_inches())
+
+
+def test_multipanel_newline_after_full_row_preserves_automatic_wrapping() -> None:
+    mp = cns.multipanel(max_width=400)
+    first = mp.panel("A", width=80, height=80)
+    assert mp.fig is not None
+    mp.fig.canvas.draw()
+    mp._max_width = mp._get_panel_total_size(mp._panels[0])[0]
+    mp.newline()
+    second = mp.panel("B", width=80, height=80)
+    third = mp.panel("C", width=80, height=80)
+    mp.fig.canvas.draw()
+
+    a, b, c = (ax.get_position() for ax in (first, second, third))
+    assert b.y1 <= a.y0
+    assert c.y1 <= b.y0
+    assert a.height == pytest.approx(b.height)
+    assert b.height == pytest.approx(c.height)
+    assert len(mp._rows) == 3
+
+
+@pytest.mark.parametrize("child_before_break", [True, False])
+def test_multipanel_newline_clears_below_subtrees(child_before_break: bool) -> None:
+    mp = cns.multipanel(max_width=600)
+    first = mp.panel("A", width=80, height=80)
+    if not child_before_break:
+        mp.newline()
+    child = mp.panel("B", width=100, height=60, below="A")
+    mp.newline()
+    second = mp.panel("C", width=80, height=80)
+    grandchild = mp.panel("D", width=120, height=40, below="B")
+    assert mp.fig is not None
+    mp.fig.canvas.draw()
+
+    a, b, c, d = (ax.get_position() for ax in (first, child, second, grandchild))
+    assert b.y1 <= a.y0
+    assert d.y1 <= b.y0
+    assert c.y1 <= d.y0
+    assert c.width == pytest.approx(a.width)
+    assert c.height == pytest.approx(a.height)
+    assert len(mp._rows) == 2
+
+
 @pytest.mark.parametrize("max_width", [0, -1, np.nan, np.inf, -np.inf])
 def test_multipanel_rejects_non_positive_or_non_finite_max_width(
     max_width: float,


### PR DESCRIPTION
Fixes #130.

`multipanel.newline()` now forces the next panel without `below` onto a new row, even when it would fit beside the previous panel. The pure layout calculation treats spacer entries as explicit row breaks instead of zero-width columns.

Empty and repeated calls add no blank rows. Panels attached with `below` stay with their parent, and subsequent rows clear the full stack, including descendants added later. Automatic wrapping and decoration measurement remain in place. The method documentation describes these interactions.

Validation: six new regression cases check rendered geometry and non-overlap for small panels, empty layouts, repeated calls, full rows, automatic wrapping, and `below` relationships. Four cases failed before the fix. `make test` passed all 734 tests with 100% coverage; `make lint` passed.

Risk: figures using `newline()` may become taller as their requested row breaks now take effect. No dependencies or public signatures changed, and no follow-up work is required for this fix.
