### PR TITLE
🐛 Respect categorical statistical annotation orientation

### DIFF
--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -26,6 +26,7 @@ from matplotlib.typing import ColorType
 from palettable.cartocolors.qualitative import get_map as _get_cartocolor_map
 from palettable.colorbrewer.colorbrewer import get_map as _get_colorbrewer_map
 from palettable.tableau.tableau import get_map as _get_tableau_map
+from seaborn._base import categorical_order, infer_orient
 from statannotations.Annotator import Annotator
 from statannotations.PValueFormat import PValueFormat
 from statannotations.utils import DEFAULT
@@ -800,6 +801,11 @@ def _validate_statistical_options(test, p_adjust, *, valid_tests):
         raise ValueError(f"p_adjust must be one of: {choices}, or None")
 
 
+def _resolve_categorical_orientation(data, x, y, orient=None):
+    """Use Seaborn's orientation rules, normalized for statannotations."""
+    return "h" if infer_orient(data[x], data[y], orient) == "y" else "v"
+
+
 def _p_value_helper(
     test,
     data,
@@ -855,17 +861,16 @@ def _p_value_helper(
 
             return super().format_data(result)
 
-    x_is_numeric = pd.api.types.is_numeric_dtype(data[plotting["x"]])
-    if x_is_numeric:
-        plotting["orient"] = "h"
-        primary_col = plotting["y"]
-    else:
-        primary_col = plotting["x"]
-
-    primary_levels = list(pd.unique(data[primary_col].dropna()))
-    order = plotting.get("order")
-    if order is not None:
-        primary_levels = [level for level in order if level in primary_levels]
+    plotting["orient"] = _resolve_categorical_orientation(
+        data, plotting["x"], plotting["y"], plotting.get("orient")
+    )
+    primary_col = plotting["y"] if plotting["orient"] == "h" else plotting["x"]
+    present_levels = data[primary_col].dropna().unique()
+    primary_levels = [
+        level
+        for level in categorical_order(data[primary_col], plotting.get("order"))
+        if level in present_levels
+    ]
 
     if pairs == "all":
         pairs = list(itertools.combinations(primary_levels, 2))
@@ -875,10 +880,7 @@ def _p_value_helper(
             raise ValueError(
                 "`pairs='hue'` requires a hue column in the plotting data."
             )
-        hue_levels = list(pd.unique(data[hue_col].dropna()))
-        hue_order = plotting.get("hue_order")
-        if hue_order is not None:
-            hue_levels = [level for level in hue_order if level in hue_levels]
+        hue_levels = categorical_order(data[hue_col], plotting.get("hue_order"))
         hue_pairs = []
         for category in primary_levels:
             subset = data[data[primary_col] == category]

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -333,12 +333,13 @@ def barplot(
         "err_kws": {"color": "black", "linewidth": 0.7},
         "capsize": 0.2,
     }
+    orient = utils._resolve_categorical_orientation(data, x, y, kwargs.get("orient"))
+    category_column = y if orient == "h" else x
     palette = kwargs.pop("palette", None)
     show_legend = False
     legend_handles = []
     if isinstance(palette, str) and palette in data.columns:
         group_col = palette
-        category_column = x if not pd.api.types.is_numeric_dtype(data[x]) else y
         palette, legend_handles = _resolve_palette_column(
             data,
             category_column,
@@ -356,11 +357,11 @@ def barplot(
     }
     plotting.update(args)
     plotting.update(kwargs)
+    plotting["orient"] = orient
     if ax is None:
         ax = plt.gca()
     seaborn_plotting = plotting
     if palette is not None and hue is None:
-        category_column = y if pd.api.types.is_numeric_dtype(data[x]) else x
         seaborn_plotting = {
             **plotting,
             "hue": category_column,
@@ -389,7 +390,6 @@ def barplot(
     if pairs is not None:
         pvalue_kwargs = {}
         if bar_labels:
-            orient = "h" if pd.api.types.is_numeric_dtype(data[x]) else "v"
             pvalue_kwargs["label_clearance"] = _bar_label_pvalue_clearance(
                 ax,
                 bar_labels,
@@ -666,21 +666,23 @@ def lollipopplot(
             "ax": ax,
             "alpha": 0,
             "edgecolor": "none",
+            "orient": orient,
+            "order": categories,
         }
-        if order is not None:
-            bar_kw["order"] = order
         if hue is not None:
             bar_kw["hue"] = hue
-        if hue_order is not None:
-            bar_kw["hue_order"] = hue_order
+            bar_kw["hue_order"] = hue_levels
         sns.barplot(**bar_kw)
-        plotting: dict[str, Any] = {"data": data, "x": x, "y": y}
-        if order is not None:
-            plotting["order"] = order
+        plotting: dict[str, Any] = {
+            "data": data,
+            "x": x,
+            "y": y,
+            "orient": orient,
+            "order": categories,
+        }
         if hue is not None:
             plotting["hue"] = hue
-        if hue_order is not None:
-            plotting["hue_order"] = hue_order
+            plotting["hue_order"] = hue_levels
         utils._p_value_helper(
             test,
             data,
@@ -1033,6 +1035,8 @@ def stackplot(
             plotting = {"data": data2, "x": "count", "y": bar, "order": order}
         else:
             plotting = {"data": data2, "x": bar, "y": "count", "order": order}
+        plotting["orient"] = "h" if y is not None else "v"
+        plotting["order"] = list(df.index)
         resolved_test = (
             ("fisher-exact" if contingency.shape[1] == 2 else "chi-squared")
             if test == "auto"

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -157,6 +157,9 @@ def boxplot(
     }
     plotting.update(args)
     plotting.update(kwargs)
+    plotting["orient"] = utils._resolve_categorical_orientation(
+        data, x, y, plotting.get("orient")
+    )
     if ax is None:
         ax = plt.gca()
     ax = sns.boxplot(ax=ax, **plotting)
@@ -346,11 +349,14 @@ def violinplot(
         "hue_order": hue_order,
     }
     plotting.update(kwargs)
+    plotting["orient"] = utils._resolve_categorical_orientation(
+        data, x, y, plotting.get("orient")
+    )
     if ax is None:
         ax = plt.gca()
     ax = sns.violinplot(ax=ax, linewidth=0.001, width=width, **plotting)
     plotting.update(args)
-    plotting.update(kwargs)
+    plotting.update({k: v for k, v in kwargs.items() if k != "orient"})
     # Remove violin-only arguments that boxplot doesn't support
     boxplot_kwargs = {k: v for k, v in plotting.items() if k not in ("split", "inner")}
     if add_box:

--- a/tests/test_annotation_orientation.py
+++ b/tests/test_annotation_orientation.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from itertools import combinations
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+@pytest.fixture
+def annotations(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    instances = []
+    original = cns.utils.Annotator
+
+    def capture(*args: Any, **kwargs: Any) -> Any:
+        annotator = original(*args, **kwargs)
+        instances.append(annotator)
+        return annotator
+
+    monkeypatch.setattr(cns.utils, "Annotator", capture)
+    return instances
+
+
+@pytest.mark.parametrize("plot_name", ["boxplot", "violinplot", "barplot"])
+@pytest.mark.parametrize("numeric", [False, True])
+@pytest.mark.parametrize("orient", [None, "v", "h", "x", "y"])
+@pytest.mark.parametrize("selector", ["explicit", "all", "hue"])
+def test_annotations_match_category_axis(
+    plot_name: str,
+    numeric: bool,
+    orient: str | None,
+    selector: str,
+    annotations: list[Any],
+) -> None:
+    levels = [2, 0, 1] if numeric else ["C", "A", "B"]
+    data = pd.DataFrame(
+        {
+            "group": np.repeat(levels, 6),
+            "value": np.arange(18, dtype=float) + 0.5,
+            "hue": [1, 1, 1, 0, 0, 0] * 3,
+        }
+    )
+    horizontal = orient in {"h", "y"}
+    order = levels[::-1]
+    pairs = [(order[0], order[1])] if selector == "explicit" else selector
+    kwargs: dict[str, Any] = {"order": order, "orient": orient}
+    if selector == "hue":
+        kwargs.update(hue="hue", hue_order=[0, 1])
+    if plot_name == "barplot":
+        kwargs.update(add_tip=True, errorbar=None)
+
+    ax = getattr(cns, plot_name)(
+        data,
+        x="value" if horizontal else "group",
+        y="group" if horizontal else "value",
+        pairs=pairs,
+        **kwargs,
+    )
+
+    annotator = annotations[0]
+    assert annotator.orient == ("h" if horizontal else "v")
+    ticks = ax.get_yticklabels() if horizontal else ax.get_xticklabels()
+    assert [tick.get_text() for tick in ticks] == [str(level) for level in order]
+    expected_groups = (
+        [(level, hue) for level in order for hue in [0, 1]]
+        if selector == "hue"
+        else [(level,) for level in order]
+    )
+    assert [item["group"] for item in annotator._plotter.structs] == expected_groups
+    for item in annotator._plotter.structs:
+        group = item["group"]
+        selected = data[data["group"] == group[0]]
+        if selector == "hue":
+            selected = selected[selected["hue"] == group[1]]
+        np.testing.assert_array_equal(item["group_data"], selected["value"])
+    expected_pairs = (
+        [((level, 0), (level, 1)) for level in order]
+        if selector == "hue"
+        else list(combinations(order, 2))
+        if selector == "all"
+        else pairs
+    )
+    assert annotator.pairs == expected_pairs
+    assert len(ax.texts) >= len(expected_pairs)
+
+
+@pytest.mark.parametrize(
+    ("plot_name", "categorical"),
+    [
+        (name, categorical)
+        for name in ["boxplot", "violinplot", "barplot"]
+        for categorical in [False, True]
+    ]
+    + [("lollipopplot", False)],
+)
+def test_default_annotation_order_matches_drawn_order(
+    plot_name: str, categorical: bool, annotations: list[Any]
+) -> None:
+    data = pd.DataFrame(
+        {"group": [2, 2, 0, 0, 1, 1], "value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
+    )
+    if categorical:
+        data["group"] = pd.Categorical(
+            data["group"], categories=[1, 2, 0], ordered=True
+        )
+    expected = (
+        [2, 0, 1]
+        if plot_name == "lollipopplot"
+        else [1, 2, 0]
+        if categorical
+        else [0, 1, 2]
+    )
+
+    ax = getattr(cns, plot_name)(data, x="group", y="value", pairs="all")
+
+    assert [tick.get_text() for tick in ax.get_xticklabels()] == list(
+        map(str, expected)
+    )
+    assert annotations[0].pairs == list(combinations(expected, 2))
+    assert [str(item["group"][0]) for item in annotations[0]._plotter.structs] == list(
+        map(str, expected)
+    )
+    for item, level in zip(annotations[0]._plotter.structs, expected):
+        np.testing.assert_array_equal(
+            item["group_data"], data.loc[data["group"] == level, "value"]
+        )
+    if plot_name == "lollipopplot":
+        offsets = ax.collections[1].get_offsets()
+        np.testing.assert_allclose(offsets[:, 0], range(3))
+        means = data.groupby("group", observed=True)["value"].mean().reindex(expected)
+        np.testing.assert_allclose(offsets[:, 1], means)
+
+
+@pytest.mark.parametrize("horizontal", [False, True])
+@pytest.mark.parametrize("numeric", [False, True])
+@pytest.mark.parametrize("selector", ["explicit", "all"])
+@pytest.mark.parametrize("ordered", [False, True])
+def test_stackplot_annotation_orientation(
+    horizontal: bool,
+    numeric: bool,
+    selector: str,
+    ordered: bool,
+    annotations: list[Any],
+) -> None:
+    levels = [0, 1] if numeric else ["A", "B"]
+    data = pd.DataFrame(
+        {"group": np.repeat(levels, [4, 6]), "outcome": ["yes", "no"] * 5}
+    )
+    expected_order = levels[::-1] if ordered else levels
+    pairs = [tuple(expected_order)] if selector == "explicit" else "all"
+
+    kwargs: dict[str, Any] = {
+        "y" if horizontal else "x": "group",
+        "order": expected_order if ordered else None,
+        "pairs": pairs,
+    }
+    ax = cns.stackplot(data, stack="outcome", **kwargs)
+
+    assert annotations[0].orient == ("h" if horizontal else "v")
+    assert annotations[0].pairs == [tuple(expected_order)]
+    assert [item["group"] for item in annotations[0]._plotter.structs] == [
+        (level,) for level in expected_order
+    ]
+    ticks = ax.get_yticklabels() if horizontal else ax.get_xticklabels()
+    assert [tick.get_text() for tick in ticks] == list(map(str, expected_order))
+
+
+@pytest.mark.parametrize(
+    "plot_name", ["boxplot", "violinplot", "barplot", "lollipopplot"]
+)
+@pytest.mark.parametrize("horizontal", [False, True])
+def test_inferred_orientation_with_hue(
+    plot_name: str, horizontal: bool, annotations: list[Any]
+) -> None:
+    levels = ["B", "A"] if horizontal else [1, 0]
+    data = pd.DataFrame(
+        {
+            "group": np.repeat(levels, 6),
+            "value": np.arange(12, dtype=float),
+            "hue": [1, 1, 1, 0, 0, 0] * 2,
+        }
+    )
+    ax = getattr(cns, plot_name)(
+        data,
+        x="value" if horizontal else "group",
+        y="group" if horizontal else "value",
+        hue="hue",
+        pairs="hue",
+    )
+    expected_order = (
+        levels if horizontal or plot_name == "lollipopplot" else levels[::-1]
+    )
+    hue_order = [1, 0] if plot_name == "lollipopplot" else [0, 1]
+    assert annotations[0].orient == ("h" if horizontal else "v")
+    assert annotations[0].pairs == [
+        ((level, hue_order[0]), (level, hue_order[1])) for level in expected_order
+    ]
+    ticks = ax.get_yticklabels() if horizontal else ax.get_xticklabels()
+    assert [tick.get_text() for tick in ticks] == list(map(str, expected_order))
+    for item in annotations[0]._plotter.structs:
+        level, hue = item["group"]
+        selected = data.loc[(data["group"] == level) & (data["hue"] == hue), "value"]
+        np.testing.assert_array_equal(item["group_data"], selected)

--- a/tests/test_plot_behavior_regressions.py
+++ b/tests/test_plot_behavior_regressions.py
@@ -393,6 +393,7 @@ def test_stackplot_y_axis_preserves_bar_and_stack_semantics(
         "x": "count",
         "y": "patient",
         "order": ["P2", "P1"],
+        "orient": "h",
     }
     assert calls[0][4] == [("P2", "P1")]
     contingency = calls[0][5]


### PR DESCRIPTION
Fix statistical annotations rejecting numeric category codes by keeping comparison selection consistent with the plot's orientation. For example, `boxplot(data, x="g", y="v", pairs=[(0, 1)])` now compares categories 0 and 1 on the vertical categorical axis.

- Resolve Seaborn orientation once for box, violin, and bar plots, including explicit `v`/`h` and `x`/`y` aliases, and pass it to the annotation helper.
- Pass the drawn orientation and category/hue order from lollipop and stacked-bar plots; use Seaborn's level ordering for automatic comparisons.
- Add regression coverage for numeric/string labels, both orientations, explicit pairs, `all`/`hue` selectors, and the actual group data and order used by annotations.

Validation: `make test` (855 passed, 100% coverage) and `make lint` passed.

Risks and follow-ups: orientation and level ordering use Seaborn's internal helpers, so compatibility should be checked on Seaborn upgrades. Count-label behavior (#132) and public comparison type hints (#168) remain separate. Testing also exposed an existing pandas deprecation warning for lollipop plots with pandas Categorical data; this change does not alter that groupby behavior.

Closes #131.
