### PR TITLE
🐛 Correct categorical axis sample counts

### DIFF
--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -786,6 +786,8 @@ def _add_count_helper(data, attr, ax, axis="x"):
     new_tick_labels = []
     for label in tick_labels:
         label_text = label.get_text()
+        if label_text not in counts:
+            label_text = re.sub(r"\n\(n=\d+\)$", "", label_text)
         n = int(counts.get(label_text, 0))
         new_tick_labels.append(f"{label_text}\n(n={n})")
     set_ticks(tick_positions)
@@ -804,6 +806,30 @@ def _validate_statistical_options(test, p_adjust, *, valid_tests):
 def _resolve_categorical_orientation(data, x, y, orient=None):
     """Use Seaborn's orientation rules, normalized for statannotations."""
     return "h" if infer_orient(data[x], data[y], orient) == "y" else "v"
+
+
+def _prepare_categorical_plot_data(plotting):
+    """Share complete displayed rows across rendering, summaries, and counts."""
+    data = plotting["data"]
+    x, y, hue = plotting["x"], plotting["y"], plotting.get("hue")
+    plotting["orient"] = _resolve_categorical_orientation(
+        data, x, y, plotting.get("orient")
+    )
+    category = y if plotting["orient"] == "h" else x
+    # Resolve levels before cleaning so empty categories keep their tick positions.
+    plotting["order"] = categorical_order(data[category], plotting.get("order"))
+    columns = [x, y] if hue is None else [x, y, hue]
+    cleaned = data.dropna(subset=columns)
+    cleaned = cleaned.loc[cleaned[category].isin(plotting["order"])]
+    if hue is not None:
+        plotting["hue_order"] = categorical_order(data[hue], plotting.get("hue_order"))
+        cleaned = cleaned.loc[cleaned[hue].isin(plotting["hue_order"])]
+    if cleaned.empty:
+        raise ValueError(
+            "No complete observations remain in the selected category and hue levels."
+        )
+    plotting["data"] = cleaned
+    return cleaned
 
 
 def _p_value_helper(

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -1091,7 +1091,10 @@ def stripplot(
     showmeans : bool, default: False
         Whether to overlay a marker at the mean for each category.
     add_count : bool, default: False
-        Whether to add sample size (n) labels above each category.
+        Append sample sizes to the categorical axis tick labels. Counts include
+        rows with non-missing x, y, and hue (when used), restricted to ``order``
+        and ``hue_order``. Hue levels are pooled within each category. The same
+        complete rows are used for points and summary markers.
     hue : str, optional
         Column name for grouping points within each category.
     order : list of str, optional
@@ -1141,24 +1144,25 @@ def stripplot(
             "use 'add_count' instead"
         )
 
+    plotting: dict[str, Any] = {
+        "data": data,
+        "x": x,
+        "y": y,
+        "hue": hue,
+        "order": order,
+        "hue_order": hue_order,
+    }
+    plotting.update(kwargs)
+    data = utils._prepare_categorical_plot_data(plotting)
     if ax is None:
         ax = plt.gca()
-    ax = sns.stripplot(
-        data=data,
-        x=x,
-        y=y,
-        hue=hue,
-        order=order,
-        hue_order=hue_order,
-        size=size,
-        ax=ax,
-        **kwargs,
-    )
+    ax = sns.stripplot(size=size, ax=ax, **plotting)
     sns.boxplot(
         data=data,
         x=x,
         y=y,
-        order=order,
+        order=plotting["order"],
+        orient=plotting["orient"],
         medianprops={"visible": showmedian, "color": "black", "lw": 1},
         meanprops={
             "markerfacecolor": "white",
@@ -1176,7 +1180,8 @@ def stripplot(
         showmeans=showmeans,
     )
     if add_count:
-        utils._add_count_helper(data, x, ax)
+        axis = "y" if plotting["orient"] == "h" else "x"
+        utils._add_count_helper(data, plotting[axis], ax, axis=axis)
 
     _resize_legend_markers(ax.get_legend(), size**2, marker_size=size * 2)
 

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -66,7 +66,10 @@ def boxplot(
     showoutliers : bool, default: False
         Whether to display outlier points beyond the whiskers.
     add_count : bool, default: False
-        Whether to add sample size (n) labels above each box.
+        Append sample sizes to the categorical axis tick labels. Counts include
+        rows with non-missing x, y, and hue (when used), restricted to ``order``
+        and ``hue_order``. Hue levels are pooled within each category. The same
+        complete rows are used for rendering; hidden outliers still count.
     whis : float or tuple of float, default: 1.5
         The proportion of the IQR past the low and high quartiles to extend the
         plot whiskers.
@@ -157,9 +160,7 @@ def boxplot(
     }
     plotting.update(args)
     plotting.update(kwargs)
-    plotting["orient"] = utils._resolve_categorical_orientation(
-        data, x, y, plotting.get("orient")
-    )
+    data = utils._prepare_categorical_plot_data(plotting)
     if ax is None:
         ax = plt.gca()
     ax = sns.boxplot(ax=ax, **plotting)
@@ -212,7 +213,8 @@ def boxplot(
         )
 
     if add_count:
-        utils._add_count_helper(data, x, ax)
+        axis = "y" if plotting["orient"] == "h" else "x"
+        utils._add_count_helper(data, plotting[axis], ax, axis=axis)
 
     return ax
 
@@ -257,7 +259,10 @@ def violinplot(
     add_box : bool, default: True
         Whether to overlay a narrow box plot inside each violin.
     add_count : bool, default: False
-        Whether to add sample size (n) labels above each violin.
+        Append sample sizes to the categorical axis tick labels. Counts include
+        rows with non-missing x, y, and hue (when used), restricted to ``order``
+        and ``hue_order``. Hue levels are pooled within each category. The same
+        complete rows are used for rendering.
     box_color : matplotlib color or None, default: "white"
         Color of the embedded box plots. Set to ``None`` to color boxes according
         to *hue*.
@@ -349,9 +354,7 @@ def violinplot(
         "hue_order": hue_order,
     }
     plotting.update(kwargs)
-    plotting["orient"] = utils._resolve_categorical_orientation(
-        data, x, y, plotting.get("orient")
-    )
+    data = utils._prepare_categorical_plot_data(plotting)
     if ax is None:
         ax = plt.gca()
     ax = sns.violinplot(ax=ax, linewidth=0.001, width=width, **plotting)
@@ -372,7 +375,8 @@ def violinplot(
         )
 
     if add_count:
-        utils._add_count_helper(data, x, ax)
+        axis = "y" if plotting["orient"] == "h" else "x"
+        utils._add_count_helper(data, plotting[axis], ax, axis=axis)
 
     return ax
 

--- a/tests/test_categorical_counts.py
+++ b/tests/test_categorical_counts.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize("plot_name", ["boxplot", "violinplot", "stripplot"])
+@pytest.mark.parametrize("horizontal", [False, True])
+@pytest.mark.parametrize("numeric", [False, True])
+def test_counts_use_category_axis_and_complete_values(
+    plot_name: str, horizontal: bool, numeric: bool
+) -> None:
+    levels = [0, 1] if numeric else ["A", "B"]
+    data = pd.DataFrame(
+        {
+            "group": np.repeat(levels, 4),
+            "value": [1.0, 1.2, 1.4, np.nan, 2.0, 2.2, 2.4, 2.6],
+        }
+    )
+    kwargs: dict[str, Any] = {"orient": "h"} if horizontal and numeric else {}
+    ax = getattr(cns, plot_name)(
+        data,
+        x="value" if horizontal else "group",
+        y="group" if horizontal else "value",
+        add_count=True,
+        **kwargs,
+    )
+
+    category_ticks = ax.get_yticklabels() if horizontal else ax.get_xticklabels()
+    value_ticks = ax.get_xticklabels() if horizontal else ax.get_yticklabels()
+    assert [tick.get_text() for tick in category_ticks] == [
+        f"{levels[0]}\n(n=3)",
+        f"{levels[1]}\n(n=4)",
+    ]
+    assert all("(n=" not in tick.get_text() for tick in value_ticks)
+
+
+@pytest.mark.parametrize("plot_name", ["boxplot", "violinplot", "stripplot"])
+@pytest.mark.parametrize("horizontal", [False, True])
+@pytest.mark.parametrize("subset_hue", [False, True])
+def test_counts_pool_displayed_hues_and_share_rendered_rows(
+    plot_name: str,
+    horizontal: bool,
+    subset_hue: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A"] * 6 + ["B"] * 6 + ["C", None, "empty"],
+            "value": [
+                1,
+                1.2,
+                1.4,
+                np.nan,
+                1.8,
+                9,
+                2,
+                2.2,
+                2.4,
+                2.6,
+                2.8,
+                9,
+                3,
+                4,
+                np.nan,
+            ],
+            "hue": ["H1", "H1", "H2", "H1", None, "H3"]
+            + ["H1", "H2", "H2", "H1", None, "H3", "H1", "H1", "H1"],
+            "unrelated": np.nan,
+        }
+    )
+    original = data.copy(deep=True)
+    rendered = []
+
+    def capture(name: str) -> None:
+        plot = getattr(sns, name)
+
+        def draw(*args: Any, **kwargs: Any) -> Any:
+            rendered.append(kwargs.copy())
+            return plot(*args, **kwargs)
+
+        monkeypatch.setattr(sns, name, draw)
+
+    for name in {plot_name, "boxplot"}:
+        capture(name)
+    ax = getattr(cns, plot_name)(
+        data,
+        x="value" if horizontal else "group",
+        y="group" if horizontal else "value",
+        hue="hue",
+        order=["B", "A", "empty"],
+        hue_order=["H2", "H1"] if subset_hue else None,
+        add_count=True,
+    )
+
+    ticks = ax.get_yticklabels() if horizontal else ax.get_xticklabels()
+    assert [tick.get_text() for tick in ticks] == [
+        f"B\n(n={4 if subset_hue else 5})",
+        f"A\n(n={3 if subset_hue else 4})",
+        "empty\n(n=0)",
+    ]
+    indices = [0, 1, 2, 6, 7, 8, 9] if subset_hue else [0, 1, 2, 5, 6, 7, 8, 9, 11]
+    for call in rendered:
+        pd.testing.assert_frame_equal(call["data"], data.loc[indices])
+        assert call["orient"] == ("h" if horizontal else "v")
+        assert call["order"] == ["B", "A", "empty"]
+    pd.testing.assert_frame_equal(data, original)
+    if plot_name == "stripplot":
+        values = np.concatenate(
+            [
+                collection.get_offsets()[:, 0 if horizontal else 1]
+                for collection in ax.collections
+            ]
+        )
+        np.testing.assert_allclose(np.sort(values), np.sort(data.loc[indices, "value"]))
+
+
+@pytest.mark.parametrize("plot_name", ["boxplot", "violinplot", "stripplot"])
+@pytest.mark.parametrize("horizontal", [False, True])
+def test_repeated_plot_calls_replace_counts(plot_name: str, horizontal: bool) -> None:
+    data = pd.DataFrame({"group": ["A"] * 4, "value": [1, 2, 3, 4]})
+    kwargs = {
+        "x": "value" if horizontal else "group",
+        "y": "group" if horizontal else "value",
+    }
+    plot = getattr(cns, plot_name)
+    ax = plot(data, add_count=True, **kwargs)
+    plot(data.iloc[:3], ax=ax, add_count=True, **kwargs)
+    ticks = ax.get_yticklabels() if horizontal else ax.get_xticklabels()
+    assert [tick.get_text() for tick in ticks] == ["A\n(n=3)"]
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_repeated_count_helper_updates_suffix(axis: str) -> None:
+    import matplotlib.pyplot as plt
+
+    _, ax = plt.subplots()
+    set_ticks = ax.set_xticks if axis == "x" else ax.set_yticks
+    set_ticks([0, 1, 2], ["A", "empty", "label\n(n=5)"])
+    data = pd.DataFrame({"group": ["A", "A", "label\n(n=5)"]})
+    cns.utils._add_count_helper(data, "group", ax, axis=axis)
+    cns.utils._add_count_helper(data.iloc[1:], "group", ax, axis=axis)
+    ticks = ax.get_xticklabels() if axis == "x" else ax.get_yticklabels()
+    assert [tick.get_text() for tick in ticks] == [
+        "A\n(n=1)",
+        "empty\n(n=0)",
+        "label\n(n=5)\n(n=1)",
+    ]
+
+
+@pytest.mark.parametrize("horizontal", [False, True])
+def test_stackplot_counts_keep_raw_totals(horizontal: bool) -> None:
+    data = pd.DataFrame(
+        {"group": ["A", "A", "A", "B", "B"], "stack": ["yes", "no", None, "yes", "no"]}
+    )
+    ax = cns.stackplot(
+        data,
+        x=None if horizontal else "group",
+        y="group" if horizontal else None,
+        stack="stack",
+        add_count=True,
+    )
+    ticks = ax.get_yticklabels() if horizontal else ax.get_xticklabels()
+    assert [tick.get_text() for tick in ticks] == ["A\n(n=3)", "B\n(n=2)"]
+
+
+@pytest.mark.parametrize("plot_name", ["boxplot", "violinplot", "stripplot"])
+def test_empty_category_keeps_default_position(plot_name: str) -> None:
+    data = pd.DataFrame({"group": ["empty", "A", "A"], "value": [np.nan, 1, 2]})
+    ax = getattr(cns, plot_name)(data, x="group", y="value", add_count=True)
+    assert [tick.get_text() for tick in ax.get_xticklabels()] == [
+        "empty\n(n=0)",
+        "A\n(n=2)",
+    ]
+
+
+@pytest.mark.parametrize("plot_name", ["boxplot", "violinplot", "stripplot"])
+def test_order_selecting_no_complete_rows_raises(plot_name: str) -> None:
+    data = pd.DataFrame({"group": ["empty", "A", "A"], "value": [np.nan, 1, 2]})
+    with pytest.raises(ValueError, match="No complete observations remain"):
+        getattr(cns, plot_name)(
+            data, x="group", y="value", order=["empty"], add_count=True
+        )


### PR DESCRIPTION
Fixes #132.

Box, violin, and strip plots now place sample counts on the resolved categorical axis and count complete observations used by the plot. The issue's example reports A `n=3` and B `n=4`, including when horizontal.

- Share rows with non-missing category, value, and hue between rendering, summary overlays, statistical annotations, and counts; restrict them to the selected category and hue levels.
- Document that counts pool displayed hue levels within each category, and keep hidden boxplot outliers in the sample size.
- Replace existing count suffixes on repeated calls, preserve empty category positions, and retain stackplot's raw-total count semantics.

Validation: `make test` (895 passed, 100% coverage) and `make lint` passed. The new regression tests cover both orientations, numeric categories, missing values and hue, order subsets, shared rendering rows, repeated labels, and stackplot totals. The initial 12 reproduction cases failed before the fix.

Behavior change: stripplot summary markers now exclude rows with missing or excluded hue levels, matching the displayed points. Selecting no complete observations raises a clear `ValueError`. No dependency or public signature changes; no follow-up required.
