### PR TITLE
🐛 Isolate violin overlay keyword arguments

### DIFF
--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -229,6 +229,7 @@ def violinplot(
     add_count: bool = False,
     *,
     box_color: ColorType | None = "white",
+    box_kws: dict[str, Any] | None = None,
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
@@ -266,6 +267,12 @@ def violinplot(
     box_color : matplotlib color or None, default: "white"
         Color of the embedded box plots. Set to ``None`` to color boxes according
         to *hue*.
+    box_kws : dict, optional
+        Keyword arguments passed only to the `seaborn.boxplot` overlay, such as
+        ``whis``, ``width``, ``boxprops``, and ``medianprops``. Property dictionaries
+        are merged with the overlay defaults; an explicit ``boxprops.facecolor``
+        overrides ``box_color``. Shared data, category, and hue settings come from
+        the main arguments. Ignored when ``add_box=False``.
     hue : str, optional
         Column name for grouping violins within each category.
     order : list of str, optional
@@ -279,7 +286,12 @@ def violinplot(
     ax : matplotlib.axes.Axes, optional
         Axes on which to draw the plot. Defaults to the current Axes.
     **kwargs
-        Additional keyword arguments passed to `seaborn.violinplot`.
+        Additional keyword arguments passed to `seaborn.violinplot`, including
+        density options such as ``bw_adjust``, ``cut``, and ``density_norm`` and
+        violin styling such as ``linewidth`` and ``inner_kws``. The overlay also
+        receives shared ``orient``, ``color``, ``palette``, ``saturation``,
+        ``hue_norm``, ``dodge``, ``gap``, ``log_scale``, ``native_scale``,
+        ``formatter``, and ``legend`` settings. Use ``box_kws`` for box styling.
 
     Returns
     -------
@@ -302,6 +314,8 @@ def violinplot(
     ...     pairs=[("control", "treated")],
     ...     p_adjust="fdr_bh",
     ...     add_box=True,
+    ...     bw_adjust=0.5,
+    ...     box_kws={"whis": (0, 100), "medianprops": {"linewidth": 1}},
     ... )
     >>> ax.set_title("Expression by Condition")
     """
@@ -345,6 +359,11 @@ def violinplot(
         },
         "width": 0.2,
     }
+    for key, value in (box_kws or {}).items():
+        if key in args and isinstance(args[key], dict):
+            args[key] = {**args[key], **value}
+        else:
+            args[key] = value
     plotting: dict[str, Any] = {
         "data": data,
         "x": x,
@@ -353,23 +372,41 @@ def violinplot(
         "order": order,
         "hue_order": hue_order,
     }
-    plotting.update(kwargs)
+    # Share only category geometry and color semantics, never layer-specific options.
+    for key in (
+        "orient",
+        "color",
+        "palette",
+        "saturation",
+        "hue_norm",
+        "dodge",
+        "gap",
+        "log_scale",
+        "native_scale",
+        "formatter",
+        "legend",
+    ):
+        if key in kwargs:
+            plotting[key] = kwargs.pop(key)
     data = utils._prepare_categorical_plot_data(plotting)
     if ax is None:
         ax = plt.gca()
-    ax = sns.violinplot(ax=ax, linewidth=0.001, width=width, **plotting)
-    plotting.update(args)
-    plotting.update({k: v for k, v in kwargs.items() if k != "orient"})
-    # Remove violin-only arguments that boxplot doesn't support
-    boxplot_kwargs = {k: v for k, v in plotting.items() if k not in ("split", "inner")}
+    violin_kwargs = {"linewidth": 0.001, "width": width, **kwargs, **plotting}
+    ax = sns.violinplot(ax=ax, **violin_kwargs)
     if add_box:
-        sns.boxplot(ax=ax, **boxplot_kwargs)
+        sns.boxplot(ax=ax, **{**args, **plotting})
     if pairs is not None:
+        annotation_kwargs = {
+            key: value
+            for key, value in plotting.items()
+            if key in ("data", "x", "y", "hue", "order", "hue_order", "orient", "dodge")
+        }
+        annotation_kwargs["width"] = args["width"] if add_box else width
         utils._p_value_helper(
             test,
             data,
             ax,
-            plotting,
+            annotation_kwargs,
             pairs,
             p_adjust=p_adjust,
         )

--- a/tests/test_violin_layers.py
+++ b/tests/test_violin_layers.py
@@ -1,0 +1,152 @@
+"""Regression tests for violin and box overlay keyword routing."""
+
+from copy import deepcopy
+from typing import Any
+from unittest.mock import patch
+
+import matplotlib.pyplot as plt
+from matplotlib.colors import to_rgba
+from matplotlib.patches import PathPatch
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize("add_box", [False, True])
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"bw_adjust": 0.5},
+        {"cut": 0},
+        {"gridsize": 32},
+        {"bw_method": "silverman"},
+        {"density_norm": "count", "common_norm": True},
+        {"density_norm": "width"},
+        {"inner": "quart", "inner_kws": {"linewidth": 2}},
+        {"linewidth": 2, "linecolor": "red", "alpha": 0.4},
+        {"fill": False},
+    ],
+)
+def test_violin_options_only_reach_violin_layer(
+    categorical_df: pd.DataFrame, add_box: bool, options: dict[str, Any]
+) -> None:
+    with (
+        patch("seaborn.violinplot", wraps=sns.violinplot) as violin,
+        patch("seaborn.boxplot", wraps=sns.boxplot) as box,
+    ):
+        ax = cns.violinplot(
+            categorical_df, x="group", y="value", add_box=add_box, **options
+        )
+
+    assert ax.collections
+    for key, value in options.items():
+        assert violin.call_args.kwargs[key] == value
+    boxes = [artist for artist in ax.patches if isinstance(artist, PathPatch)]
+    assert len(boxes) == (3 if add_box else 0)
+    if add_box:
+        assert box.call_args.kwargs["linewidth"] == 0.4
+        assert not (options.keys() - {"linewidth"}) & box.call_args.kwargs.keys()
+        assert all(artist.get_facecolor() == to_rgba("white") for artist in boxes)
+    else:
+        box.assert_not_called()
+
+
+@pytest.mark.parametrize("add_box", [False, True])
+@pytest.mark.parametrize("facecolor", [None, "green"])
+def test_box_options_are_isolated_and_do_not_mutate_input(
+    categorical_df: pd.DataFrame, add_box: bool, facecolor: str | None
+) -> None:
+    box_kws: dict[str, Any] = {
+        "width": 0.1,
+        "whis": (0, 100),
+        "boxprops": {"edgecolor": "red"},
+        "medianprops": {"color": "blue", "linewidth": 2},
+    }
+    if facecolor is not None:
+        box_kws["boxprops"]["facecolor"] = facecolor
+    original = deepcopy(box_kws)
+    _, (ax, reference) = plt.subplots(1, 2)
+    cns.violinplot(
+        categorical_df,
+        x="group",
+        y="value",
+        inner=None,
+        box_color="yellow",
+        box_kws=box_kws,
+        add_box=add_box,
+        ax=ax,
+    )
+    cns.violinplot(
+        categorical_df, x="group", y="value", inner=None, add_box=False, ax=reference
+    )
+
+    for actual, expected in zip(ax.collections, reference.collections, strict=True):
+        np.testing.assert_array_equal(
+            actual.get_paths()[0].vertices, expected.get_paths()[0].vertices
+        )
+    boxes = [artist for artist in ax.patches if isinstance(artist, PathPatch)]
+    assert len(boxes) == (3 if add_box else 0)
+    for artist in boxes:
+        assert artist.get_facecolor() == to_rgba(facecolor or "yellow")
+        assert artist.get_edgecolor() == to_rgba("red")
+        assert np.ptp(artist.get_path().vertices[:, 0]) == pytest.approx(0.1)
+    assert box_kws == original
+
+
+@pytest.mark.parametrize("add_box", [False, True])
+@pytest.mark.parametrize("horizontal", [False, True])
+def test_split_violin_comparisons_share_category_semantics(
+    categorical_df: pd.DataFrame, add_box: bool, horizontal: bool
+) -> None:
+    palette = {"H1": "red", "H2": "blue"}
+    comparison_options: dict[str, Any] = {"pairs": "hue", "p_adjust": "holm"}
+    with (
+        patch("seaborn.violinplot", wraps=sns.violinplot) as violin,
+        patch("seaborn.boxplot", wraps=sns.boxplot) as box,
+        patch.object(cns.utils, "Annotator", wraps=cns.utils.Annotator) as annotate,
+    ):
+        ax = cns.violinplot(
+            categorical_df,
+            x="value" if horizontal else "group",
+            y="group" if horizontal else "value",
+            orient="y" if horizontal else "x",
+            hue="hue",
+            order=["B", "A"],
+            hue_order=["H2", "H1"],
+            palette=palette,
+            saturation=1,
+            box_color=None,
+            dodge=True,
+            split=True,
+            inner=None,
+            bw_adjust=0.5,
+            cut=0,
+            add_box=add_box,
+            **comparison_options,
+            box_kws={"whis": (0, 100)},
+        )
+
+    assert len(ax.texts) == 2
+    expected_data = categorical_df[categorical_df["group"].isin(["A", "B"])]
+    calls = [violin.call_args.kwargs, annotate.call_args.kwargs]
+    if add_box:
+        calls.append(box.call_args.kwargs)
+        boxes = [artist for artist in ax.patches if isinstance(artist, PathPatch)]
+        assert [artist.get_facecolor() for artist in boxes] == [
+            to_rgba("blue"),
+            to_rgba("blue"),
+            to_rgba("red"),
+            to_rgba("red"),
+        ]
+    for call in calls:
+        pd.testing.assert_frame_equal(call["data"], expected_data)
+        assert call["orient"] == ("h" if horizontal else "v")
+        assert call["order"] == ["B", "A"]
+        assert call["hue_order"] == ["H2", "H1"]
+        assert call["dodge"] is True
+    assert not {"bw_adjust", "cut", "split", "inner", "whis", "boxprops"} & (
+        annotate.call_args.kwargs.keys()
+    )


### PR DESCRIPTION
Fix the crash when violin density options such as `bw_adjust=0.5` reach the default box overlay. Violin density and style keywords now stay on the violin layer; both layers retain shared data, orientation, ordering, and hue settings.

- Add documented `box_kws` for overlay customization, merging property dictionaries with the defaults and preserving `box_color` behavior.
- Keep layer-specific keywords out of statistical comparisons.
- Add 26 regression cases covering density/style options, disabled overlays, box properties, split/hue plots, and horizontal and vertical comparisons.

Validation: reproduced the original `Axes.bxp` error before the fix; `make test` passes with 921 tests and 100% coverage; `make lint` passes.

Compatibility: violin style options affect only the violin layer. Use `box_kws` to customize the overlay; an explicit `boxprops.facecolor` overrides `box_color`. No dependency or configuration changes.

Closes #133.
