### PR TITLE
🐛 Preserve distinct SVG label weights

### DIFF
--- a/src/cnsplots/_svg.py
+++ b/src/cnsplots/_svg.py
@@ -14,35 +14,8 @@ import subprocess
 
 import matplotlib.pyplot as plt
 from lxml import etree  # ty: ignore[unresolved-import]
-from matplotlib.text import Text
 
 _PDF_SUBSET_FONT_PREFIX = re.compile(r"^[A-Z]{6}\+")
-
-
-def _collect_bold_texts() -> set[str]:
-    """Collect text strings that are bold in the current matplotlib figure."""
-    bold_texts: set[str] = set()
-    fig = plt.gcf()
-    text_artists = list(fig.texts)
-    for ax in fig.get_axes():
-        for artist in ax.get_children():
-            if isinstance(artist, Text):
-                text_artists.append(artist)
-
-    for artist in text_artists:
-        txt = artist.get_text().strip()
-        if not txt:
-            continue
-        weight = artist.get_fontweight()
-        if weight in ("bold", "heavy", "extra bold", "semibold", "demibold") or (
-            isinstance(weight, (int, float)) and weight >= 600
-        ):
-            bold_texts.add(txt)
-            for line in txt.split("\n"):
-                line = line.strip()
-                if line:
-                    bold_texts.add(line)
-    return bold_texts
 
 
 def _save_plain_svg(filepath: str, message: str, bbox_inches=None) -> None:
@@ -58,7 +31,6 @@ def _save_plain_svg(filepath: str, message: str, bbox_inches=None) -> None:
 
 
 def _save_svg(filepath: str, root: str, bbox_inches=None) -> None:
-    bold_texts = _collect_bold_texts()
     stem = Path(root).name or Path(filepath).stem or "cnsplots"
     savefig_kwargs: dict[str, object] = {}
     if bbox_inches is not None:
@@ -96,7 +68,7 @@ def _save_svg(filepath: str, root: str, bbox_inches=None) -> None:
                 check=True,
                 capture_output=True,
             )
-            _correct_svg(str(tmp_svg), filepath, bold_texts)
+            _correct_svg(str(tmp_svg), filepath)
         except FileNotFoundError:
             _save_plain_svg(
                 filepath,
@@ -114,16 +86,13 @@ def _save_svg(filepath: str, root: str, bbox_inches=None) -> None:
             )
 
 
-def _correct_svg(
-    input_file: str, output_file: str, bold_texts: set[str] | None = None
-) -> None:
+def _correct_svg(input_file: str, output_file: str) -> None:
     """
     Process an SVG file to ungroup both text elements and clipped elements.
 
     Args:
         input_file (str): Path to the input SVG file
         output_file (str): Path to save the processed SVG file
-        bold_texts (set[str] | None): Text strings that should have font-weight bold
     """
     # Read the SVG file
     with open(input_file) as f:
@@ -144,10 +113,7 @@ def _correct_svg(
     # Process text elements
     _process_text_elements_lxml(root, ns)
 
-    # Restore bold font-weight lost during PDF→SVG conversion
-    _restore_bold_fonts(root, ns, bold_texts or set())
-
-    # Normalize PDF subset font names for better SVG editor compatibility
+    # Preserve each element's style, including styles encoded in PDF font names.
     _normalize_text_fonts(root, ns)
 
     # Flatten any remaining g elements
@@ -192,23 +158,6 @@ def _process_text_elements_lxml(root: _Element, ns: dict[str, str]) -> None:
 
         # Remove the original text element
         parent.remove(text)
-
-
-def _restore_bold_fonts(
-    root: _Element, ns: dict[str, str], bold_texts: set[str]
-) -> None:
-    """Restore font-weight="bold" on text elements whose content was bold in matplotlib.
-
-    Mutool drops bold information during PDF→SVG conversion, so we match text
-    content against the set collected from matplotlib before saving.
-    """
-    if not bold_texts:
-        return
-
-    for text_el in root.xpath(".//svg:text", namespaces=ns):
-        content = (text_el.text or "").strip()
-        if content in bold_texts:
-            text_el.set("font-weight", "bold")
 
 
 def _normalize_pdf_font_family(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -755,15 +755,6 @@ def test_svg_helpers_and_export(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     output_dir.mkdir(parents=True)
-    mp = cns.multipanel(max_width=220, title="Figure Bold")
-    ax = mp.panel("A", width=80, height=60)
-    ax.set_title("Panel Bold")
-    ax.text(0.5, 0.3, "Plain")
-    bold_texts = _svg._collect_bold_texts()
-    assert "Figure Bold" in bold_texts
-    assert "Panel Bold" in bold_texts
-    assert "A" in bold_texts
-
     svg_in = output_dir / "input.svg"
     svg_out = output_dir / "output.svg"
     svg_in.write_text(
@@ -777,7 +768,7 @@ def test_svg_helpers_and_export(
 </svg>""",
         encoding="utf-8",
     )
-    _svg._correct_svg(str(svg_in), str(svg_out), {"Panel Bold", "Figure Bold"})
+    _svg._correct_svg(str(svg_in), str(svg_out))
     root = etree.parse(str(svg_out)).getroot()
     ns = {"svg": "http://www.w3.org/2000/svg"}
     text_els = root.xpath(".//svg:text", namespaces=ns)
@@ -919,11 +910,8 @@ def test_svg_helpers_and_export(
         )
         return types.SimpleNamespace(returncode=0)
 
-    def fake_correct(
-        input_file: str, output_file: str, bold_texts: set[str] | None = None
-    ) -> None:
+    def fake_correct(input_file: str, output_file: str) -> None:
         corrected["input_file"] = input_file
-        corrected["bold_texts"] = bold_texts
         Path(output_file).write_text(
             "<svg xmlns='http://www.w3.org/2000/svg' />", encoding="utf-8"
         )
@@ -933,7 +921,6 @@ def test_svg_helpers_and_export(
     _svg._save_svg(str(success_path), str(output_dir / "optimized"))
     assert success_path.exists()
     assert str(corrected["input_file"]).endswith("1.svg")
-    assert isinstance(corrected["bold_texts"], set)
 
     cns.figure(120, 120)
     plt.plot([0, 1], [0, 1])

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -416,9 +416,6 @@ def test_svg_internal_coverage() -> None:
             return [FakeGroup()]
 
     _svg._flatten_groups(FakeGroupRoot(), {"svg": "http://www.w3.org/2000/svg"})
-    _svg._restore_bold_fonts(
-        types.SimpleNamespace(), {"svg": "http://www.w3.org/2000/svg"}, set()
-    )
 
 
 def test_utils_internal_coverage(

--- a/tests/test_svg_font_weights.py
+++ b/tests/test_svg_font_weights.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pytest
+from lxml import etree  # ty: ignore[unresolved-import]
+
+import cnsplots as cns
+from cnsplots import _svg
+
+
+@pytest.mark.parametrize("converter", ["mutool", "missing", "failed"])
+def test_svg_export_preserves_repeated_label_styles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, converter: str
+) -> None:
+    if converter == "mutool" and shutil.which("mutool") is None:
+        pytest.skip("MuPDF's mutool is required for the conversion regression")
+
+    def unavailable_mutool(*args: object, **kwargs: object) -> None:
+        if converter == "missing":
+            raise FileNotFoundError("mutool")
+        raise subprocess.CalledProcessError(1, ["mutool"], stderr=b"conversion failed")
+
+    if converter != "mutool":
+        monkeypatch.setattr(_svg.subprocess, "run", unavailable_mutool)
+
+    styles = [
+        ("normal", "normal"),
+        ("bold", "normal"),
+        ("normal", "italic"),
+        ("bold", "italic"),
+    ]
+    with plt.rc_context(
+        {"font.family": "DejaVu Sans", "pdf.fonttype": 42, "svg.fonttype": "none"}
+    ):
+        fig, axes = plt.subplots(2, 2, figsize=(8, 6))
+        for ax, (weight, style) in zip(axes.flat, styles):
+            properties = {"weight": weight, "style": style}
+            position = ax.get_position()
+            fig.text(position.x0, position.y0, "Panel", fontdict=properties)
+            ax.set_title("Title", **properties)
+            ax.set_xlabel("Axis", **properties)
+            ax.set_ylabel("Axis", **properties)
+            ax.set_xticks([0.5], ["Tick"], **properties)
+            ax.set_yticks([])
+            ax.text(0.2, 0.3, "SAME\nLINE", **properties)
+            ax.plot([0, 1], [0, 1], label="Legend")
+            ax.legend(prop=properties)
+
+        path = tmp_path / "weights.svg"
+        if converter == "mutool":
+            cns.savefig(path)
+        else:
+            with pytest.warns(RuntimeWarning, match="mutool"):
+                cns.savefig(path)
+
+    root = etree.parse(str(path))
+    ns = {"svg": "http://www.w3.org/2000/svg"}
+    texts = root.xpath("//svg:text", namespaces=ns)
+    for label in ("Panel", "Title", "Axis", "Tick", "Legend", "SAME", "LINE"):
+        actual = []
+        for text in texts:
+            if "".join(text.itertext()) != label:
+                continue
+            attributes = dict(text.attrib)
+            for declaration in text.get("style", "").split(";"):
+                if ":" in declaration:
+                    name, value = declaration.split(":", 1)
+                    attributes[name.strip()] = value.strip()
+            weight = attributes.get("font-weight", "normal")
+            actual.append(
+                (
+                    "bold" if weight in ("bold", "700") else weight,
+                    attributes.get("font-style", "normal"),
+                )
+            )
+        assert Counter(actual) == Counter(styles * (2 if label == "Axis" else 1)), label
+
+
+def test_svg_normalizes_each_repeated_labels_pdf_font(tmp_path: Path) -> None:
+    source = tmp_path / "source.svg"
+    destination = tmp_path / "normalized.svg"
+    source.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg">'
+        '<text font-family="ABCDEF+Helvetica"><tspan>SAME</tspan></text>'
+        '<text font-family="ABCDEF+Helvetica-Bold"><tspan>SAME</tspan></text>'
+        '<text font-family="ABCDEF+Helvetica-Oblique"><tspan>SAME</tspan></text>'
+        '<text font-family="ABCDEF+Helvetica-BoldOblique"><tspan>SAME</tspan></text>'
+        "</svg>",
+        encoding="utf-8",
+    )
+
+    _svg._correct_svg(str(source), str(destination))
+
+    texts = etree.parse(str(destination)).xpath(
+        "//svg:text", namespaces={"svg": "http://www.w3.org/2000/svg"}
+    )
+    assert [text.text for text in texts] == ["SAME"] * 4
+    assert [text.get("font-family") for text in texts] == ["Helvetica"] * 4
+    assert [
+        (text.get("font-weight", "normal"), text.get("font-style", "normal"))
+        for text in texts
+    ] == [
+        ("normal", "normal"),
+        ("bold", "normal"),
+        ("normal", "italic"),
+        ("bold", "italic"),
+    ]


### PR DESCRIPTION
Fixes #135.

Repeated text in SVG exports now retains its individual normal, bold, italic, or bold-italic style. Previously, any bold occurrence caused other elements with the same text to become bold.

Remove the global text-content matching and preserve the font attributes supplied by MuPDF, while keeping existing PDF subset-font normalization. Add final-SVG regressions for repeated panel, title, axis, tick, legend, and multiline labels through real mutool conversion and both standard fallback cases.

Validation: `make test` (925 passed, 100% coverage) and `make lint`. The new conversion regression failed before the fix and passed afterward, using MuPDF 1.28.0.

Limitations: the real conversion test skips when mutool is unavailable; fallback and subset-font normalization tests still run.
