### PR TITLE
🐛 Restore Matplotlib style after contexts

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -43,8 +43,20 @@ with cns.settings.context(
     figure_width=200,
     figure_height=120,
 ):
-    ...
+    cns.figure()
+    # Create plots using the temporary settings.
 ```
+
+The context restores both the overridden settings and Matplotlib's previous
+`rcParams` when it exits, including for nested contexts and exceptions. Later
+Matplotlib or seaborn figures use the style from before the context; artists
+created inside it retain their assigned properties.
+
+Entering the context updates the settings object. Call `cns.figure()` or
+`cns.setup_matplotlib()` inside it to apply those settings to Matplotlib. This
+also works with `cns.settings.context()` without overrides when you want to
+temporarily apply explicit `setup_matplotlib()` arguments. Restoration follows
+`matplotlib.rc_context`: backend changes and font/colormap registrations persist.
 
 ## Methods
 

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -819,22 +819,31 @@ class CNSSettings:
 
         Notes
         -----
-        Previous values are restored after the context exits, even if an
-        exception is raised inside the block.
+        The overridden settings and Matplotlib rcParams are restored on exit,
+        including when contexts are nested or an exception is raised. Call
+        ``cns.figure()`` or ``cns.setup_matplotlib()`` inside the block to apply
+        the temporary settings to Matplotlib. Existing artists retain their
+        assigned properties after the context exits.
+
+        Matplotlib state is scoped with ``matplotlib.rc_context``: backend
+        changes and font/colormap registrations are not undone.
         """
+        import matplotlib as mpl
+
         for key in kwargs:
             if key not in self._defaults:
                 raise AttributeError(self._invalid_setting_message(key))
 
         old_values = {key: deepcopy(getattr(self, key)) for key in kwargs}
 
-        try:
-            for key, value in kwargs.items():
-                setattr(self, key, value)
-            yield self
-        finally:
-            for key, value in old_values.items():
-                setattr(self, key, value)
+        with mpl.rc_context():
+            try:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+                yield self
+            finally:
+                for key, value in old_values.items():
+                    setattr(self, key, value)
 
     def __repr__(self) -> str:
         """Return a string representation of current settings."""

--- a/tests/test_settings_context.py
+++ b/tests/test_settings_context.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import nullcontext
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import pytest
+from matplotlib.rcsetup import cycler
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize("configure", [cns.setup_matplotlib, cns.figure])
+@pytest.mark.parametrize("custom_style", [False, True])
+def test_context_restores_style_and_preserves_artists(
+    configure: Callable[[], None], custom_style: bool
+) -> None:
+    with mpl.rc_context():
+        mpl.rcdefaults()
+        if custom_style:
+            mpl.rcParams.update(
+                {
+                    "axes.labelsize": 17,
+                    "font.family": ["monospace"],
+                    "axes.prop_cycle": cycler(color=["red", "blue"]),
+                    "image.cmap": "plasma",
+                }
+            )
+        before = mpl.rcParams.copy()
+        _, before_ax = plt.subplots()
+        overrides = {
+            "title_fontsize": 23,
+            "font_family": "serif",
+            "font_sans_serif": ["DejaVu Sans"],
+            "palette_qual": "Set2",
+            "palette_seq": "parula",
+        }
+        previous_settings = {key: getattr(cns.settings, key) for key in overrides}
+
+        with cns.settings.context(**overrides) as settings:
+            assert settings is cns.settings
+            configure()
+            ax = plt.gcf().add_subplot()
+            label = ax.set_xlabel("Temporary style")
+            (line,) = ax.plot([0, 1], [0, 1])
+            color = mpl.rcParams["axes.prop_cycle"].by_key()["color"][0]
+            assert color == cns.palettes("Set2")[0]
+            assert label.get_fontsize() == 23
+            assert label.get_fontfamily() == ["serif"]
+            assert mpl.rcParams["font.sans-serif"] == ["DejaVu Sans"]
+            assert mpl.rcParams["image.cmap"] == "parula"
+
+        assert mpl.rcParams == before
+        assert {
+            key: getattr(cns.settings, key) for key in overrides
+        } == previous_settings
+        _, after_ax = plt.subplots()
+        assert (
+            after_ax.xaxis.label.get_fontsize() == before_ax.xaxis.label.get_fontsize()
+        )
+        assert after_ax.xaxis.label.get_fontfamily() == before["font.family"]
+        (after_line,) = after_ax.plot([0, 1], [0, 1])
+        assert after_line.get_color() == before["axes.prop_cycle"].by_key()["color"][0]
+        assert label.get_fontsize() == 23
+        assert label.get_fontfamily() == ["serif"]
+        assert line.get_color() == color
+
+
+@pytest.mark.parametrize("raise_error", [False, True])
+def test_nested_contexts_restore_each_style(raise_error: bool) -> None:
+    with mpl.rc_context():
+        before = mpl.rcParams.copy()
+        previous_fontsize = cns.settings.title_fontsize
+        previous_palette = cns.settings.palette_qual
+        with cns.settings.context(title_fontsize=19, palette_qual="Dark2"):
+            cns.figure()
+            outer = mpl.rcParams.copy()
+            with (
+                pytest.raises(RuntimeError, match="inner")
+                if raise_error
+                else nullcontext()
+            ):
+                with cns.settings.context(title_fontsize=29, palette_qual="Set2"):
+                    cns.setup_matplotlib()
+                    assert mpl.rcParams["axes.labelsize"] == 29
+                    assert mpl.rcParams["axes.prop_cycle"] != outer["axes.prop_cycle"]
+                    if raise_error:
+                        raise RuntimeError("inner")
+            assert mpl.rcParams == outer
+            assert cns.settings.title_fontsize == 19
+            assert cns.settings.palette_qual == "Dark2"
+        assert mpl.rcParams == before
+        assert cns.settings.title_fontsize == previous_fontsize
+        assert cns.settings.palette_qual == previous_palette
+
+
+def test_context_restores_style_when_exception_escapes() -> None:
+    with mpl.rc_context():
+        before = mpl.rcParams.copy()
+        previous_fontsize = cns.settings.title_fontsize
+        with pytest.raises(RuntimeError, match="plot failed"):
+            with cns.settings.context(title_fontsize=23):
+                cns.figure()
+                raise RuntimeError("plot failed")
+        assert mpl.rcParams == before
+        assert cns.settings.title_fontsize == previous_fontsize
+
+
+def test_context_without_overrides_restores_explicit_setup_style() -> None:
+    with mpl.rc_context():
+        before = mpl.rcParams.copy()
+        with cns.settings.context():
+            cns.setup_matplotlib(
+                title_fontsize=31, color_cycle=["red", "blue"], color_map="plasma"
+            )
+            assert mpl.rcParams["axes.labelsize"] == 31
+            assert mpl.rcParams["axes.prop_cycle"].by_key()["color"] == cns.palettes(
+                ["red", "blue"]
+            )
+            assert mpl.rcParams["image.cmap"] == "plasma"
+        assert mpl.rcParams == before


### PR DESCRIPTION
Fixes #136.

Calls to `figure()` or `setup_matplotlib()` inside `settings.context()` left temporary styles active for later Matplotlib and seaborn figures. Wrap the settings overrides in Matplotlib's `rc_context()` so exiting restores the previous style, including through nested contexts and exceptions, while existing artists retain their assigned properties. Import Matplotlib only when entering the context to preserve lazy settings access.

Document the restoration contract and add eight regression cases covering default and customized styles, palettes, fonts, existing artists, nested contexts, exceptions, and explicit setup arguments without settings overrides.

Validation: `make test` (933 passed, 100% coverage) and `make lint` passed. All eight regression cases failed against the original implementation.

Scope and risks: restoration follows `matplotlib.rc_context()`; backend changes and font/colormap registrations persist. No dependencies or export override behavior changed, and no follow-up work is required for this fix.
