### PR TITLE
🐛 Fix pie and donut ordering

### DIFF
--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -1188,6 +1188,28 @@ def stripplot(
     return ax
 
 
+def _circular_plot_counts(
+    data: pd.DataFrame,
+    x: str,
+    order: list[str] | None,
+    function_name: str,
+) -> pd.Series:
+    """Resolve category counts consistently for pie and donut charts."""
+    counts = data[x].value_counts()
+    if order is not None:
+        if pd.Index(order).has_duplicates:
+            raise ValueError(
+                f"[{function_name}] 'order' contains duplicate categories."
+            )
+        counts = counts.reindex(index=order, fill_value=0)
+    if counts.sum() == 0:
+        raise ValueError(
+            f"[{function_name}] No non-missing observations remain in '{x}' "
+            "for the selected categories."
+        )
+    return counts
+
+
 def pieplot(
     data: pd.DataFrame,
     x: str,
@@ -1204,11 +1226,15 @@ def pieplot(
     data : pd.DataFrame
         The input DataFrame containing the data to be plotted.
     x : str
-        Column name for the categorical variable to visualize.
+        Column name for the categorical variable to visualize. Missing values
+        are excluded from the counts.
     legend : {'right', 'left', 'top', 'bottom'}, default: 'bottom'
         Position of the legend relative to the pie chart.
     order : list, optional
-        Order of categories to display in the pie chart.
+        Categories to display, in order. Defaults to decreasing frequency.
+        Subsets are supported; proportions are normalized over the selected
+        counts. Absent categories are retained with zero counts and legend
+        entries. Duplicate categories are not allowed.
     ax : matplotlib.axes.Axes, optional
         Axes on which to draw the plot. Defaults to the current Axes.
 
@@ -1216,6 +1242,12 @@ def pieplot(
     -------
     matplotlib.axes.Axes
         The matplotlib Axes object containing the plot.
+
+    Raises
+    ------
+    ValueError
+        If ``order`` contains duplicates or no observations remain, including
+        an empty ``order``, only absent categories, or all-missing values in ``x``.
 
     See Also
     --------
@@ -1237,12 +1269,10 @@ def pieplot(
     validate_column_exists(data, x, "x", "pieplot")
     validate_dataframe_not_empty(data, "pieplot")
 
-    df = data[x].value_counts()
-    if order is None:
-        order = df.index
+    df = _circular_plot_counts(data, x, order, "pieplot")
     if ax is None:
         ax = plt.gca()
-    ax = df.reindex(index=order).plot.pie(
+    ax = df.plot.pie(
         shadow=False,
         autopct="%1.0f%%",
         explode=[0] * df.shape[0],
@@ -1263,7 +1293,7 @@ def pieplot(
         "bottom": {"loc": "upper center", "bbox_to_anchor": (0.5, -0.05)},
     }
     pos = legend_positions.get(legend, legend_positions["right"])
-    ax.legend(**pos, title=x)
+    ax.legend(handles=ax.patches[-len(df) :], labels=df.index.tolist(), **pos, title=x)
     return ax
 
 
@@ -1283,11 +1313,15 @@ def donutplot(
     data : pd.DataFrame
         The input DataFrame containing the data to be plotted.
     x : str
-        Column name for the categorical variable to visualize.
+        Column name for the categorical variable to visualize. Missing values
+        are excluded from the counts.
     legend : {'right', 'left', 'top', 'bottom'}, default: 'bottom'
         Position of the legend relative to the pie chart.
     order : list, optional
-        Order of categories to display in the donut chart.
+        Categories to display, in order. Defaults to decreasing frequency.
+        Subsets are supported; proportions are normalized over the selected
+        counts. Absent categories are retained with zero counts and legend
+        entries. Duplicate categories are not allowed.
     ax : matplotlib.axes.Axes, optional
         Axes on which to draw the plot. Defaults to the current Axes.
 
@@ -1295,6 +1329,12 @@ def donutplot(
     -------
     matplotlib.axes.Axes
         The matplotlib Axes object containing the plot.
+
+    Raises
+    ------
+    ValueError
+        If ``order`` contains duplicates or no observations remain, including
+        an empty ``order``, only absent categories, or all-missing values in ``x``.
 
     See Also
     --------
@@ -1316,12 +1356,10 @@ def donutplot(
     validate_column_exists(data, x, "x", "donutplot")
     validate_dataframe_not_empty(data, "donutplot")
 
-    df = data[x].value_counts()
-    if order is None:
-        order = df.index
+    df = _circular_plot_counts(data, x, order, "donutplot")
     if ax is None:
         ax = plt.gca()
-    ax = df.reindex(index=order).plot.pie(
+    ax = df.plot.pie(
         labeldistance=None,
         ax=ax,
         ylabel="",
@@ -1337,5 +1375,5 @@ def donutplot(
         "bottom": {"loc": "upper center", "bbox_to_anchor": (0.5, -0.05)},
     }
     pos = legend_positions.get(legend, legend_positions["right"])
-    ax.legend(**pos, title=x)
+    ax.legend(handles=ax.patches[-len(df) :], labels=df.index.tolist(), **pos, title=x)
     return ax

--- a/tests/test_circular_plot_order.py
+++ b/tests/test_circular_plot_order.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.colors import to_rgba
+from matplotlib.patches import Wedge
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize("plot_name", ["pieplot", "donutplot"])
+@pytest.mark.parametrize("categorical", [False, True])
+@pytest.mark.parametrize(
+    ("order", "labels", "counts"),
+    [
+        (None, ["C", "A", "B"], [3, 2, 1]),
+        (["B", "C", "A"], ["B", "C", "A"], [1, 3, 2]),
+        (["A"], ["A"], [2]),
+        (["B", "A"], ["B", "A"], [1, 2]),
+        (["A", "B", "C", "D"], ["A", "B", "C", "D"], [2, 1, 3, 0]),
+        (["D", "B", "A"], ["D", "B", "A"], [0, 1, 2]),
+        (["B", "D", "A"], ["B", "D", "A"], [1, 0, 2]),
+    ],
+)
+def test_circular_plot_slice_alignment(
+    plot_name: str,
+    categorical: bool,
+    order: list[str] | None,
+    labels: list[str],
+    counts: list[int],
+) -> None:
+    data = pd.DataFrame({"group": ["A", "A", "B", "C", "C", "C", None]})
+    if categorical:
+        data["group"] = pd.Categorical(data["group"], categories=["A", "B", "C"])
+    original = data.copy(deep=True)
+    colors = ["#111111", "#eeeeee", "#222222", "#dddddd"]
+    _, ax = plt.subplots()
+    with plt.rc_context({"axes.prop_cycle": plt.cycler(color=colors)}):
+        result = getattr(cns, plot_name)(data, x="group", order=order, ax=ax)
+
+    assert result is ax
+    wedges = [patch for patch in ax.patches if isinstance(patch, Wedge)]
+    proportions = np.asarray(counts) / sum(counts)
+    assert len(wedges) == len(counts)
+    np.testing.assert_allclose(
+        [wedge.theta2 - wedge.theta1 for wedge in wedges],
+        proportions * 360,
+        atol=1e-5,
+    )
+    np.testing.assert_allclose(
+        [wedge.get_facecolor() for wedge in wedges],
+        [to_rgba(color) for color in colors[: len(counts)]],
+    )
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.get_texts()] == labels
+    np.testing.assert_allclose(
+        [handle.get_facecolor() for handle in legend.legend_handles],
+        [wedge.get_facecolor() for wedge in wedges],
+    )
+    if plot_name == "pieplot":
+        percentages = [text for text in ax.texts if text.get_text().endswith("%")]
+        assert [text.get_text() for text in percentages] == [
+            f"{value * 100:.0f}%" for value in proportions
+        ]
+        assert [text.get_color() for text in percentages] == [
+            "white",
+            "black",
+            "white",
+            "black",
+        ][: len(counts)]
+    else:
+        assert [wedge.width for wedge in wedges] == pytest.approx([0.4] * len(counts))
+        assert [text.get_text() for text in ax.texts] == ["group"]
+    pd.testing.assert_frame_equal(data, original)
+
+
+@pytest.mark.parametrize("plot_name", ["pieplot", "donutplot"])
+def test_circular_plot_retains_unused_categorical_levels(plot_name: str) -> None:
+    data = pd.DataFrame(
+        {"group": pd.Categorical(["A", "A", "B"], categories=["A", "B", "C"])}
+    )
+    ax = getattr(cns, plot_name)(data, x="group")
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.get_texts()] == ["A", "B", "C"]
+    wedges = [patch for patch in ax.patches if isinstance(patch, Wedge)]
+    np.testing.assert_allclose(
+        [wedge.theta2 - wedge.theta1 for wedge in wedges], [240, 120, 0]
+    )
+
+
+@pytest.mark.parametrize("plot_name", ["pieplot", "donutplot"])
+@pytest.mark.parametrize("order", [["A", "A"], ["D", "D", "A"]])
+def test_circular_plot_rejects_duplicate_order(
+    plot_name: str, order: list[str]
+) -> None:
+    data = pd.DataFrame({"group": ["A", "A", "B"]})
+    _, ax = plt.subplots()
+    with pytest.raises(ValueError, match=rf"\[{plot_name}\].*order.*duplicate"):
+        getattr(cns, plot_name)(data, x="group", order=order, ax=ax)
+    assert not ax.patches
+    assert ax.get_legend() is None
+
+
+@pytest.mark.parametrize("plot_name", ["pieplot", "donutplot"])
+@pytest.mark.parametrize(
+    ("values", "order"),
+    [
+        (["A", "A", "B"], []),
+        (["A", "A", "B"], ["D"]),
+        (["A", "A", "B"], ["D", "E"]),
+        ([None, None], None),
+        ([None, None], ["A"]),
+        (pd.Categorical([None, None], categories=["A", "B"]), None),
+        (pd.Categorical(["A", "A"], categories=["A", "B"]), ["B"]),
+    ],
+)
+def test_circular_plot_requires_remaining_counts(
+    plot_name: str, values: list[str | None] | pd.Categorical, order: list[str] | None
+) -> None:
+    data = pd.DataFrame({"group": values})
+    _, ax = plt.subplots()
+    with pytest.raises(
+        ValueError, match=rf"\[{plot_name}\].*No non-missing observations.*group"
+    ):
+        getattr(cns, plot_name)(data, x="group", order=order, ax=ax)
+    assert not ax.patches
+    assert ax.get_legend() is None


### PR DESCRIPTION
Fixes #137.

`pieplot(..., order=["A"])` now renders a subset without the `explode` length error. Pie and donut plots share count preparation: full reorders and subsets are supported, absent categories retain zero-count slices and matching legend entries, and duplicate orders or selections with no observations raise contextual `ValueError`s before drawing.

Both docstrings describe the ordering rules and normalization over selected counts. Regression tests cover slice angles, percentages, contrast text, legend labels and colors, categorical dtypes, unused levels, missing values, and input preservation.

Validation:

- `make test`: 981 passed, 100% coverage
- `make lint`: all checks passed
- 48 focused regression cases passed
- Pixel-identical before/after renders for default and fully reordered pie and donut charts

Compatibility: duplicate categories now raise an intentional error, and zero-count categories retain legend entries. Ordinary chart rendering is unchanged in the checked cases. No dependencies or configuration changed; no follow-up work is required.
