### PR TITLE
💥 Add explicit figure export controls

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -209,8 +209,8 @@ def test_boxplot_basic():
     """Test basic boxplot creation."""
     df = pd.DataFrame({"x": ["A", "B"], "y": [1, 2]})
     fig = cns.figure(150, 150)
-    cns.boxplot(data=df, x="x", y="y")
-    assert fig is not None
+    ax = cns.boxplot(data=df, x="x", y="y")
+    assert ax.figure is fig
 
 
 def test_boxplot_invalid_data():

--- a/README.md
+++ b/README.md
@@ -155,13 +155,13 @@ import cnsplots as cns
 df = cns.datasets.load_dataset("tips")
 
 # Create a figure (width, height in pixels)
-cns.figure(width=100, height=150)
+fig = cns.figure(width=100, height=150)
 
 # Create a publication-ready boxplot
 cns.boxplot(data=df, x="day", y="total_bill")
 
 # Save as vector graphic
-cns.savefig("figure.svg")
+cns.savefig("figure.svg", fig=fig)
 ```
 
 ### Statistical Comparisons
@@ -216,6 +216,9 @@ Specify sizes in **pixels** for precise control:
 ```python
 cns.figure(width=100, height=150)  # Final canvas size is 100px × 150px
 ```
+
+`cns.figure(...)` returns the Matplotlib `Figure` and makes it current for
+subsequent plotting calls. Retain it to export a specific figure with `fig=`.
 
 ### Color Palettes
 
@@ -281,11 +284,19 @@ cns.stackplot(
 cns.savefig("figure.svg")
 
 # High-resolution PNG
-cns.savefig("figure.png")
+cns.savefig("figure.png", dpi=300, transparent=False)
 
 # PDF with editable text
 cns.savefig("figure.pdf")
+
+# Keep the full figure canvas instead of cropping to its contents
+cns.savefig("figure-full.pdf", bbox_inches=None)
 ```
+
+`savefig` uses the current figure unless `fig=` is supplied. Omitted export
+options use `cns.settings`; per-call `dpi`, `transparent`, `bbox_inches`, and
+`pad_inches` overrides leave those settings unchanged. Use
+`bbox_inches="tight", pad_inches=0.1` for a tight crop with padding in inches.
 
 For Illustrator-optimized SVG post-processing, install MuPDF's `mutool`.
 Without it, `cns.savefig("figure.svg")` falls back to a standard matplotlib SVG

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,13 +12,13 @@ import matplotlib.pyplot as plt
 df = cns.datasets.load_dataset("tips")
 
 # Create a figure with specific dimensions (width x height in pixels)
-cns.figure(100, 150)
+fig = cns.figure(100, 150)
 
 # Create a boxplot
 cns.boxplot(data=df, x="day", y="total_bill")
 
 # Save the figure
-cns.savefig("my_figure.svg")
+cns.savefig("my_figure.svg", fig=fig)
 ```
 
 In these examples, `data` is a pandas DataFrame, and `x`, `y`, and `hue`
@@ -38,6 +38,22 @@ cns.figure(150, 200)
 
 `cns.figure(width, height)` uses the conventional width-first order, and those
 values are the final canvas size in pixels.
+
+`cns.figure(...)` returns the created `matplotlib.figure.Figure` and makes it
+the current figure, so subsequent cnsplots calls still draw on it. Keep this
+handle to save it later, even after creating another figure:
+
+```python
+fig = cns.figure(150, 100)
+cns.boxplot(data=df, x="day", y="total_bill")
+cns.figure(150, 100)
+cns.barplot(data=df, x="day", y="tip")
+cns.savefig("boxplot.svg", fig=fig)
+```
+
+Previously, `cns.figure(...)` returned `None`. Calls that ignore the return value
+continue to work, but code that checks for `None` or uses the result as a boolean
+must be updated for the returned `Figure`.
 
 ## Basic Plot Types
 
@@ -91,7 +107,7 @@ cns.barplot(data=df, x="day", y="total_bill", ax=axes[1])
 axes[1].set_title("Bar Plot")
 
 plt.tight_layout()
-cns.savefig("subplots.svg")
+cns.savefig("subplots.svg", fig=fig)
 ```
 
 All plotting functions accept `ax` as a keyword-only argument, so they can be
@@ -112,8 +128,33 @@ cns.savefig("figure.svg")
 cns.savefig("figure.pdf")
 
 # PNG for presentations or raster workflows
-cns.savefig("figure.png")
+cns.savefig("figure.png", dpi=300, transparent=False)
 ```
+
+By default, `cns.savefig(...)` saves the current figure. Pass `fig=fig` to save
+a retained `Figure` without changing which figure is current. Export options
+are keyword-only and apply to that save without changing `cns.settings`:
+
+```python
+# Tight crop with 0.1 inches of padding around the plotted contents
+cns.savefig("figure-tight.pdf", bbox_inches="tight", pad_inches=0.1)
+
+# Preserve the full figure canvas without cropping
+cns.savefig("figure-full.png", bbox_inches=None)
+
+# Export a specific rectangle in inches: left, bottom, width, height
+from matplotlib.transforms import Bbox
+
+cns.savefig("figure-region.pdf", bbox_inches=Bbox.from_bounds(0, 0, 1, 1))
+```
+
+Omitting `dpi`, `transparent`, `bbox_inches`, or `pad_inches` uses the matching
+export default in {doc}`settings`. Passing `None` for `dpi`, `transparent`, or
+`pad_inches` also uses the setting; explicit `bbox_inches=None` instead disables
+cropping. Padding applies only to `bbox_inches="tight"` and is ignored for
+`None` or a `Bbox`. Raster output dimensions depend on the figure's size in
+inches, export DPI, and any crop or padding; export DPI does not resize the
+figure itself.
 
 If MuPDF's `mutool` is available, `cnsplots` uses an enhanced SVG export path
 for Illustrator workflows. Otherwise it saves a standard matplotlib SVG and

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -87,6 +87,13 @@ verbosity used by later helper and plotting calls.
 These settings control the default save behavior and font embedding choices for
 exported figures.
 
+Override export defaults for one call with `cns.savefig(..., dpi=300,
+transparent=False, bbox_inches="tight", pad_inches=0.1)`. These arguments leave
+`cns.settings` unchanged. Omitted options use the corresponding settings, as do
+`None` values for `dpi`, `transparent`, and `pad_inches`. Explicit
+`bbox_inches=None` saves the full figure canvas without cropping. Padding is in
+inches and applies only to tight cropping.
+
 ```{eval-rst}
 .. autoattribute:: cnsplots._settings.CNSSettings.savefig_bbox
 .. autoattribute:: cnsplots._settings.CNSSettings.savefig_pad_inches

--- a/examples/figure_setup.py
+++ b/examples/figure_setup.py
@@ -25,8 +25,9 @@ iris = cns.datasets.load_dataset("iris")
 # ~~~~~~~~~~~~~~~~~~~~~
 # Create a figure with specified dimensions in pixels.
 # figure(width, height) uses the conventional width-first order, and those
-# requested dimensions are the final canvas size.
-cns.figure(150, 150)
+# requested dimensions are the final canvas size. The returned Matplotlib
+# Figure is also the current figure used by subsequent plotting calls.
+fig = cns.figure(150, 150)
 ax = cns.placeholderplot("150x150 Figure")
 ax.set_title("Figure Setup")
 
@@ -211,16 +212,21 @@ ax.set_title("Custom Font Sizes")
 # Saving figures
 # ~~~~~~~~~~~~~~
 # Use ``savefig()`` to save figures in various formats.
-# Supported formats: PDF, PNG, SVG, EPS, JPG
-cns.figure(100, 150)
+# Supported formats: PDF, PNG, SVG, EPS, JPG. Keep the returned figure so it
+# can be saved even when another figure becomes current.
+fig = cns.figure(100, 150)
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 ax.set_title("Save Example")
 
 # Example save commands (commented to avoid creating files):
-# cns.savefig("figure.pdf")   # PDF for publications
-# cns.savefig("figure.svg")   # SVG for editing in Illustrator
-# cns.savefig("figure.png")   # PNG for presentations
+# cns.savefig("figure.pdf", fig=fig)   # PDF for publications
+# cns.savefig("figure.svg", fig=fig)   # SVG for editing in Illustrator
+# cns.savefig("figure.png", fig=fig, dpi=300, transparent=False)
+# cns.savefig("figure-tight.pdf", fig=fig, bbox_inches="tight", pad_inches=0.1)
+# cns.savefig("figure-full.pdf", fig=fig, bbox_inches=None)  # Full canvas
 # cns.savefig("~/Desktop/figure.pdf")  # Supports ~ expansion
+# Omitted options use cns.settings. Per-save overrides leave settings unchanged.
+# Padding is in inches and applies only to tight cropping.
 
 
 # %%

--- a/src/cnsplots/_agent_skill/cnsplots/SKILL.md
+++ b/src/cnsplots/_agent_skill/cnsplots/SKILL.md
@@ -42,8 +42,8 @@ artifact.
 4. Build the figure.
    - In headless execution, set `MPLBACKEND=Agg` or call
      `matplotlib.use("Agg")` before importing plotting backends.
-   - Start single-panel figures with `cns.figure(width=..., height=...)`.
-     Dimensions are in pixels.
+   - Start single-panel figures with `fig = cns.figure(width=..., height=...)`.
+     Dimensions are in pixels. The returned Matplotlib `Figure` becomes current.
    - Pass `ax=` explicitly when composing with existing Matplotlib axes.
    - Use `cns.multipanel` for labeled publication panels.
    - Add titles and axis labels through the returned Matplotlib axes.
@@ -51,8 +51,11 @@ artifact.
      leaving global settings changed.
 
 5. Save and validate the result.
-   - Use `cns.savefig(...)`. Prefer SVG or PDF for editable publication output
-     and PNG for a raster preview.
+   - Use `cns.savefig(..., fig=fig)` to save a retained figure, or omit `fig` to
+     save the current figure. Prefer SVG or PDF for editable publication output
+     and PNG for a raster preview. Per-save `dpi`, `transparent`, `bbox_inches`,
+     and `pad_inches` override export settings; `bbox_inches=None` preserves
+     the full canvas, and padding applies only to tight cropping.
    - Run the complete script, confirm the output exists and is non-empty, and
      inspect or render it when visual tools are available.
    - Check clipping, unreadable labels, misleading scales, legend collisions,
@@ -68,10 +71,10 @@ matplotlib.use("Agg")
 
 import cnsplots as cns
 
-cns.figure(width=180, height=150)
+fig = cns.figure(width=180, height=150)
 ax = cns.boxplot(data=df, x="group", y="value")
 ax.set(xlabel="Group", ylabel="Value")
-cns.savefig("figure.svg")
+cns.savefig("figure.svg", fig=fig)
 ```
 
 Adapt this only after inspecting the selected function's installed signature and

--- a/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
+++ b/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
@@ -72,12 +72,14 @@ input columns expected by the installed version.
 
 ## Figure composition and export
 
-- `figure`: initialize a styled single-panel canvas in pixel dimensions.
+- `figure`: initialize a styled single-panel canvas in pixel dimensions and
+  return the Matplotlib `Figure`, which also becomes current.
 - `multipanel`: create labeled, pixel-sized panels; `panel(...)` returns the
   target `Axes`.
 - `add_panel_label`: label an existing axes.
 - `take_legend_out`: position a legend outside its axes.
-- `savefig`: save the current figure and create parent directories as needed.
+- `savefig`: save the current figure or an explicit `fig=`, with per-save DPI,
+  transparency, crop, and padding options; create parent directories as needed.
 - `settings.context(...)`: apply temporary package-wide style settings.
 - `palettes`: retrieve curated categorical or continuous palettes.
 

--- a/src/cnsplots/_svg.py
+++ b/src/cnsplots/_svg.py
@@ -9,33 +9,51 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from lxml.etree import _Element  # ty: ignore[unresolved-import]
+    from matplotlib.figure import Figure
+    from matplotlib.transforms import Bbox
 
 import subprocess
 
-import matplotlib.pyplot as plt
 from lxml import etree  # ty: ignore[unresolved-import]
 
 _PDF_SUBSET_FONT_PREFIX = re.compile(r"^[A-Z]{6}\+")
 
 
-def _save_plain_svg(filepath: str, message: str, bbox_inches=None) -> None:
+def _save_plain_svg(
+    filepath: str,
+    message: str,
+    *,
+    fig: Figure,
+    dpi: float,
+    transparent: bool,
+    bbox_inches: Bbox,
+    pad_inches: float,
+) -> None:
     """Save a standard matplotlib SVG and surface why the optimized path was skipped."""
     warnings.warn(message, RuntimeWarning, stacklevel=2)
-    savefig_kwargs: dict[str, object] = {"format": "svg"}
-    if bbox_inches is not None:
-        savefig_kwargs["bbox_inches"] = bbox_inches
-        savefig_kwargs["pad_inches"] = 0
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        plt.savefig(filepath, **savefig_kwargs)
+        fig.savefig(
+            filepath,
+            format="svg",
+            dpi=dpi,
+            transparent=transparent,
+            bbox_inches=bbox_inches,
+            pad_inches=pad_inches,
+        )
 
 
-def _save_svg(filepath: str, root: str, bbox_inches=None) -> None:
+def _save_svg(
+    filepath: str,
+    root: str,
+    *,
+    fig: Figure,
+    dpi: float,
+    transparent: bool,
+    bbox_inches: Bbox,
+    pad_inches: float,
+) -> None:
     stem = Path(root).name or Path(filepath).stem or "cnsplots"
-    savefig_kwargs: dict[str, object] = {}
-    if bbox_inches is not None:
-        savefig_kwargs["bbox_inches"] = bbox_inches
-        savefig_kwargs["pad_inches"] = 0
 
     with TemporaryDirectory(prefix=f"{stem}-svg-") as tmp_dir:
         tmp_dir_path = Path(tmp_dir)
@@ -49,7 +67,13 @@ def _save_svg(filepath: str, root: str, bbox_inches=None) -> None:
             )
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                plt.savefig(tmp_pdf, **savefig_kwargs)
+                fig.savefig(
+                    tmp_pdf,
+                    dpi=dpi,
+                    transparent=transparent,
+                    bbox_inches=bbox_inches,
+                    pad_inches=pad_inches,
+                )
         finally:
             fonttools_logger.setLevel(previous_level)
         try:
@@ -73,7 +97,11 @@ def _save_svg(filepath: str, root: str, bbox_inches=None) -> None:
             _save_plain_svg(
                 filepath,
                 "MuPDF's `mutool` is unavailable; saved a standard matplotlib SVG instead.",
+                fig=fig,
+                dpi=dpi,
+                transparent=transparent,
                 bbox_inches=bbox_inches,
+                pad_inches=pad_inches,
             )
         except subprocess.CalledProcessError as exc:
             stderr = (exc.stderr or b"").decode(errors="replace").strip()
@@ -82,7 +110,11 @@ def _save_svg(filepath: str, root: str, bbox_inches=None) -> None:
                 filepath,
                 "MuPDF's `mutool` failed during SVG conversion"
                 f"{detail}; saved a standard matplotlib SVG instead.",
+                fig=fig,
+                dpi=dpi,
+                transparent=transparent,
                 bbox_inches=bbox_inches,
+                pad_inches=pad_inches,
             )
 
 

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Sequence
+from enum import Enum
 from typing import Any, Literal, cast, overload
 
 import itertools
@@ -22,6 +23,7 @@ import seaborn as sns
 from matplotlib.axes import Axes
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.colors import Colormap
+from matplotlib.figure import Figure
 from matplotlib.typing import ColorType
 from palettable.cartocolors.qualitative import get_map as _get_cartocolor_map
 from palettable.colorbrewer.colorbrewer import get_map as _get_colorbrewer_map
@@ -317,12 +319,16 @@ def _capture_detached_axes_layout(
     return new_layouts
 
 
+class _SavefigDefault(Enum):
+    SETTINGS = "settings"
+
+
 def figure(
     width: int | float | None = None,
     height: int | float | None = None,
     color_cycle: str | Sequence[ColorType] | None = None,
     color_map: str | None = None,
-) -> None:
+) -> Figure:
     """
     Initialize a new figure with custom size and styling.
 
@@ -346,8 +352,8 @@ def figure(
 
     Returns
     -------
-    None
-        This function creates a figure and returns nothing.
+    matplotlib.figure.Figure
+        The newly created figure, which is also the current pyplot figure.
 
     See Also
     --------
@@ -361,6 +367,9 @@ def figure(
     resolution and uses ``cns.settings.figure_dpi`` for the rendered DPI.
 
     The figure size formula is: inches = pixels / 72.
+
+    This function previously returned None. Callers that ignore the return value
+    continue to work; callers or type checks relying on None must be updated.
 
     Examples
     --------
@@ -382,14 +391,24 @@ def figure(
     if color_map is None:
         color_map = settings.palette_seq
     setup_matplotlib(color_cycle, color_map)
-    plt.figure(figsize=(width / 72, height / 72), dpi=settings.figure_dpi)
+    return plt.figure(figsize=(width / 72, height / 72), dpi=settings.figure_dpi)
 
 
-def savefig(filepath: str | os.PathLike[str]) -> None:
+def savefig(
+    filepath: str | os.PathLike[str],
+    *,
+    fig: Figure | None = None,
+    dpi: float | None = None,
+    transparent: bool | None = None,
+    bbox_inches: Literal["tight"] | mtransforms.Bbox | None | _SavefigDefault = (
+        _SavefigDefault.SETTINGS
+    ),
+    pad_inches: float | None = None,
+) -> None:
     """
-    Save the current figure to a file, creating directories if needed.
+    Save a figure to a file, creating directories if needed.
 
-    This function saves the current matplotlib figure to the specified file path,
+    This function saves a matplotlib figure to the specified file path,
     automatically creating any missing parent directories.
 
     Parameters
@@ -397,6 +416,23 @@ def savefig(filepath: str | os.PathLike[str]) -> None:
     filepath : str
         Path where the figure should be saved. Can include home directory shorthand
         (~). The file format is determined by the extension (e.g., .pdf, .png, .svg).
+    fig : matplotlib.figure.Figure, optional
+        Figure to export. If None, use the current pyplot figure. Exporting an
+        explicit figure does not change the current figure selection.
+    dpi : float, optional
+        Positive, finite export resolution. If None, use cns.settings.savefig_dpi.
+        Vector geometry retains its physical size; DPI controls rasterized content.
+    transparent : bool, optional
+        Whether figure and axes backgrounds are transparent. If None, use
+        cns.settings.savefig_transparent. Format support follows matplotlib.
+    bbox_inches : {'tight', None} or matplotlib.transforms.Bbox, optional
+        Export bounds in inches. If omitted, use cns.settings.savefig_bbox
+        ('tight' crops to the artists; other configured modes use the full figure).
+        Explicit None saves the full figure, even when the configured default is
+        'tight'. A Bbox specifies a fixed region in inches.
+    pad_inches : float, optional
+        Non-negative, finite padding around tight bounds, in inches. If None, use
+        cns.settings.savefig_pad_inches. Ignored for full-figure or fixed bounds.
 
     Returns
     -------
@@ -419,7 +455,10 @@ def savefig(filepath: str | os.PathLike[str]) -> None:
       is available, and falls back to matplotlib SVG output otherwise
 
     Supported formats include: PDF, PNG, SVG, JPG, EPS, and more (any format
-    supported by matplotlib.pyplot.savefig).
+    supported by matplotlib.figure.Figure.savefig). Explicit options take
+    precedence over current cnsplots settings. Other options retain matplotlib's
+    backend defaults. Settings, rcParams, figure DPI, and canvas are preserved,
+    including when export fails. This does not make matplotlib thread-safe.
 
     Examples
     --------
@@ -431,28 +470,64 @@ def savefig(filepath: str | os.PathLike[str]) -> None:
     >>> # Save in multiple formats
     >>> cns.savefig("plot.png")
     >>> cns.savefig("plot.svg")
+
+    >>> # Export a retained figure with per-call options
+    >>> fig = cns.figure(width=300, height=200)
+    >>> cns.boxplot(data=df, x="group", y="value")
+    >>> cns.savefig("plot.png", fig=fig, dpi=300, transparent=False, bbox_inches=None)
     """
+    if dpi is None:
+        dpi = settings.savefig_dpi
+    if isinstance(dpi, bool) or not isinstance(dpi, (int, float)):
+        raise TypeError("dpi must be a number")
+    if not math.isfinite(dpi) or dpi <= 0:
+        raise ValueError("dpi must be positive and finite")
+    if transparent is None:
+        transparent = settings.savefig_transparent
+    if not isinstance(transparent, bool):
+        raise TypeError("transparent must be a boolean")
+    if pad_inches is None:
+        pad_inches = settings.savefig_pad_inches
+    if isinstance(pad_inches, bool) or not isinstance(pad_inches, (int, float)):
+        raise TypeError("pad_inches must be a number")
+    if not math.isfinite(pad_inches) or pad_inches < 0:
+        raise ValueError("pad_inches must be non-negative and finite")
+    if bbox_inches is _SavefigDefault.SETTINGS:
+        bbox_inches = "tight" if settings.savefig_bbox == "tight" else None
+    if not (
+        bbox_inches is None
+        or isinstance(bbox_inches, mtransforms.Bbox)
+        or (isinstance(bbox_inches, str) and bbox_inches == "tight")
+    ):
+        raise ValueError("bbox_inches must be 'tight', None, or a Bbox")
+
     filepath = Path(filepath).expanduser()
     if filepath.parent != Path("."):
         filepath.parent.mkdir(parents=True, exist_ok=True)
-    fig = plt.gcf()
+    if fig is None:
+        fig = plt.gcf()
     for ax in fig.get_axes():
         apply_unicode_font(ax)
-    target_dpi = float(settings.savefig_dpi)
+    target_dpi = float(dpi)
     original_dpi = fig.dpi
+    original_canvas = fig.canvas
     root, ext = os.path.splitext(filepath)
     try:
         if target_dpi != original_dpi:
             fig.set_dpi(target_dpi)
         fig.canvas.draw()
-        bbox_inches = _get_export_bbox_inches(fig)
+        export_bbox = _get_export_bbox_inches(
+            fig, bbox_inches=bbox_inches, pad_inches=pad_inches
+        )
+        savefig_kwargs: dict[str, Any] = {
+            "dpi": target_dpi,
+            "transparent": transparent,
+            "bbox_inches": export_bbox,
+            "pad_inches": 0,
+        }
         if ext.lower() == ".svg":
-            _save_svg(str(filepath), root, bbox_inches=bbox_inches)
+            _save_svg(str(filepath), root, fig=fig, **savefig_kwargs)
         else:
-            savefig_kwargs: dict[str, object] = {"dpi": target_dpi}
-            if bbox_inches is not None:
-                savefig_kwargs["bbox_inches"] = bbox_inches
-                savefig_kwargs["pad_inches"] = 0
             if ext.lower() == ".pdf":
                 fonttools_logger = logging.getLogger("fontTools")
                 previous_level = fonttools_logger.level
@@ -460,21 +535,31 @@ def savefig(filepath: str | os.PathLike[str]) -> None:
                     fonttools_logger.setLevel(
                         max(fonttools_logger.getEffectiveLevel(), logging.ERROR)
                     )
-                    plt.savefig(filepath, **savefig_kwargs)
+                    fig.savefig(filepath, **savefig_kwargs)
                 finally:
                     fonttools_logger.setLevel(previous_level)
             else:
-                plt.savefig(filepath, **savefig_kwargs)
+                fig.savefig(filepath, **savefig_kwargs)
     finally:
+        fig.set_canvas(original_canvas)
         if fig.dpi != original_dpi:
             fig.set_dpi(original_dpi)
-            fig.canvas.draw()
+    # Refresh the original canvas after success without masking export failures.
+    fig.canvas.draw()
 
 
-def _get_export_bbox_inches(fig) -> mtransforms.Bbox | None:
+def _get_export_bbox_inches(
+    fig: Figure,
+    *,
+    bbox_inches: Literal["tight"] | mtransforms.Bbox | None,
+    pad_inches: float,
+) -> mtransforms.Bbox:
     """Return a shared export bbox so raster and vector outputs align."""
-    if settings.savefig_bbox != "tight":
-        return None
+    if isinstance(bbox_inches, mtransforms.Bbox):
+        return bbox_inches.frozen()
+    if bbox_inches is None:
+        # Passing None to Figure.savefig would reapply rcParams['savefig.bbox'].
+        return fig.bbox_inches.frozen()
 
     original_canvas = fig.canvas
     agg_canvas = FigureCanvasAgg(fig)
@@ -482,9 +567,9 @@ def _get_export_bbox_inches(fig) -> mtransforms.Bbox | None:
         agg_canvas.draw()
         bbox_inches = fig.get_tightbbox(agg_canvas.get_renderer())
         if bbox_inches is None:
-            return None
-        if settings.savefig_pad_inches:
-            bbox_inches = bbox_inches.padded(float(settings.savefig_pad_inches))
+            return fig.bbox_inches.frozen()
+        if pad_inches:
+            bbox_inches = bbox_inches.padded(pad_inches)
         return mtransforms.Bbox.from_extents(*bbox_inches.extents)
     finally:
         fig.set_canvas(original_canvas)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -825,7 +825,7 @@ def test_svg_helpers_and_export(
     cns.figure(120, 120)
     plt.plot([0, 1], [0, 1])
     original_dpi = plt.gcf().dpi
-    original_plt_savefig = _utils.plt.savefig
+    original_figure_savefig = Figure.savefig
     saved_png_meta: dict[str, float] = {}
 
     def fake_png_savefig(*args: object, **kwargs: object) -> None:
@@ -844,7 +844,7 @@ def test_svg_helpers_and_export(
             assert isinstance(pad_inches, (int, float))
             saved_png_meta["pad_inches"] = float(pad_inches)
 
-    monkeypatch.setattr(_utils.plt, "savefig", fake_png_savefig)
+    monkeypatch.setattr(Figure, "savefig", fake_png_savefig)
     with cns.settings.context(savefig_dpi=300):
         cns.savefig(str(output_dir / "captured.png"))
     assert saved_png_meta["fig_dpi"] == pytest.approx(300)
@@ -853,7 +853,7 @@ def test_svg_helpers_and_export(
     assert saved_png_meta["bbox_y1"] > saved_png_meta["bbox_y0"]
     assert saved_png_meta["pad_inches"] == pytest.approx(0)
     assert plt.gcf().dpi == pytest.approx(original_dpi)
-    monkeypatch.setattr(_utils.plt, "savefig", original_plt_savefig)
+    monkeypatch.setattr(Figure, "savefig", original_figure_savefig)
 
     cns.figure(120, 120)
     plt.plot([0, 1], [0, 1])
@@ -863,20 +863,24 @@ def test_svg_helpers_and_export(
         standard_meta["bbox_inches"] = kwargs.get("bbox_inches")
         standard_meta["pad_inches"] = kwargs.get("pad_inches")
 
-    monkeypatch.setattr(_utils.plt, "savefig", fake_standard_savefig)
+    monkeypatch.setattr(Figure, "savefig", fake_standard_savefig)
     with cns.settings.context(savefig_bbox="standard"):
         cns.savefig(str(output_dir / "captured-standard.png"))
-    assert standard_meta["bbox_inches"] is None
-    assert standard_meta["pad_inches"] is None
-    monkeypatch.setattr(_utils.plt, "savefig", original_plt_savefig)
+    standard_bbox = standard_meta["bbox_inches"]
+    assert isinstance(standard_bbox, mtransforms.Bbox)
+    np.testing.assert_allclose(standard_bbox.bounds, plt.gcf().bbox_inches.bounds)
+    assert standard_meta["pad_inches"] == 0
+    monkeypatch.setattr(Figure, "savefig", original_figure_savefig)
 
     cns.figure(120, 120)
     plt.plot([0, 1], [0, 1])
     original_svg_dpi = plt.gcf().dpi
     saved_svg_meta: dict[str, float] = {}
 
-    def fake_save_svg(filepath: str, root: str, bbox_inches=None) -> None:
-        saved_svg_meta["fig_dpi"] = plt.gcf().dpi
+    def fake_save_svg(
+        filepath: str, root: str, *, fig: Figure, bbox_inches, **kwargs: object
+    ) -> None:
+        saved_svg_meta["fig_dpi"] = fig.dpi
         if bbox_inches is not None:
             saved_svg_meta["bbox_x0"] = float(bbox_inches.x0)
             saved_svg_meta["bbox_y0"] = float(bbox_inches.y0)
@@ -896,7 +900,10 @@ def test_svg_helpers_and_export(
     plt.plot([0, 1], [0, 1])
     fig = plt.gcf()
     monkeypatch.setattr(fig, "get_tightbbox", lambda renderer: None)
-    assert _utils._get_export_bbox_inches(fig) is None
+    np.testing.assert_allclose(
+        _utils._get_export_bbox_inches(fig, bbox_inches="tight", pad_inches=0).bounds,
+        fig.bbox_inches.bounds,
+    )
 
     cns.figure(120, 120)
     plt.plot([0, 1], [0, 1])
@@ -918,7 +925,15 @@ def test_svg_helpers_and_export(
 
     monkeypatch.setattr(_svg.subprocess, "run", fake_run)
     monkeypatch.setattr(_svg, "_correct_svg", fake_correct)
-    _svg._save_svg(str(success_path), str(output_dir / "optimized"))
+    _svg._save_svg(
+        str(success_path),
+        str(output_dir / "optimized"),
+        fig=plt.gcf(),
+        dpi=300,
+        transparent=True,
+        bbox_inches=plt.gcf().bbox_inches,
+        pad_inches=0,
+    )
     assert success_path.exists()
     assert str(corrected["input_file"]).endswith("1.svg")
 
@@ -934,6 +949,10 @@ def test_svg_helpers_and_export(
         _svg._save_svg(
             str(missing_path),
             str(output_dir / "missing-mutool"),
+            fig=plt.gcf(),
+            dpi=300,
+            transparent=True,
+            pad_inches=0,
             bbox_inches=mtransforms.Bbox.from_extents(0, 0, 1, 1),
         )
     assert missing_path.exists()
@@ -947,7 +966,15 @@ def test_svg_helpers_and_export(
     monkeypatch.setattr(_svg.subprocess, "run", fail_run)
     failed_path = output_dir / "failed.svg"
     with pytest.warns(RuntimeWarning, match="boom"):
-        _svg._save_svg(str(failed_path), str(output_dir / "failed"))
+        _svg._save_svg(
+            str(failed_path),
+            str(output_dir / "failed"),
+            fig=plt.gcf(),
+            dpi=300,
+            transparent=True,
+            bbox_inches=plt.gcf().bbox_inches,
+            pad_inches=0,
+        )
     assert failed_path.exists()
 
 
@@ -962,13 +989,13 @@ def test_svg_export_suppresses_fonttools_logs_and_restores_level(
     fonttools_logger.setLevel(expected_level)
 
     def fake_savefig(*args: object, **kwargs: object) -> None:
-        if str(args[0]).endswith(".pdf"):
+        if str(args[1]).endswith(".pdf"):
             logging.getLogger("fontTools.subset").info("maxp pruned")
 
     def missing_run(*args: object, **kwargs: object) -> object:
         raise FileNotFoundError("mutool")
 
-    monkeypatch.setattr(_svg.plt, "savefig", fake_savefig)
+    monkeypatch.setattr(Figure, "savefig", fake_savefig)
     monkeypatch.setattr(_svg.subprocess, "run", missing_run)
 
     try:
@@ -976,7 +1003,15 @@ def test_svg_export_suppresses_fonttools_logs_and_restores_level(
             caplog.at_level(logging.INFO),
             pytest.warns(RuntimeWarning, match="mutool"),
         ):
-            _svg._save_svg(str(output_dir / "plot.svg"), str(output_dir / "plot"))
+            _svg._save_svg(
+                str(output_dir / "plot.svg"),
+                str(output_dir / "plot"),
+                fig=plt.gcf(),
+                dpi=300,
+                transparent=True,
+                bbox_inches=plt.gcf().bbox_inches,
+                pad_inches=0,
+            )
 
         assert not [
             record for record in caplog.records if record.name.startswith("fontTools")
@@ -997,7 +1032,7 @@ def test_pdf_export_suppresses_fonttools_logs_and_restores_level(
     def fake_savefig(*args: object, **kwargs: object) -> None:
         logging.getLogger("fontTools.subset").info("maxp pruned")
 
-    monkeypatch.setattr(_utils.plt, "savefig", fake_savefig)
+    monkeypatch.setattr(Figure, "savefig", fake_savefig)
 
     try:
         cns.figure(120, 120)

--- a/tests/test_figure_exports.py
+++ b/tests/test_figure_exports.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from lxml import etree  # ty: ignore[unresolved-import]
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
+from matplotlib.transforms import Bbox
+
+import cnsplots as cns
+from cnsplots import _svg
+
+
+def test_figure_returns_new_current_figure_and_preserves_plotting(
+    tmp_path: Path, numeric_df: pd.DataFrame
+) -> None:
+    previous = plt.figure()
+    with cns.settings.context(figure_dpi=96), plt.rc_context():
+        fig = cns.figure(width=216, height=144)
+        assert isinstance(fig, Figure)
+        assert fig is plt.gcf()
+        assert fig is not previous
+        assert fig.get_size_inches() == pytest.approx((3, 2))
+        assert fig.dpi == 96
+
+        ax = cns.scatterplot(data=numeric_df, x="x", y="y")
+        assert ax.figure is fig
+        assert len(np.asarray(ax.collections[0].get_offsets())) == len(numeric_df)
+        path = tmp_path / "returned-figure.png"
+        cns.savefig(path)
+        assert path.is_file()
+        assert plt.gcf() is fig
+        assert fig.get_size_inches() == pytest.approx((3, 2))
+        assert fig.dpi == 96
+
+
+def _colored_figure(width: float, height: float, color: str) -> Figure:
+    fig = plt.figure(figsize=(width, height), dpi=72, facecolor="yellow")
+    fig.add_artist(
+        Rectangle(
+            (0.25, 0.25),
+            0.5,
+            0.5,
+            transform=fig.transFigure,
+            facecolor=color,
+            edgecolor="none",
+        )
+    )
+    return fig
+
+
+def _assert_export(
+    path: Path, size_inches: tuple[float, float], dpi: float, transparent: bool
+) -> None:
+    """Check the output dimensions and the red target, not the blue current figure."""
+    if path.suffix == ".png":
+        pixels = plt.imread(path)
+        assert pixels.shape[1::-1] == pytest.approx(
+            np.asarray(size_inches) * dpi, abs=1
+        )
+        assert np.any(np.all(pixels[:, :, :3] == (1, 0, 0), axis=-1))
+        assert not np.any(np.all(pixels[:, :, :3] == (0, 0, 1), axis=-1))
+        assert pixels[0, 0, 3] == (0 if transparent else 1)
+    elif path.suffix == ".pdf":
+        content = path.read_bytes()
+        match = re.search(rb"/MediaBox\s*\[\s*0\s+0\s+([\d.]+)\s+([\d.]+)", content)
+        assert match is not None
+        size_points = tuple(float(value) for value in match.groups())
+        assert size_points == pytest.approx(np.asarray(size_inches) * 72)
+        assert b"1 0 0 rg" in content
+        assert b"0 0 1 rg" not in content
+        assert (b"1 1 0 rg" in content) is not transparent
+    else:
+        root = etree.parse(str(path)).getroot()
+        view_box = [float(value) for value in root.get("viewBox").split()]
+        assert view_box[2:] == pytest.approx(np.asarray(size_inches) * 72, abs=0.01)
+        content = path.read_text(encoding="utf-8").lower()
+        assert "#ff0000" in content
+        assert "#0000ff" not in content
+        assert ("#ffff00" in content) is not transparent
+
+
+@pytest.mark.parametrize("format", ["png", "pdf", "svg", "svg-missing", "svg-failed"])
+@pytest.mark.parametrize("bounds", ["tight", "full", "explicit"])
+@pytest.mark.parametrize("transparent", [False, True])
+def test_savefig_exports_explicit_figure_with_per_call_options(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    format: str,
+    bounds: str,
+    transparent: bool,
+) -> None:
+    if format == "svg" and shutil.which("mutool") is None:
+        pytest.skip("MuPDF's mutool is required for optimized SVG export")
+
+    def unavailable_mutool(*args: object, **kwargs: object) -> None:
+        if format == "svg-missing":
+            raise FileNotFoundError("mutool")
+        raise subprocess.CalledProcessError(1, ["mutool"], stderr=b"conversion failed")
+
+    if format.startswith("svg-"):
+        monkeypatch.setattr(_svg.subprocess, "run", unavailable_mutool)
+
+    bbox: Literal["tight"] | Bbox | None
+    if bounds == "tight":
+        bbox, size_inches = "tight", (1.2, 0.7)
+    elif bounds == "full":
+        bbox, size_inches = None, (2.0, 1.0)
+    else:
+        bbox, size_inches = Bbox.from_bounds(0, 0, 1.25, 0.75), (1.25, 0.75)
+
+    with (
+        cns.settings.context(
+            savefig_dpi=144,
+            savefig_bbox="tight",
+            savefig_pad_inches=0.2,
+            savefig_transparent=not transparent,
+        ),
+        plt.rc_context(
+            {
+                "savefig.dpi": 72,
+                "savefig.bbox": "tight",
+                "savefig.pad_inches": 0.3,
+                "savefig.transparent": not transparent,
+                "pdf.compression": 0,
+            }
+        ),
+    ):
+        target = _colored_figure(2, 1, "red")
+        current = _colored_figure(5, 4, "blue")
+        original_canvas = target.canvas
+        assert isinstance(original_canvas, FigureCanvasAgg)
+        original_canvas.draw()
+        original_pixels = np.asarray(original_canvas.buffer_rgba()).copy()
+        original_rc = dict(plt.rcParams)
+        original_settings = repr(cns.settings)
+        path = tmp_path / "nested" / f"target.{format.split('-')[0]}"
+
+        def save() -> None:
+            cns.savefig(
+                path,
+                fig=target,
+                dpi=100,
+                transparent=transparent,
+                bbox_inches=bbox,
+                pad_inches=0.1,
+            )
+
+        if format.startswith("svg-"):
+            with pytest.warns(RuntimeWarning, match="mutool"):
+                save()
+        else:
+            save()
+
+        _assert_export(path, size_inches, dpi=100, transparent=transparent)
+        assert plt.gcf() is current
+        assert target.dpi == 72
+        assert target.canvas is original_canvas
+        np.testing.assert_array_equal(original_canvas.buffer_rgba(), original_pixels)
+        assert target.patch.get_alpha() is None
+        assert dict(plt.rcParams) == original_rc
+        assert repr(cns.settings) == original_settings
+
+
+@pytest.mark.parametrize("bbox_setting", ["tight", "standard"])
+@pytest.mark.parametrize("transparent", [False, True])
+def test_savefig_uses_current_settings_without_reapplying_style(
+    tmp_path: Path, bbox_setting: str, transparent: bool
+) -> None:
+    with (
+        cns.settings.context(
+            savefig_dpi=100,
+            savefig_bbox=bbox_setting,
+            savefig_pad_inches=0.1,
+            savefig_transparent=transparent,
+        ),
+        plt.rc_context(
+            {
+                "savefig.dpi": 200,
+                "savefig.bbox": None if bbox_setting == "tight" else "tight",
+                "savefig.pad_inches": 0.4,
+                "savefig.transparent": not transparent,
+            }
+        ),
+    ):
+        target = _colored_figure(2, 1, "red")
+        path = tmp_path / "defaults.png"
+        original_rc = dict(plt.rcParams)
+        cns.savefig(path, dpi=None, transparent=None, pad_inches=None)
+
+        size_inches = (1.2, 0.7) if bbox_setting == "tight" else (2.0, 1.0)
+        _assert_export(path, size_inches, dpi=100, transparent=transparent)
+        assert plt.gcf() is target
+        assert target.dpi == 72
+        assert dict(plt.rcParams) == original_rc
+
+
+@pytest.mark.parametrize("stage", ["draw", "bbox", "save"])
+def test_savefig_restores_figure_and_style_after_export_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stage: str
+) -> None:
+    target = _colored_figure(2, 1, "red")
+    current = _colored_figure(5, 4, "blue")
+    original_canvas = target.canvas
+    original_rc = dict(plt.rcParams)
+    original_settings = repr(cns.settings)
+    logger = logging.getLogger("fontTools")
+    original_level = logger.level
+    calls = 0
+
+    def fail_permanently(*args: object, **kwargs: object) -> None:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError(f"export interrupted at attempt {calls}")
+
+    if stage == "draw":
+        monkeypatch.setattr(original_canvas, "draw", fail_permanently)
+    elif stage == "bbox":
+        monkeypatch.setattr(target, "get_tightbbox", fail_permanently)
+    else:
+        monkeypatch.setattr(target, "savefig", fail_permanently)
+
+    with pytest.raises(RuntimeError, match="export interrupted at attempt 1$"):
+        cns.savefig(
+            tmp_path / "failure.pdf",
+            fig=target,
+            dpi=144,
+            transparent=True,
+            bbox_inches="tight",
+            pad_inches=0.1,
+        )
+
+    assert target.dpi == 72
+    assert target.canvas is original_canvas
+    assert target.patch.get_alpha() is None
+    assert plt.gcf() is current
+    assert dict(plt.rcParams) == original_rc
+    assert repr(cns.settings) == original_settings
+    assert logger.level == original_level
+
+
+@pytest.mark.parametrize(
+    "option,value,error",
+    [
+        ("dpi", 0, ValueError),
+        ("dpi", -1, ValueError),
+        ("dpi", float("inf"), ValueError),
+        ("dpi", float("nan"), ValueError),
+        ("dpi", "100", TypeError),
+        ("dpi", True, TypeError),
+        ("pad_inches", -1, ValueError),
+        ("pad_inches", float("inf"), ValueError),
+        ("pad_inches", float("nan"), ValueError),
+        ("pad_inches", "0.1", TypeError),
+        ("pad_inches", False, TypeError),
+        ("transparent", 1, TypeError),
+        ("bbox_inches", "standard", ValueError),
+        ("bbox_inches", "invalid", ValueError),
+    ],
+)
+def test_savefig_rejects_invalid_export_options(
+    tmp_path: Path, option: str, value: object, error: type[Exception]
+) -> None:
+    target = _colored_figure(2, 1, "red")
+    path = tmp_path / "invalid.png"
+    save = cast(Callable[..., None], cns.savefig)
+    with pytest.raises(error, match=option):
+        save(path, fig=target, **{option: value})
+    assert not path.exists()
+    assert target.dpi == 72
+
+
+@pytest.mark.parametrize("option", ["facecolor", "format", "metadata"])
+def test_savefig_rejects_unsupported_options(tmp_path: Path, option: str) -> None:
+    path = tmp_path / "unsupported.png"
+    save = cast(Callable[..., None], cns.savefig)
+    with pytest.raises(TypeError, match=option):
+        save(path, **{option: "unsupported"})
+    assert not path.exists()

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
     from anndata import AnnData
     from matplotlib.axes import Axes
     from matplotlib.colors import Colormap
+    from matplotlib.figure import Figure
+    from matplotlib.transforms import Bbox
     from typing_extensions import assert_type
 
     import cnsplots as cns
@@ -27,8 +29,27 @@ if TYPE_CHECKING:
         assert_type(cns.settings.font_sans_serif, tuple[str, ...])
         assert_type(cns.settings.panel_label_fontname, str | None)
 
-        assert_type(cns.figure(width=120, height=80), None)
+        fig = cns.figure(width=120, height=80)
+        assert_type(fig, Figure)
         assert_type(cns.savefig("figure.svg"), None)
+        assert_type(
+            cns.savefig(
+                "figure.png",
+                fig=fig,
+                dpi=300,
+                transparent=False,
+                bbox_inches="tight",
+                pad_inches=0.1,
+            ),
+            None,
+        )
+        assert_type(cns.savefig("figure.pdf", fig=fig, bbox_inches=None), None)
+        assert_type(
+            cns.savefig(
+                "figure.svg", fig=fig, bbox_inches=Bbox.from_bounds(0, 0, 2, 1)
+            ),
+            None,
+        )
         assert_type(cns.add_panel_label("A"), None)
         assert_type(cns.apply_unicode_font(ax), None)
         assert_type(cns.take_legend_out("Group"), None)


### PR DESCRIPTION
## What changed

Return the newly created Matplotlib Figure from `cns.figure`, so callers can retain it and export it after another figure becomes current.

- Add keyword-only `fig` selection to `cns.savefig`, preserving the current figure across PNG, PDF, optimized SVG, and SVG fallback exports.
- Add per-export `dpi`, `transparent`, `bbox_inches`, and `pad_inches` overrides with call-time settings defaults. Distinguish omitted bounds from explicit `None`, and support fixed `Bbox` regions.
- Restore target DPI and canvas identity on failures, refresh the original canvas after successful exports, and preserve SVG text/font processing.
- Update public typing, documentation, examples, and regression coverage.

## How it was tested

- `make test`: 1,036 tests passed, 100% coverage.
- `make lint`: all checks passed.
- Includes 55 new regressions covering differing target/current figures, real output contents and dimensions, transparency, both SVG fallbacks, canvas restoration, and invalid options.

## Risks or follow-ups

`cns.figure` previously returned `None`; consumers or type checks relying on that result must migrate to the returned Figure. Calls that ignore the result retain their plotting workflow. Export defaults now consistently use current cnsplots settings, ahead of corresponding rcParams values. Figure sizing is unchanged; its broader documentation clarification remains in #141.

## Related issue

Closes #138
Closes #139
Closes #140

## Release Notes Label

`enhancement`
