### PR TITLE
✨ Add physical figure sizing units

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Create visually stunning, journal-quality figures with minimal code. Built on ma
 
 - 🎨 **Publication-Ready**: Pre-configured styles matching Cell, Nature, and Science journal requirements
 - 🎯 **Simple API**: Create complex multi-panel figures with just a few lines of code
-- 📐 **Precise Control**: Specify dimensions in pixels, perfect for journal submission guidelines
+- 📐 **Precise Control**: Specify dimensions in points, inches, or millimeters for publication layouts
 - 🖋️ **Adobe Illustrator Compatible**: SVG exports with editable fonts (no text-to-path conversion)
 - 📊 **Statistical Integration**: Built-in statistical tests and annotations
 - 🔧 **Highly Customizable**: Full control over colors, fonts, and styling
@@ -154,7 +154,7 @@ import cnsplots as cns
 # Load example data
 df = cns.datasets.load_dataset("tips")
 
-# Create a figure (width, height in pixels)
+# Create a figure (width, height in points)
 fig = cns.figure(width=100, height=150)
 
 # Create a publication-ready boxplot
@@ -211,11 +211,35 @@ Full documentation is available at [cnsplots.farid.one](https://cnsplots.farid.o
 
 ### Figure Dimensions
 
-Specify sizes in **pixels** for precise control:
+Specify width and height in **points** by default: one point is 1/72 inch.
+These are the legacy logical 72-DPI units, so existing numeric calls retain
+their physical size. Use `unit="pt"`, `unit="in"`, or `unit="mm"` explicitly:
 
 ```python
-cns.figure(width=100, height=150)  # Final canvas size is 100px × 150px
+fig = cns.figure(width=100, height=150)
+print(fig.get_size_inches())  # [1.38888889 2.08333333]
+print(fig.canvas.get_width_height())  # (200, 300) at the default display DPI of 144
+
+# Equivalent 2 × 1 inch canvases
+cns.figure(144, 72, unit="pt")
+cns.figure(2, 1, unit="in")
+cns.figure(50.8, 25.4, unit="mm")
 ```
+
+`figure` dimensions describe the whole canvas. Display DPI determines its
+pixel dimensions; export DPI determines raster resolution without changing
+the physical size. The 100 × 150 point canvas exports as 400 × 600 pixels at
+the default export DPI of 288 when saved with `bbox_inches=None`. The default
+`bbox_inches="tight"` instead crops around artists and adds `pad_inches`
+(in inches), so the saved dimensions can differ from the full canvas.
+
+`cns.multipanel(max_width=..., unit="mm")` sets the full canvas width and the
+unit inherited by explicit `mp.panel(..., width=..., height=...)` sizes.
+Panel sizes describe the axes area; labels, titles, and margins contribute
+to the layout and total height. A panel can override `unit` independently.
+Margins remain in points and label `pad_left`/`pad_top` remain in display
+pixels. Omitted dimensions always use settings stored in points, regardless
+of `unit`.
 
 `cns.figure(...)` returns the Matplotlib `Figure` and makes it current for
 subsequent plotting calls. Retain it to export a specific figure with `fig=`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -168,6 +168,7 @@ independent of `unit`. Omitted `max_width`, panel width, or panel height always
 use their settings values in points. Changing units alone does not reinterpret
 these defaults.
 
+(saving-figures)=
 ## Saving Figures
 
 For publication, save figures in vector formats:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 # Load example data
 df = cns.datasets.load_dataset("tips")
 
-# Create a figure with specific dimensions (width x height in pixels)
+# Create a figure with specific dimensions (width x height in points)
 fig = cns.figure(100, 150)
 
 # Create a boxplot
@@ -26,18 +26,48 @@ refer to column names in that DataFrame.
 
 ## Understanding Figure Dimensions
 
-cnsplots uses **pixels** for figure dimensions:
+cnsplots uses **points** for figure dimensions by default. One point is
+1/72 inch, equivalent to the logical 72-DPI units used by existing calls:
 
 ```python
-# Small figure: 80 px wide and 100 px tall
+# Small figure: 80 pt wide and 100 pt tall
 cns.figure(80, 100)
 
-# Larger figure: 150 px wide and 200 px tall
+# Larger figure: 150 pt wide and 200 pt tall
 cns.figure(150, 200)
 ```
 
-`cns.figure(width, height)` uses the conventional width-first order, and those
-values are the final canvas size in pixels.
+`cns.figure(width, height)` uses the conventional width-first order and sizes
+the whole figure canvas, including the space available for axes decorations.
+Use the keyword-only `unit` option for points (`"pt"`), inches (`"in"`), or
+millimeters (`"mm"`). These calls create equal physical sizes:
+
+```python
+cns.figure(144, 72, unit="pt")
+cns.figure(2, 1, unit="in")
+cns.figure(50.8, 25.4, unit="mm")
+```
+
+Explicit dimensions must be finite and positive, and other units are rejected.
+Omitted dimensions still use `cns.settings.figure_width` and `figure_height`
+in points, even when `unit` is set. For example, `cns.figure(width=2, unit="in")`
+is two inches wide with the default height in points.
+
+Physical size and raster pixels are different quantities. Display DPI controls
+the number of pixels per inch without changing the physical canvas size:
+
+```python
+fig = cns.figure(100, 150)
+print(fig.get_size_inches())  # [1.38888889 2.08333333] = [100 / 72, 150 / 72]
+print(fig.canvas.get_width_height())  # (200, 300) at the default display DPI of 144
+
+# 400 × 600 pixels at the default export DPI of 288, preserving the full canvas
+cns.savefig("full-canvas.png", fig=fig, bbox_inches=None)
+```
+
+The default export uses `bbox_inches="tight"`, which crops to the artists and
+adds padding in inches. Its final dimensions can therefore differ from the
+full canvas. See [Saving Figures](#saving-figures) for crop and DPI overrides.
 
 `cns.figure(...)` returns the created `matplotlib.figure.Figure` and makes it
 the current figure, so subsequent cnsplots calls still draw on it. Keep this
@@ -115,6 +145,28 @@ composed into an existing Matplotlib layout. Most return the target
 `matplotlib.axes.Axes`. `heatmapplot`, `dotplot`, `upsetplot`, and `vennplot`
 retain their backend-native return objects so callers can access their
 multi-panel layout or diagram elements.
+
+### Sizing Multipanel Figures
+
+`cns.multipanel` accepts the same units. Its `max_width` fixes the full figure
+width and controls row wrapping. Explicit panel widths and heights inherit
+the constructor's unit, or use the panel's own `unit` override:
+
+```python
+mp = cns.multipanel(max_width=180, unit="mm")
+ax_a = mp.panel("A", width=50.8, height=25.4)  # Axes area: 2 × 1 inches
+cns.boxplot(data=df, x="day", y="total_bill", ax=ax_a)
+ax_b = mp.panel("B", width=2, height=1, unit="in")  # Same axes area
+cns.barplot(data=df, x="day", y="tip", ax=ax_b)
+```
+
+Panel dimensions describe the **axes area**, not each panel's outer bounds.
+Titles, tick labels, axis labels, and margins also occupy space in the layout;
+the figure height grows with the rows and their decorations. Margins stay in
+points, while label `pad_left` and `pad_top` stay in rendered display pixels,
+independent of `unit`. Omitted `max_width`, panel width, or panel height always
+use their settings values in points. Changing units alone does not reinterpret
+these defaults.
 
 ## Saving Figures
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ cnsplots is a Python visualization library built on matplotlib and fully compati
 - **Publication-ready defaults** — Figures styled for Cell, Nature, and Science journals
 - **Adobe Illustrator compatible** — PDF fonts work seamlessly in publication workflows
 - **Familiar API** — Built on matplotlib/seaborn, easy to learn if you know these libraries
-- **Precise sizing** — Dimensions in pixels for exact control
+- **Precise sizing** — Dimensions in points, inches, or millimeters
 
 ## Quick Example
 
@@ -33,7 +33,7 @@ cnsplots is a Python visualization library built on matplotlib and fully compati
 import cnsplots as cns
 
 df = cns.datasets.load_dataset("tips")
-cns.figure(100, 150)  # Width x Height in pixels
+cns.figure(100, 150)  # Width x height in points (1/72 inch)
 cns.boxplot(data=df, x="day", y="total_bill")
 cns.savefig("figure.svg")
 ```

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -168,6 +168,14 @@ generate ggplot theme defaults.
 These defaults power figure sizing, multipanel layout, panel labels, and
 legend-placement helpers when explicit arguments are omitted.
 
+Figure and panel dimensions, multipanel width, title layout sizes, and panel
+margins are stored in points (1/72 inch). The `unit` argument on `figure`,
+`multipanel`, or `panel` converts only explicitly supplied dimensions;
+omitted dimensions keep these point-based defaults. Panel label padding
+(`panel_pad_left` and `panel_pad_top`) is in rendered display pixels.
+`figure_dpi` controls display resolution, while export DPI controls raster
+save resolution; neither changes the requested physical dimensions.
+
 ```{eval-rst}
 .. autoattribute:: cnsplots._settings.CNSSettings.figure_width
 .. autoattribute:: cnsplots._settings.CNSSettings.figure_height

--- a/examples/figure_setup.py
+++ b/examples/figure_setup.py
@@ -23,13 +23,35 @@ iris = cns.datasets.load_dataset("iris")
 # %%
 # Basic figure creation
 # ~~~~~~~~~~~~~~~~~~~~~
-# Create a figure with specified dimensions in pixels.
-# figure(width, height) uses the conventional width-first order, and those
-# requested dimensions are the final canvas size. The returned Matplotlib
-# Figure is also the current figure used by subsequent plotting calls.
+# Create a figure with specified dimensions in points (1/72 inch).
+# figure(width, height) uses width-first order and sizes the whole canvas.
+# Points are the legacy logical 72-DPI units; existing calls keep their size.
+# The returned Matplotlib Figure is also the current figure used by subsequent
+# plotting calls. Display and export DPI set pixel resolution, not physical size.
 fig = cns.figure(150, 150)
-ax = cns.placeholderplot("150x150 Figure")
+ax = cns.placeholderplot("150x150 pt Figure")
 ax.set_title("Figure Setup")
+
+
+# %%
+# Physical units and raster resolution
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ``unit="pt"`` (default), ``unit="in"``, and ``unit="mm"`` apply to explicitly
+# supplied dimensions. Omitted dimensions keep settings values in points.
+# These three calls all create a 2 x 1 inch canvas:
+for width, height, unit in [(144, 72, "pt"), (2, 1, "in"), (50.8, 25.4, "mm")]:
+    fig = cns.figure(width, height, unit=unit)
+    print(fig.get_size_inches())  # [2. 1.]
+    plt.close(fig)
+
+fig = cns.figure(100, 150)
+print(fig.get_size_inches())  # [1.38888889 2.08333333]
+print(fig.canvas.get_width_height())  # (200, 300) at default display DPI 144
+ax = cns.placeholderplot("100x150 pt Canvas")
+# At the default export DPI of 288, bbox_inches=None preserves a 400 x 600 px
+# full canvas. Default tight cropping instead encloses the artists and adds
+# pad_inches in inches, so the saved dimensions can differ from the canvas.
+# cns.savefig("full-canvas.png", fig=fig, bbox_inches=None)
 
 
 # %%
@@ -44,7 +66,7 @@ ax.set_title("Small Figure")
 # %%
 # Wider figure for more categories
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-cns.figure(100, 200)  # Wide
+cns.figure(200, 100)  # Wide
 ax = cns.boxplot(data=tips, x="day", y="total_bill", hue="sex")
 cns.take_legend_out()
 ax.set_title("Wide Figure")
@@ -232,16 +254,16 @@ ax.set_title("Save Example")
 # %%
 # Figure dimensions reference
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Common figure sizes for different purposes:
+# Example publication widths (check the target journal's current guidelines):
 #
-# - Single column (Nature/Science): max 89mm = ~252 pixels
-# - 1.5 column: max 120mm = ~340 pixels
-# - Double column: max 183mm = ~518 pixels
-# - Full page: max 178mm = ~504 pixels (with margins)
+# - 89 mm = ~252 pt
+# - 120 mm = ~340 pt
+# - 183 mm = ~519 pt
+# - 178 mm = ~505 pt
 #
-# cnsplots uses pixels at 72 DPI base for sizing.
-# The default max_width=540 in multipanel matches double column.
+# The default multipanel max_width=540 pt corresponds to 190.5 mm.
+# Use bbox_inches=None on export to preserve the requested canvas size.
 
-cns.figure(150, 252)  # Single column width
+cns.figure(width=89, height=53, unit="mm")
 ax = cns.boxplot(data=tips, x="day", y="total_bill")
 ax.set_title("Single Column Width (89mm)")

--- a/examples/multipanel.py
+++ b/examples/multipanel.py
@@ -6,7 +6,7 @@ Create multi-panel figures in Cell, Nature, Science journal style.
 
 Multi-panel figures are essential for scientific publications. cnsplots
 provides automatic panel labeling (A, B, C...), flexible layouts, and
-precise control over figure dimensions in pixels.
+precise control over figure dimensions in points, inches, or millimeters.
 """
 
 # %%
@@ -23,7 +23,9 @@ iris = cns.datasets.load_dataset("iris")
 # Basic 2x2 multi-panel figure
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Create a simple grid layout with different panel sizes.
-# Each panel has explicit size: ``mp.panel(label, width, height)``.
+# ``mp.panel(label, width, height)`` sizes each axes area in points by default.
+# ``max_width`` fixes the full figure width and controls row wrapping. Labels,
+# titles, and margins take additional space; the height grows with the layout.
 # Labels (A, B, C, D) are automatically added in bold, 8pt font.
 mp = cns.multipanel(max_width=265)
 
@@ -38,6 +40,27 @@ cns.violinplot(data=iris, x="species", y="sepal_width")
 
 mp.panel("D", 80, 120)
 cns.stripplot(data=tips, x="day", y="tip", hue="sex")
+
+
+# %%
+# Physical units
+# ~~~~~~~~~~~~~~
+# Explicit panel dimensions inherit ``unit`` from the multipanel constructor.
+# A panel can override the unit; both axes below are 2 x 1 inches.
+# Omitted dimensions still use settings values in points. Panel margins also
+# stay in points, while label pad_left/pad_top remain rendered display pixels.
+mp = cns.multipanel(max_width=180, unit="mm")
+
+mp.panel("A", width=50.8, height=25.4)
+cns.boxplot(data=tips, x="day", y="total_bill")
+
+mp.panel("B", width=2, height=1, unit="in")
+cns.barplot(data=tips, x="day", y="tip")
+
+# Display/export DPI set raster resolution without changing physical sizes.
+# bbox_inches=None preserves the complete 180 mm-wide canvas on export;
+# default tight cropping encloses artists plus pad_inches (in inches).
+# cns.savefig("multipanel-full.pdf", bbox_inches=None)
 
 
 # %%

--- a/src/cnsplots/_agent_skill/cnsplots/SKILL.md
+++ b/src/cnsplots/_agent_skill/cnsplots/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cnsplots
-description: Create, revise, and troubleshoot publication-ready scientific plots in Python with cnsplots, including distribution, regression, heatmap, genomics, survival, set, flow, and multi-panel figures. Use when a user asks for cnsplots code, Cell/Nature/Science-style visualization, precise pixel-sized figures, statistical plot annotations, or editable SVG/PDF publication output.
+description: Create, revise, and troubleshoot publication-ready scientific plots in Python with cnsplots, including distribution, regression, heatmap, genomics, survival, set, flow, and multi-panel figures. Use when a user asks for cnsplots code, Cell/Nature/Science-style visualization, precise physical figure dimensions, statistical plot annotations, or editable SVG/PDF publication output.
 ---
 
 # CNSPlots
@@ -43,9 +43,16 @@ artifact.
    - In headless execution, set `MPLBACKEND=Agg` or call
      `matplotlib.use("Agg")` before importing plotting backends.
    - Start single-panel figures with `fig = cns.figure(width=..., height=...)`.
-     Dimensions are in pixels. The returned Matplotlib `Figure` becomes current.
+     Dimensions size the whole canvas in points (1/72 inch) by default, with
+     `unit="pt"`, `unit="in"`, or `unit="mm"` for explicit dimensions.
+     Omitted dimensions always use settings stored in points. The returned
+     Matplotlib `Figure` becomes current.
    - Pass `ax=` explicitly when composing with existing Matplotlib axes.
-   - Use `cns.multipanel` for labeled publication panels.
+   - Use `cns.multipanel` for labeled publication panels. Its `max_width` sets
+     the full figure width; explicit panel dimensions inherit its `unit` or
+     override it per panel. Panel sizes describe axes area, with decorations
+     and margins adding layout space. Margins stay in points; label
+     `pad_left`/`pad_top` stay in rendered display pixels.
    - Add titles and axis labels through the returned Matplotlib axes.
    - Use `cns.settings.context(...)` for temporary style overrides rather than
      leaving global settings changed.
@@ -55,7 +62,11 @@ artifact.
      save the current figure. Prefer SVG or PDF for editable publication output
      and PNG for a raster preview. Per-save `dpi`, `transparent`, `bbox_inches`,
      and `pad_inches` override export settings; `bbox_inches=None` preserves
-     the full canvas, and padding applies only to tight cropping.
+     the full canvas, and padding in inches applies only to tight cropping.
+     DPI controls raster resolution, not physical size: `cns.figure(100, 150)`
+     is 100/72 × 150/72 inches, or a 200 × 300 pixel canvas at default display
+     DPI 144. At default export DPI 288 it saves as 400 × 600 pixels with
+     `bbox_inches=None`; default tight cropping changes the saved bounds.
    - Run the complete script, confirm the output exists and is non-empty, and
      inspect or render it when visual tools are available.
    - Check clipping, unreadable labels, misleading scales, legend collisions,

--- a/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
+++ b/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
@@ -72,10 +72,13 @@ input columns expected by the installed version.
 
 ## Figure composition and export
 
-- `figure`: initialize a styled single-panel canvas in pixel dimensions and
-  return the Matplotlib `Figure`, which also becomes current.
-- `multipanel`: create labeled, pixel-sized panels; `panel(...)` returns the
-  target `Axes`.
+- `figure`: size a styled whole canvas in points (1/72 inch) by default, or
+  explicitly use `unit="pt"`, `unit="in"`, or `unit="mm"`. Return the
+  Matplotlib `Figure`, which also becomes current.
+- `multipanel`: set the full canvas width with `max_width` and create labeled
+  panels. Explicit panel dimensions inherit the constructor's `unit`, with
+  a per-panel override. `panel(...)` sizes the axes area and returns the target
+  `Axes`; decorations and margins occupy additional space in the layout.
 - `add_panel_label`: label an existing axes.
 - `take_legend_out`: position a legend outside its axes.
 - `savefig`: save the current figure or an explicit `fig=`, with per-save DPI,
@@ -98,6 +101,18 @@ cns.scatterplot(data=continuous, x="x", y="y", ax=ax_b)
 
 cns.savefig("multipanel.svg")
 ```
+
+All dimensions above are in points. For physical units, use, for example,
+`mp = cns.multipanel(max_width=180, unit="mm")` and
+`mp.panel("A", width=50.8, height=25.4)` for a 2 × 1 inch axes area, or
+`mp.panel("B", width=2, height=1, unit="in")` for an equivalent panel.
+Omitted dimensions always use settings stored in points. Panel margins remain
+in points, and label `pad_left`/`pad_top` remain in display pixels, regardless
+of `unit`.
+
+Display and export DPI determine raster resolution without changing physical
+size. Default tight cropping exports the artists' bounds plus `pad_inches`
+in inches; set `bbox_inches=None` to preserve the full canvas size.
 
 See the current API documentation at <https://cnsplots.farid.one/latest/api.html>
 when web access is available.

--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any, Literal, Optional, cast
 
@@ -16,22 +15,15 @@ from matplotlib.transforms import Bbox
 import cnsplots._utils as utils
 from cnsplots._settings import settings
 from cnsplots._setup import ColorCycle, setup_matplotlib
+from cnsplots._sizing import (
+    _SizeUnit,
+    _dimension_to_points,
+    _validate_positive_finite_dimension,
+)
 
 _LEFT_DECORATION_TOLERANCE_PX = 0.5
 _RELAYOUT_MAX_PASSES = 3
 _TitleLocation = Literal["left", "center", "right"]
-
-
-def _validate_positive_finite_dimension(
-    name: str,
-    value: int | float,
-) -> int | float:
-    """Validate a dimension used to construct a matplotlib figure or axes."""
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise TypeError(f"{name} must be a number")
-    if not math.isfinite(value) or value <= 0:
-        raise ValueError(f"{name} must be a positive finite number")
-    return value
 
 
 @dataclass
@@ -254,15 +246,28 @@ class multipanel:
 
     Parameters
     ----------
-    max_width : int, optional
-        Maximum figure width in pixels (default: 540). Panels wrap to new
-        rows when this width would be exceeded.
+    max_width : int or float, optional
+        Figure width and panel wrapping limit in ``unit``. If None, use
+        cns.settings.multipanel_max_width in points (default: 540), regardless
+        of ``unit``. Panels wrap to new rows when this width would be exceeded.
     title : str or None, optional
         Figure-level title shown above the panel grid (default: None).
     loc : {'left', 'center', 'right'}, optional
         Horizontal alignment for the figure title (default: 'center').
     title_fontweight : str or int, optional
         Font weight for the figure title (default: 'bold').
+    unit : {'pt', 'in', 'mm'}, default: 'pt'
+        Unit for explicit max_width and subsequent panel width/height values:
+        points (1/72 inch), inches, or millimeters. Each panel can override it.
+        Omitted dimensions use settings in points. Margins remain in points
+        and label padding remains in display pixels, independent of ``unit``.
+
+    Raises
+    ------
+    TypeError
+        If max_width is not numeric or is a boolean.
+    ValueError
+        If max_width is nonpositive or nonfinite, or the unit is unsupported.
 
     Attributes
     ----------
@@ -292,6 +297,15 @@ class multipanel:
 
     Notes
     -----
+    Default dimensions are logical 72-DPI units, numerically equal to points.
+    Panel width/height describe the axes area; figure height includes panel
+    margins, labels, axis decorations, and the optional title band. Display
+    pixels equal inches times ``cns.settings.figure_dpi`` (default: 144).
+    Export uses ``cns.settings.savefig_dpi`` (default: 288); default tight
+    cropping fits artists plus padding in inches, so saved dimensions can
+    differ from the full canvas. Use ``savefig(..., bbox_inches=None)`` to
+    preserve the full canvas bounds.
+
     Panel layout structure::
 
         +------------------------------------------------+
@@ -326,15 +340,18 @@ class multipanel:
         title: str | None = None,
         loc: str | None = None,
         title_fontweight: str | int = "bold",
+        *,
+        unit: _SizeUnit = "pt",
     ) -> None:
-        if max_width is None:
-            max_width = settings.multipanel_max_width
         if loc is None:
             loc = settings.multipanel_title_loc
-        self._max_width = _validate_positive_finite_dimension(
+        self._max_width = _dimension_to_points(
             "max_width",
             max_width,
+            unit,
+            default=settings.multipanel_max_width,
         )
+        self._unit = unit
         self._title = title
         self._title_loc = _validate_title_loc(loc)
         self._title_fontweight = _validate_title_fontweight(title_fontweight)
@@ -388,12 +405,12 @@ class multipanel:
         return float(panel.get("top_decoration_height_px", 0.0))
 
     def _get_layout_scale(self) -> float:
-        """Get the display-to-layout pixel scale used by multipanel geometry."""
+        """Get display pixels per logical point used by multipanel geometry."""
         dpi = self.fig.dpi if self.fig is not None else settings.figure_dpi
         return dpi / 72
 
     def _display_px_to_layout_px(self, value: float) -> float:
-        """Convert rendered pixels into multipanel layout pixels."""
+        """Convert rendered pixels into multipanel layout points."""
         return value / self._get_layout_scale()
 
     def _get_label_gap_px(self, panel: _Panel | dict[str, Any]) -> float:
@@ -401,7 +418,7 @@ class multipanel:
         return self._get_left_decoration_width_px(panel) + panel.get("pad_left", 0)
 
     def _get_left_reserve_px(self, panel: _Panel | dict[str, Any]) -> float:
-        """Get total left reserve in layout pixels for panel geometry."""
+        """Get total left reserve in layout points for panel geometry."""
         return self._display_px_to_layout_px(
             self._get_label_width_px(panel) + self._get_label_gap_px(panel)
         )
@@ -413,7 +430,7 @@ class multipanel:
         )
 
     def _get_top_reserve_px(self, panel: _Panel | dict[str, Any]) -> float:
-        """Get total top reserve in layout pixels for panel geometry."""
+        """Get total top reserve in layout points for panel geometry."""
         return self._display_px_to_layout_px(
             self._get_label_height_px(panel) + self._get_top_label_offset_px(panel)
         )
@@ -772,7 +789,7 @@ class multipanel:
         fig_height_px = title_height_px + sum(self._row_heights)
         fig_width_px = self._max_width
 
-        # Convert pixels to inches (72 dpi base)
+        # Convert logical layout points to inches.
         fig_width = fig_width_px / 72
         fig_height = fig_height_px / 72
 
@@ -912,6 +929,7 @@ class multipanel:
         color_cycle: ColorCycle | None = None,
         color_map: str | None = None,
         below: str | None = None,
+        unit: _SizeUnit | None = None,
     ) -> Axes:
         """
         Add a panel with specified dimensions, padding, and margins.
@@ -921,31 +939,33 @@ class multipanel:
         label : str or None, optional
             Panel label (e.g., "A", "B", "C"). If None, uses automatic
             sequential labeling (A, B, C, ...).
-        width : int, optional
-            Axes width in pixels. If None, uses cns.settings.panel_width.
-        height : int, optional
-            Axes height in pixels. If None, uses cns.settings.panel_height.
+        width : int or float, optional
+            Axes width in ``unit``. If None, use cns.settings.panel_width
+            in points, regardless of ``unit``.
+        height : int or float, optional
+            Axes height in ``unit``. If None, use cns.settings.panel_height
+            in points, regardless of ``unit``.
         pad_left : int, optional
-            Extra horizontal gap in pixels between the panel label and the
+            Extra horizontal gap in display pixels between the panel label and the
             leftmost visible left-side axis decoration. The layout reserves the
             rendered width of y-axis decorations plus this gap. If no left-side
             decorations are visible, the panel label sits ``pad_left`` pixels to
             the left of the axes. If None, uses cns.settings.panel_pad_left.
         pad_top : int, optional
-            Extra vertical gap in pixels between the panel label and the
+            Extra vertical gap in display pixels between the panel label and the
             topmost visible top-side axis decoration, such as the axes title.
             The layout reserves the rendered height of those decorations plus
             this gap. If no top-side decorations are visible, the panel label's
             bottom edge sits ``pad_top`` pixels above the axes. If None, uses
             cns.settings.panel_pad_top.
         margin_top : int, optional
-            Top margin in pixels. If None, uses cns.settings.panel_margin_top.
+            Top margin in points. If None, uses cns.settings.panel_margin_top.
         margin_bottom : int, optional
-            Bottom margin in pixels. If None, uses cns.settings.panel_margin_bottom.
+            Bottom margin in points. If None, uses cns.settings.panel_margin_bottom.
         margin_left : int, optional
-            Left margin in pixels. If None, uses cns.settings.panel_margin_left.
+            Left margin in points. If None, uses cns.settings.panel_margin_left.
         margin_right : int, optional
-            Right margin in pixels. If None, uses cns.settings.panel_margin_right.
+            Right margin in points. If None, uses cns.settings.panel_margin_right.
         color_cycle : str or sequence of matplotlib colors, optional
             Color palette name or explicit color sequence for this panel. If
             None, uses cns.settings.palette_qual.
@@ -955,11 +975,22 @@ class multipanel:
             Label of another panel to stack this panel below (e.g., "D").
             The panel is positioned directly below the specified panel
             instead of flowing in the normal left-to-right layout.
+        unit : {'pt', 'in', 'mm'} or None, optional
+            Unit for explicitly supplied width and height. If None, inherit
+            the unit passed to multipanel (default: 'pt'). Margins stay in
+            points and label padding stays in display pixels for all units.
 
         Returns
         -------
         ax : matplotlib.axes.Axes
             The matplotlib axes object for plotting.
+
+        Raises
+        ------
+        TypeError
+            If a dimension is not numeric or is a boolean.
+        ValueError
+            If a dimension is nonpositive or nonfinite, or the unit is unsupported.
 
         Examples
         --------
@@ -995,7 +1026,8 @@ class multipanel:
 
         Notes
         -----
-        Total panel dimensions are calculated as:
+        After converting dimensions, margins, and rendered measurements to
+        a common physical unit, total panel dimensions are calculated as:
 
         - Total width = margin_left + label width + left decorations + pad_left
           + width + margin_right
@@ -1010,10 +1042,6 @@ class multipanel:
             color_cycle = settings.palette_qual
         if color_map is None:
             color_map = settings.palette_seq
-        if width is None:
-            width = settings.panel_width
-        if height is None:
-            height = settings.panel_height
         if pad_left is None:
             pad_left = settings.panel_pad_left
         if pad_top is None:
@@ -1027,8 +1055,12 @@ class multipanel:
         if margin_bottom is None:
             margin_bottom = settings.panel_margin_bottom
 
-        width = _validate_positive_finite_dimension("width", width)
-        height = _validate_positive_finite_dimension("height", height)
+        if unit is None:
+            unit = self._unit
+        width = _dimension_to_points("width", width, unit, default=settings.panel_width)
+        height = _dimension_to_points(
+            "height", height, unit, default=settings.panel_height
+        )
 
         if label is None:
             if self._panel_index >= len(self._labels):

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -279,17 +279,17 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
     "savefig_bbox": _spec(
         "tight",
         lambda value: _validate_string("savefig_bbox", value),
-        "Default savefig bounding box mode.",
+        "Default savefig bounds; 'tight' crops to artists, so output size can differ from the full canvas.",
     ),
     "savefig_pad_inches": _spec(
         0.01,
         lambda value: _validate_number("savefig_pad_inches", value, positive=True),
-        "Default savefig padding in inches.",
+        "Default savefig padding in inches around tight bounds.",
     ),
     "savefig_dpi": _spec(
         72 * 4,
         lambda value: _validate_number("savefig_dpi", value, positive=True),
-        "Default savefig DPI.",
+        "Default export pixels per inch for raster output and rasterized vector content.",
     ),
     "savefig_transparent": _spec(
         True,
@@ -528,22 +528,22 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
     "figure_width": _spec(
         150,
         lambda value: _validate_number("figure_width", value, positive=True),
-        "Default figure width in pixels for figure().",
+        "Default full figure width in points (1/72 inch) for figure().",
     ),
     "figure_height": _spec(
         150,
         lambda value: _validate_number("figure_height", value, positive=True),
-        "Default figure height in pixels for figure().",
+        "Default full figure height in points (1/72 inch) for figure().",
     ),
     "figure_dpi": _spec(
         72 * 2,
         lambda value: _validate_number("figure_dpi", value, positive=True),
-        "Default figure DPI for figure helpers.",
+        "Display pixels per inch for figure helpers; independent of physical size and export DPI.",
     ),
     "multipanel_max_width": _spec(
         540,
         lambda value: _validate_number("multipanel_max_width", value, positive=True),
-        "Default maximum width in pixels for multipanel figures.",
+        "Default figure width and wrapping limit in points (1/72 inch) for multipanel figures.",
     ),
     "multipanel_title_loc": _spec(
         "center",
@@ -557,54 +557,54 @@ _SETTING_SPECS: dict[str, _SettingSpec] = {
         lambda value: _validate_number(
             "multipanel_title_height_min", value, non_negative=True
         ),
-        "Minimum reserved title-band height for multipanel figures.",
+        "Minimum reserved title-band height in points for multipanel figures.",
     ),
     "multipanel_title_height_pad": _spec(
         4,
         lambda value: _validate_number(
             "multipanel_title_height_pad", value, non_negative=True
         ),
-        "Extra title-band padding added to title_fontsize in multipanel figures.",
+        "Extra title-band padding in points added to title_fontsize in multipanel figures.",
     ),
     "panel_width": _spec(
         150,
         lambda value: _validate_number("panel_width", value, positive=True),
-        "Default panel width in pixels for multipanel.panel().",
+        "Default axes width in points (1/72 inch) for multipanel.panel().",
     ),
     "panel_height": _spec(
         150,
         lambda value: _validate_number("panel_height", value, positive=True),
-        "Default panel height in pixels for multipanel.panel().",
+        "Default axes height in points (1/72 inch) for multipanel.panel().",
     ),
     "panel_pad_left": _spec(
         0,
         lambda value: _validate_number("panel_pad_left", value, non_negative=True),
-        "Default left padding in pixels for multipanel.panel() and add_panel_label().",
+        "Default left padding in display pixels for multipanel.panel() and add_panel_label().",
     ),
     "panel_pad_top": _spec(
         0,
         lambda value: _validate_number("panel_pad_top", value, non_negative=True),
-        "Default top padding in pixels for multipanel.panel() and add_panel_label().",
+        "Default top padding in display pixels for multipanel.panel() and add_panel_label().",
     ),
     "panel_margin_top": _spec(
         0,
         lambda value: _validate_number("panel_margin_top", value, non_negative=True),
-        "Default top margin in pixels for multipanel.panel().",
+        "Default top margin in points (1/72 inch) for multipanel.panel().",
     ),
     "panel_margin_bottom": _spec(
         10,
         lambda value: _validate_number("panel_margin_bottom", value, non_negative=True),
-        "Default bottom margin in pixels for multipanel.panel().",
+        "Default bottom margin in points (1/72 inch) for multipanel.panel().",
     ),
     "panel_margin_left": _spec(
         0,
         lambda value: _validate_number("panel_margin_left", value, non_negative=True),
-        "Default left margin in pixels for multipanel.panel().",
+        "Default left margin in points (1/72 inch) for multipanel.panel().",
     ),
     "panel_margin_right": _spec(
         10,
         lambda value: _validate_number("panel_margin_right", value, non_negative=True),
-        "Default right margin in pixels for multipanel.panel().",
+        "Default right margin in points (1/72 inch) for multipanel.panel().",
     ),
     "panel_label_fontname": _spec(
         None,

--- a/src/cnsplots/_sizing.py
+++ b/src/cnsplots/_sizing.py
@@ -1,0 +1,39 @@
+"""Shared conversion of physical sizes to the legacy point-based layout."""
+
+from __future__ import annotations
+
+import math
+from numbers import Real
+from typing import Literal
+
+_SizeUnit = Literal["pt", "in", "mm"]
+_POINTS_PER_UNIT = {"pt": 1, "in": 72, "mm": 72 / 25.4}
+
+
+def _validate_positive_finite_dimension(
+    name: str,
+    value: int | float,
+) -> int | float:
+    """Validate a dimension used to construct a matplotlib figure or axes."""
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{name} must be a number")
+    value = float(value)
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be a positive finite number")
+    return value
+
+
+def _dimension_to_points(
+    name: str,
+    value: int | float | None,
+    unit: _SizeUnit,
+    *,
+    default: int | float,
+) -> int | float:
+    """Convert an explicit size, keeping omitted settings-based sizes in points."""
+    if not isinstance(unit, str) or unit not in _POINTS_PER_UNIT:
+        raise ValueError("unit must be one of: 'pt', 'in', or 'mm'")
+    if value is None:
+        return _validate_positive_finite_dimension(name, default)
+    value = _validate_positive_finite_dimension(name, value)
+    return _validate_positive_finite_dimension(name, value * _POINTS_PER_UNIT[unit])

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -35,6 +35,7 @@ from statannotations.utils import DEFAULT
 
 from cnsplots._settings import settings
 from cnsplots._setup import setup_matplotlib
+from cnsplots._sizing import _SizeUnit, _dimension_to_points
 from cnsplots._svg import _save_svg
 
 logger = logging.getLogger(__name__)
@@ -328,6 +329,8 @@ def figure(
     height: int | float | None = None,
     color_cycle: str | Sequence[ColorType] | None = None,
     color_map: str | None = None,
+    *,
+    unit: _SizeUnit = "pt",
 ) -> Figure:
     """
     Initialize a new figure with custom size and styling.
@@ -337,10 +340,12 @@ def figure(
 
     Parameters
     ----------
-    width : int, default: 150
-        Width of the figure in pixels.
-    height : int, default: 150
-        Height of the figure in pixels.
+    width : int or float, optional
+        Full figure width in ``unit``. If None, use cns.settings.figure_width
+        in points (default: 150), regardless of ``unit``.
+    height : int or float, optional
+        Full figure height in ``unit``. If None, use cns.settings.figure_height
+        in points (default: 150), regardless of ``unit``.
     color_cycle : str, default: None
         Name of the qualitative color palette to use for the color cycle.
         If None, uses cns.settings.palette_qual.
@@ -349,11 +354,21 @@ def figure(
         Name of the sequential colormap to use for continuous data.
         If None, uses cns.settings.palette_seq.
         Options include: 'gnuplot', 'parula', 'bwr', 'hot', etc.
+    unit : {'pt', 'in', 'mm'}, default: 'pt'
+        Unit for explicitly supplied width and height: points (1/72 inch),
+        inches, or millimeters. The default preserves legacy numerical sizes.
 
     Returns
     -------
     matplotlib.figure.Figure
         The newly created figure, which is also the current pyplot figure.
+
+    Raises
+    ------
+    TypeError
+        If a dimension is not numeric or is a boolean.
+    ValueError
+        If a dimension is nonpositive or nonfinite, or the unit is unsupported.
 
     See Also
     --------
@@ -363,10 +378,17 @@ def figure(
 
     Notes
     -----
-    The function converts pixel dimensions to inches assuming 72 DPI base
-    resolution and uses ``cns.settings.figure_dpi`` for the rendered DPI.
+    Default dimensions are logical 72-DPI units, numerically equal to points:
+    inches = points / 72. They describe the full canvas, including space around
+    the axes. In contrast, ``multipanel.panel`` sizes describe the axes area.
 
-    The figure size formula is: inches = pixels / 72.
+    Display pixels = inches * ``cns.settings.figure_dpi`` (default: 144).
+    Thus ``figure(100, 150)`` has size ``(100 / 72, 150 / 72)`` inches and a
+    200 by 300 pixel canvas at the default display DPI. Export uses
+    ``cns.settings.savefig_dpi`` (default: 288), yielding 400 by 600 pixels
+    when saved with ``bbox_inches=None``. The default tight export instead
+    crops to artists plus ``pad_inches`` (in inches), so its dimensions can
+    differ from the full canvas. DPI does not change the physical figure size.
 
     This function previously returned None. Callers that ignore the return value
     continue to work; callers or type checks relying on None must be updated.
@@ -381,11 +403,16 @@ def figure(
     >>> # With custom color scheme
     >>> cns.figure(width=150, height=150, color_cycle="Set2", color_map="parula")
     >>> cns.heatmapplot(adata)
+
+    >>> # Equivalent physical sizes
+    >>> fig = cns.figure(50.8, 25.4, unit="mm")
+    >>> fig = cns.figure(2, 1, unit="in")
+    >>> fig = cns.figure(144, 72, unit="pt")
     """
-    if width is None:
-        width = settings.figure_width
-    if height is None:
-        height = settings.figure_height
+    width = _dimension_to_points("width", width, unit, default=settings.figure_width)
+    height = _dimension_to_points(
+        "height", height, unit, default=settings.figure_height
+    )
     if color_cycle is None:
         color_cycle = settings.palette_qual
     if color_map is None:

--- a/tests/test_sizing_units.py
+++ b/tests/test_sizing_units.py
@@ -1,0 +1,268 @@
+"""Regression tests for physical sizing units and the legacy point defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+
+import cnsplots as cns
+
+
+def _render(fig: Figure) -> np.ndarray:
+    canvas = cast(FigureCanvasAgg, fig.canvas)
+    canvas.draw()
+    return np.asarray(canvas.buffer_rgba()).copy()
+
+
+@pytest.mark.parametrize(
+    "unit,width,height", [("pt", 144, 108), ("in", 2, 1.5), ("mm", 50.8, 38.1)]
+)
+def test_figure_units_define_the_same_physical_size(
+    unit: Literal["pt", "in", "mm"], width: float, height: float
+) -> None:
+    with cns.settings.context(figure_dpi=144):
+        fig = cns.figure(width, height, unit=unit)
+    assert fig.get_size_inches() == pytest.approx((2, 1.5))
+    assert fig.canvas.get_width_height() == (288, 216)
+
+
+@pytest.mark.parametrize("scalar_type", [np.int64, np.float32, np.float64])
+def test_numpy_real_scalars_preserve_legacy_sizes_and_unit_conversion(
+    scalar_type: Any,
+) -> None:
+    legacy = cns.figure(scalar_type(100), scalar_type(150))
+    assert legacy.get_size_inches() == pytest.approx((100 / 72, 150 / 72))
+    dimensions: list[tuple[Literal["pt", "in", "mm"], int, float]] = [
+        ("pt", 144, 1 / 72),
+        ("in", 2, 1),
+        ("mm", 50, 1 / 25.4),
+    ]
+    for unit, width, inches_per_unit in dimensions:
+        expected = (width * inches_per_unit, width / 2 * inches_per_unit)
+        fig = cns.figure(scalar_type(width), scalar_type(width / 2), unit=unit)
+        assert fig.get_size_inches() == pytest.approx(expected)
+        mp = cns.multipanel(max_width=scalar_type(width * 3), unit=unit)
+        ax = mp.panel(width=scalar_type(width), height=scalar_type(width / 2))
+        assert mp.fig is not None
+        mp.fig.canvas.draw()
+        assert mp.fig.get_size_inches()[0] == pytest.approx(expected[0] * 3)
+        bbox = ax.get_window_extent()
+        assert np.asarray((bbox.width, bbox.height)) / mp.fig.dpi == (
+            pytest.approx(expected)
+        )
+
+
+def test_legacy_point_dimensions_and_export_dpi(tmp_path: Path) -> None:
+    with cns.settings.context(figure_dpi=144):
+        fig = cns.figure(100, 150)
+    ax = fig.add_axes((0.2, 0.2, 0.6, 0.6))
+    ax.plot([0, 1], [0, 1])
+    ax.set_axis_off()
+    assert fig.get_size_inches() == pytest.approx((100 / 72, 150 / 72))
+    assert fig.canvas.get_width_height() == (200, 300)
+
+    full_path = tmp_path / "full.png"
+    cns.savefig(full_path, fig=fig, dpi=288, bbox_inches=None)
+    assert plt.imread(full_path).shape[1::-1] == (400, 600)
+    tight_path = tmp_path / "tight.png"
+    cns.savefig(tight_path, fig=fig, dpi=288, bbox_inches="tight", pad_inches=0)
+    assert plt.imread(tight_path).shape[1::-1] != (400, 600)
+    assert fig.dpi == 144
+    assert fig.get_size_inches() == pytest.approx((100 / 72, 150 / 72))
+
+
+def test_explicit_points_preserve_legacy_figure_rendering() -> None:
+    with cns.settings.context(figure_dpi=144):
+        legacy = cns.figure(144, 108, "Set2", "parula")
+        explicit = cns.figure(144, 108, "Set2", "parula", unit="pt")
+    for fig in (legacy, explicit):
+        ax = fig.add_subplot()
+        ax.plot([0, 1, 2], [1, 0, 2])
+        ax.set_title("Physical size")
+    np.testing.assert_array_equal(_render(legacy), _render(explicit))
+
+
+def _sized_multipanel(unit: Literal["pt", "in", "mm"] | None) -> cns.multipanel:
+    points_per_unit = {None: 1, "pt": 1, "in": 72, "mm": 72 / 25.4}[unit]
+    unit_kwargs: dict[str, Any] = {} if unit is None else {"unit": unit}
+    mp = cns.multipanel(324 / points_per_unit, "Sizing", "left", **unit_kwargs)
+    for label in "ABC":
+        ax = mp.panel(
+            label,
+            width=72 / points_per_unit,
+            height=54 / points_per_unit,
+            pad_left=13,
+            pad_top=9,
+            margin_left=7,
+            margin_right=11,
+            margin_top=5,
+            margin_bottom=8,
+        )
+        ax.plot([0, 1, 2], [1, 0, 2])
+        ax.set_title("Panel")
+    assert mp.fig is not None
+    mp.fig.canvas.draw()
+    return mp
+
+
+@pytest.mark.parametrize("unit", ["pt", "in", "mm"])
+def test_multipanel_units_preserve_axes_wrapping_margins_and_pixel_padding(
+    unit: Literal["pt", "in", "mm"],
+) -> None:
+    with cns.settings.context(figure_dpi=144):
+        legacy = _sized_multipanel(None)
+        converted = _sized_multipanel(unit)
+    assert legacy.fig is not None
+    assert converted.fig is not None
+    assert converted._rows == legacy._rows == [[0, 1], [2]]
+    assert converted.fig.get_size_inches() == pytest.approx(
+        legacy.fig.get_size_inches()
+    )
+    renderer = cast(FigureCanvasAgg, converted.fig.canvas).get_renderer()
+    for actual, expected, panel in zip(
+        converted.axes, legacy.axes, converted._panels, strict=True
+    ):
+        assert actual.get_position().bounds == pytest.approx(
+            expected.get_position().bounds
+        )
+        bbox = actual.get_window_extent(renderer=renderer)
+        assert np.asarray((bbox.width, bbox.height)) / converted.fig.dpi == (
+            pytest.approx((1, 0.75))
+        )
+        assert (panel.margin_left, panel.margin_right) == (7, 11)
+        assert (panel.margin_top, panel.margin_bottom) == (5, 8)
+        label_bbox = converted._label_texts[panel.label].get_window_extent(renderer)
+        yaxis_bbox = actual.yaxis.get_tightbbox(renderer)
+        assert yaxis_bbox is not None
+        assert yaxis_bbox.x0 - label_bbox.x1 == pytest.approx(13, abs=0.8)
+        assert label_bbox.y0 - actual.title.get_window_extent(renderer).y1 == (
+            pytest.approx(9, abs=0.8)
+        )
+    if unit == "pt":
+        np.testing.assert_array_equal(_render(legacy.fig), _render(converted.fig))
+
+
+@pytest.mark.parametrize("unit,two_inches", [("in", 2), ("mm", 50.8)])
+def test_omitted_dimensions_keep_settings_in_points(
+    unit: Literal["in", "mm"], two_inches: float
+) -> None:
+    with cns.settings.context(
+        figure_width=216,
+        figure_height=108,
+        multipanel_max_width=360,
+        panel_width=72,
+        panel_height=54,
+        figure_dpi=144,
+    ):
+        assert cns.figure(unit=unit).get_size_inches() == pytest.approx((3, 1.5))
+        assert cns.figure(width=two_inches, unit=unit).get_size_inches() == (
+            pytest.approx((2, 1.5))
+        )
+        assert cns.figure(height=two_inches, unit=unit).get_size_inches() == (
+            pytest.approx((3, 2))
+        )
+        mp = cns.multipanel(unit=unit)
+        mp.panel("A")
+        mp.panel("B", width=two_inches)
+        mp.panel("C", height=two_inches, unit=None)
+        assert mp.fig is not None
+        mp.fig.canvas.draw()
+        assert mp.fig.get_size_inches()[0] == pytest.approx(5)
+        for ax, expected in zip(mp.axes, [(1, 0.75), (2, 0.75), (1, 2)], strict=True):
+            bbox = ax.get_window_extent()
+            assert np.asarray((bbox.width, bbox.height)) / mp.fig.dpi == (
+                pytest.approx(expected)
+            )
+
+
+def test_panel_unit_override_does_not_change_inherited_units() -> None:
+    mp = cns.multipanel(max_width=8, unit="in")
+    mp.panel("A", width=25.4, height=12.7, unit="mm")
+    mp.panel("B", width=72, height=36, unit="pt")
+    mp.panel("C", width=1, height=0.5)
+    mp.panel("D", width=1, height=0.5, unit=None)
+    assert mp.fig is not None
+    mp.fig.canvas.draw()
+    for ax in mp.axes:
+        bbox = ax.get_window_extent()
+        assert np.asarray((bbox.width, bbox.height)) / mp.fig.dpi == (
+            pytest.approx((1, 0.5))
+        )
+
+
+@pytest.mark.parametrize("unit", ["px", "inch", "PT", "", 1, ["pt"]])
+def test_invalid_units_leave_figures_and_panel_state_unchanged(unit: Any) -> None:
+    mp = cns.multipanel()
+    ax = mp.panel("A", width=72, height=54)
+    assert mp.fig is not None
+    before_pixels = _render(mp.fig)
+    before_rc = dict(plt.rcParams)
+    before_figures = plt.get_fignums()
+    before_panel = vars(mp._panels[0]).copy()
+    for make in (cns.figure, cns.multipanel, mp.panel):
+        with pytest.raises(ValueError, match="unit"):
+            cast(Any, make)(unit=unit)
+        assert plt.get_fignums() == before_figures
+        assert plt.gcf() is mp.fig
+        assert dict(plt.rcParams) == before_rc
+        assert mp.axes == [ax]
+        assert mp._panel_index == 1
+        assert len(mp._panels) == 1
+        assert vars(mp._panels[0]) == before_panel
+        np.testing.assert_array_equal(_render(mp.fig), before_pixels)
+    empty = cns.multipanel()
+    with pytest.raises(ValueError, match="unit"):
+        cast(Any, empty.panel)(unit=unit)
+    assert empty.fig is None
+    assert empty._panels == []
+
+
+def test_none_unit_is_only_valid_for_panel_inheritance() -> None:
+    before = plt.get_fignums()
+    for make in (cns.figure, cns.multipanel):
+        with pytest.raises(ValueError, match="unit"):
+            cast(Any, make)(unit=None)
+    assert plt.get_fignums() == before
+
+
+@pytest.mark.parametrize("dimension", ["width", "height"])
+@pytest.mark.parametrize(
+    "value,error",
+    [
+        (True, TypeError),
+        ("2", TypeError),
+        (1j, TypeError),
+        (0, ValueError),
+        (-1, ValueError),
+        (np.nan, ValueError),
+        (np.inf, ValueError),
+        (-np.inf, ValueError),
+    ],
+)
+def test_invalid_dimensions_leave_existing_state_unchanged(
+    dimension: str, value: Any, error: type[Exception]
+) -> None:
+    mp = cns.multipanel(unit="in")
+    ax = mp.panel("A", width=1, height=0.75)
+    assert mp.fig is not None
+    before_pixels = _render(mp.fig)
+    before_rc = dict(plt.rcParams)
+    before_figures = plt.get_fignums()
+    for make in (cns.figure, mp.panel):
+        with pytest.raises(error, match=dimension):
+            cast(Any, make)(**{dimension: value}, unit="mm")
+        assert plt.get_fignums() == before_figures
+        assert plt.gcf() is mp.fig
+        assert dict(plt.rcParams) == before_rc
+        assert mp.axes == [ax]
+        assert len(mp._panels) == mp._panel_index == 1
+        np.testing.assert_array_equal(_render(mp.fig), before_pixels)
+    with pytest.raises(error, match="max_width"):
+        cns.multipanel(max_width=value, unit="in")
+    assert plt.get_fignums() == before_figures

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -31,6 +31,9 @@ if TYPE_CHECKING:
 
         fig = cns.figure(width=120, height=80)
         assert_type(fig, Figure)
+        assert_type(cns.figure(2, 1.5, unit="in"), Figure)
+        assert_type(cns.figure(50.8, 38.1, unit="mm"), Figure)
+        assert_type(cns.figure(144, 108, unit="pt"), Figure)
         assert_type(cns.savefig("figure.svg"), None)
         assert_type(
             cns.savefig(
@@ -69,6 +72,12 @@ if TYPE_CHECKING:
 
         panels = cns.multipanel()
         assert_type(panels.panel("A", color_cycle=("red", "blue")), Axes)
+        sized_panels = cns.multipanel(max_width=7, unit="in")
+        assert_type(sized_panels, cns.multipanel)
+        assert_type(sized_panels.panel("A", width=2, height=1.5), Axes)
+        assert_type(sized_panels.panel("B", width=50.8, unit="mm"), Axes)
+        assert_type(sized_panels.panel("C", width=144, unit="pt"), Axes)
+        assert_type(sized_panels.panel("D", width=2, unit=None), Axes)
 
         showcase = cns.datasets.get_showcase_data()
         assert_type(showcase[0], pd.DataFrame)


### PR DESCRIPTION
## What changed

Add physical sizing units while preserving the existing point-based numerical defaults, and correct the documentation that described those dimensions as final raster pixels.

- Share validation and conversion for `unit="pt"`, `"in"`, and `"mm"` across `figure`, `multipanel`, and panel dimensions, including per-panel overrides and NumPy scalar sizes.
- Document canvas versus axes dimensions, settings defaults, margins/padding, display and export DPI, and tight cropping throughout the README, docstrings, getting-started guide, examples, and bundled plotting guidance.
- Add regression and typing coverage for unit equivalence, legacy rendering, invalid inputs, and documented raster dimensions.

## How it was tested

- `make test` — 1,073 tests passed with 100% coverage.
- `make lint` — all applicable checks passed, including type checking.
- Strict Sphinx HTML build (all 37 gallery examples) and documentation link checks passed.
- Executed `examples/figure_setup.py` and `examples/multipanel.py` with the Agg backend; the documented size calculations match the runtime output.

## Risks or follow-ups

The unit option applies only to explicitly supplied width, height, and maximum width. Omitted dimensions and panel margins retain point units; label padding retains display-pixel units. Invalid figure sizes now fail early. Existing valid sizes and rendering defaults are preserved.

Closes #141
Closes #142
