### PR TITLE
✨ Improve dataset access and discovery

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -142,6 +142,28 @@ diagram object, respectively.
 The gallery datasets are bundled with cnsplots, so loading them does not
 require network access.
 
+Discover the packaged tabular datasets without loading them:
+
+```python
+import cnsplots as cns
+
+cns.datasets.get_dataset_names()
+# ['flights', 'fmri', 'iris', 'penguins', 'tips']
+tips = cns.datasets.load_dataset("tips")
+```
+
+Showcase results support named access as well as the existing positional
+indexing and unpacking. The default `ShowcaseData` has 13 fields;
+`include_showcase_images=True` returns `ShowcaseDataWithImages` with the same
+fields followed by `showcase_images` as the 14th field. Both modes generate
+all showcase datasets, so named access selects from the complete result:
+
+```python
+survival_df = cns.datasets.get_showcase_data().survival_df
+showcase = cns.datasets.get_showcase_data(include_showcase_images=True)
+images = showcase.showcase_images
+```
+
 ```{eval-rst}
 .. currentmodule:: cnsplots.datasets
 .. apirootsummary::
@@ -149,7 +171,10 @@ require network access.
    :nosignatures:
 
    load_dataset
+   get_dataset_names
    get_showcase_data
+   ShowcaseData
+   ShowcaseDataWithImages
 ```
 
 ## Configuration & Setup

--- a/src/cnsplots/datasets/__init__.py
+++ b/src/cnsplots/datasets/__init__.py
@@ -1,7 +1,18 @@
 """Packaged datasets used by the documentation gallery."""
 
 from cnsplots.datasets import gallery
-from cnsplots.datasets._loader import load_dataset
-from cnsplots.datasets.gallery import get_showcase_data
+from cnsplots.datasets._loader import get_dataset_names, load_dataset
+from cnsplots.datasets.gallery import (
+    ShowcaseData,
+    ShowcaseDataWithImages,
+    get_showcase_data,
+)
 
-__all__ = ("gallery", "get_showcase_data", "load_dataset")
+__all__ = (
+    "ShowcaseData",
+    "ShowcaseDataWithImages",
+    "gallery",
+    "get_dataset_names",
+    "get_showcase_data",
+    "load_dataset",
+)

--- a/src/cnsplots/datasets/_loader.py
+++ b/src/cnsplots/datasets/_loader.py
@@ -7,6 +7,17 @@ import pandas as pd
 _DATASET_NAMES = frozenset({"flights", "fmri", "iris", "penguins", "tips"})
 
 
+def get_dataset_names() -> list[str]:
+    """List the packaged example datasets without loading data or using the network.
+
+    Returns
+    -------
+    list[str]
+        A new, alphabetically sorted list of names accepted by ``load_dataset``.
+    """
+    return sorted(_DATASET_NAMES)
+
+
 def load_dataset(name: str) -> pd.DataFrame:
     """Load a packaged example dataset without network access.
 

--- a/src/cnsplots/datasets/gallery.py
+++ b/src/cnsplots/datasets/gallery.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from importlib import resources
-from typing import TYPE_CHECKING, Literal, TypeAlias, overload
+from typing import TYPE_CHECKING, Literal, NamedTuple, overload
 
 if sys.version_info >= (3, 11):
     from importlib.resources.abc import Traversable  # pragma: no cover
@@ -15,42 +15,42 @@ if TYPE_CHECKING:
     import pandas as pd
     from anndata import AnnData
 
-    _ShowcaseData: TypeAlias = tuple[
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        AnnData,
-        pd.DataFrame,
-        list[set[str]],
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        dict[str, set[str]],
-    ]
-    _ShowcaseDataWithImages: TypeAlias = tuple[
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        AnnData,
-        pd.DataFrame,
-        list[set[str]],
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        pd.DataFrame,
-        dict[str, set[str]],
-        Traversable,
-    ]
-else:
-    # Keep importing the datasets namespace lightweight while allowing
-    # typing.get_type_hints() to resolve the public function at runtime.
-    _ShowcaseData = tuple[object, ...]
-    _ShowcaseDataWithImages = tuple[object, ...]
+
+class ShowcaseData(NamedTuple):
+    """Named showcase datasets in the original 13-item sequence order."""
+
+    iris_df: pd.DataFrame
+    tips_df: pd.DataFrame
+    survival_df: pd.DataFrame
+    blobs: AnnData
+    volcano_df: pd.DataFrame
+    gene_sets: list[set[str]]
+    roc_df: pd.DataFrame
+    slope_df: pd.DataFrame
+    confusion_df: pd.DataFrame
+    line_df: pd.DataFrame
+    cumulative_incidence_df: pd.DataFrame
+    forest_df: pd.DataFrame
+    upset_sets: dict[str, set[str]]
+
+
+class ShowcaseDataWithImages(NamedTuple):
+    """The same 13 showcase datasets followed by packaged showcase images."""
+
+    iris_df: pd.DataFrame
+    tips_df: pd.DataFrame
+    survival_df: pd.DataFrame
+    blobs: AnnData
+    volcano_df: pd.DataFrame
+    gene_sets: list[set[str]]
+    roc_df: pd.DataFrame
+    slope_df: pd.DataFrame
+    confusion_df: pd.DataFrame
+    line_df: pd.DataFrame
+    cumulative_incidence_df: pd.DataFrame
+    forest_df: pd.DataFrame
+    upset_sets: dict[str, set[str]]
+    showcase_images: Traversable
 
 
 def _showcase_images() -> Traversable:
@@ -61,24 +61,24 @@ def _showcase_images() -> Traversable:
 @overload
 def get_showcase_data(
     *, include_showcase_images: Literal[False] = False
-) -> _ShowcaseData: ...
+) -> ShowcaseData: ...
 
 
 @overload
 def get_showcase_data(
     *, include_showcase_images: Literal[True]
-) -> _ShowcaseDataWithImages: ...
+) -> ShowcaseDataWithImages: ...
 
 
 @overload
 def get_showcase_data(
     *, include_showcase_images: bool
-) -> _ShowcaseData | _ShowcaseDataWithImages: ...
+) -> ShowcaseData | ShowcaseDataWithImages: ...
 
 
 def get_showcase_data(
     *, include_showcase_images: bool = False
-) -> _ShowcaseData | _ShowcaseDataWithImages:
+) -> ShowcaseData | ShowcaseDataWithImages:
     """Load deterministic showcase datasets and optional packaged images.
 
     Parameters
@@ -86,6 +86,23 @@ def get_showcase_data(
     include_showcase_images : bool, default: False
         When True, append the traversable packaged image directory to the
         returned tuple.
+
+    Returns
+    -------
+    ShowcaseData or ShowcaseDataWithImages
+        Named tuple containing, in order: ``iris_df``, ``tips_df``,
+        ``survival_df``, ``blobs``, ``volcano_df``, ``gene_sets``, ``roc_df``,
+        ``slope_df``, ``confusion_df``, ``line_df``, ``cumulative_incidence_df``,
+        ``forest_df``, and ``upset_sets``. With images enabled,
+        ``showcase_images`` is the 14th field. Existing positional indexing
+        and 13- or 14-item unpacking are supported.
+
+    Examples
+    --------
+    Access a dataset by name without unpacking the other values:
+
+    >>> survival_df = get_showcase_data().survival_df
+    >>> images = get_showcase_data(include_showcase_images=True).showcase_images
     """
     import numpy as np
     import pandas as pd
@@ -246,7 +263,7 @@ def get_showcase_data(
         | set(genes[44:52]),
     }
 
-    data = (
+    data = ShowcaseData(
         iris_df,
         tips_df,
         survival_df,
@@ -262,5 +279,5 @@ def get_showcase_data(
         upset_sets,
     )
     if include_showcase_images:
-        return (*data, _showcase_images())
+        return ShowcaseDataWithImages(*data, _showcase_images())
     return data

--- a/tests/test_dataset_names.py
+++ b/tests/test_dataset_names.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+from importlib import resources
+from typing import get_type_hints
+
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+from cnsplots.datasets import _loader
+
+
+def test_get_dataset_names_lists_every_packaged_dataset() -> None:
+    data_root = resources.files("cnsplots.datasets").joinpath("_data")
+    packaged_names = sorted(
+        entry.name.removesuffix(".csv")
+        for entry in data_root.iterdir()
+        if entry.is_file() and entry.name.endswith(".csv")
+    )
+
+    names = cns.datasets.get_dataset_names()
+
+    assert names == packaged_names
+    for name in names:
+        assert not cns.datasets.load_dataset(name).empty
+
+
+def test_get_dataset_names_returns_sorted_independent_lists() -> None:
+    first = cns.datasets.get_dataset_names()
+    second = cns.datasets.get_dataset_names()
+
+    assert first == second == ["flights", "fmri", "iris", "penguins", "tips"]
+    assert first is not second
+    first.clear()
+    first.append("missing")
+    assert cns.datasets.get_dataset_names() == second
+    assert get_type_hints(cns.datasets.get_dataset_names)["return"] == list[str]
+
+
+def test_get_dataset_names_does_not_load_data_or_use_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_io(*args: object, **kwargs: object) -> None:
+        raise AssertionError("Dataset discovery must not load data or use the network")
+
+    monkeypatch.setattr(resources, "files", fail_io)
+    monkeypatch.setattr(pd, "read_csv", fail_io)
+    monkeypatch.setattr(_loader, "load_dataset", fail_io)
+    monkeypatch.setattr(cns.datasets, "load_dataset", fail_io)
+    monkeypatch.setattr(socket, "create_connection", fail_io)
+    monkeypatch.setattr(socket.socket, "connect", fail_io)
+
+    assert cns.datasets.get_dataset_names() == [
+        "flights",
+        "fmri",
+        "iris",
+        "penguins",
+        "tips",
+    ]
+
+
+def test_get_dataset_names_preserves_lazy_imports() -> None:
+    script = """
+import sys
+
+import cnsplots as cns
+
+assert "cnsplots.datasets" not in sys.modules
+assert cns.datasets.get_dataset_names() == [
+    "flights", "fmri", "iris", "penguins", "tips"
+]
+assert not {
+    "Bio",
+    "PyComplexHeatmap",
+    "anndata",
+    "gseapy",
+    "lifelines",
+    "matplotlib",
+    "scanpy",
+    "scipy",
+    "seaborn",
+    "sklearn",
+    "statsmodels",
+} & {name.split(".")[0] for name in sys.modules}
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -130,3 +130,41 @@ def test_showcase_data_moved_to_datasets_namespace() -> None:
     assert "return" in get_type_hints(cns.datasets.get_showcase_data)
     assert not hasattr(cns, "get_showcase_data")
     assert not hasattr(cns.utils, "get_showcase_data")
+
+
+@pytest.mark.parametrize("include_images", [False, True])
+def test_showcase_named_fields_preserve_tuple_positions(include_images: bool) -> None:
+    data = cns.datasets.get_showcase_data(include_showcase_images=include_images)
+    fields = (
+        "iris_df",
+        "tips_df",
+        "survival_df",
+        "blobs",
+        "volcano_df",
+        "gene_sets",
+        "roc_df",
+        "slope_df",
+        "confusion_df",
+        "line_df",
+        "cumulative_incidence_df",
+        "forest_df",
+        "upset_sets",
+    )
+    if include_images:
+        fields += ("showcase_images",)
+        assert isinstance(data, cns.datasets.ShowcaseDataWithImages)
+    else:
+        assert isinstance(data, cns.datasets.ShowcaseData)
+        assert not hasattr(data, "showcase_images")
+
+    assert isinstance(data, tuple)
+    assert data._fields == fields
+    assert len(data) == len(fields)
+    for index, name in enumerate(fields):
+        assert getattr(data, name) is data[index]
+
+    assert cns.datasets.ShowcaseData is cns.datasets.gallery.ShowcaseData
+    assert (
+        cns.datasets.ShowcaseDataWithImages
+        is cns.datasets.gallery.ShowcaseDataWithImages
+    )

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     import cnsplots as cns
     from cnsplots._settings import CNSSettings
 
-    def _check_public_types(data: pd.DataFrame, ax: Axes) -> None:
+    def _check_public_types(data: pd.DataFrame, ax: Axes, include_images: bool) -> None:
         assert_type(cns.settings, CNSSettings)
         assert_type(cns.settings.palette_qual, str)
         assert_type(cns.settings.title_fontsize, int | float)
@@ -79,10 +79,51 @@ if TYPE_CHECKING:
         assert_type(sized_panels.panel("C", width=144, unit="pt"), Axes)
         assert_type(sized_panels.panel("D", width=2, unit=None), Axes)
 
+        assert_type(cns.datasets.get_dataset_names(), list[str])
         showcase = cns.datasets.get_showcase_data()
+        assert_type(showcase, cns.datasets.ShowcaseData)
+        assert_type(
+            cns.datasets.get_showcase_data(include_showcase_images=False),
+            cns.datasets.ShowcaseData,
+        )
         assert_type(showcase[0], pd.DataFrame)
         assert_type(showcase[3], AnnData)
+        assert_type(showcase.iris_df, pd.DataFrame)
+        assert_type(showcase.tips_df, pd.DataFrame)
+        assert_type(showcase.survival_df, pd.DataFrame)
+        assert_type(showcase.blobs, AnnData)
+        assert_type(showcase.volcano_df, pd.DataFrame)
+        assert_type(showcase.gene_sets, list[set[str]])
+        assert_type(showcase.roc_df, pd.DataFrame)
+        assert_type(showcase.slope_df, pd.DataFrame)
+        assert_type(showcase.confusion_df, pd.DataFrame)
+        assert_type(showcase.line_df, pd.DataFrame)
+        assert_type(showcase.cumulative_incidence_df, pd.DataFrame)
+        assert_type(showcase.forest_df, pd.DataFrame)
+        assert_type(showcase.upset_sets, dict[str, set[str]])
         showcase_with_images = cns.datasets.get_showcase_data(
             include_showcase_images=True
         )
+        assert_type(showcase_with_images, cns.datasets.ShowcaseDataWithImages)
         assert_type(showcase_with_images[-1], Traversable)
+        assert_type(showcase_with_images.showcase_images, Traversable)
+        optional_images = cns.datasets.get_showcase_data(
+            include_showcase_images=include_images
+        )
+        assert_type(
+            optional_images,
+            cns.datasets.ShowcaseData | cns.datasets.ShowcaseDataWithImages,
+        )
+        assert_type(optional_images.iris_df, pd.DataFrame)
+        assert_type(optional_images.tips_df, pd.DataFrame)
+        assert_type(optional_images.survival_df, pd.DataFrame)
+        assert_type(optional_images.blobs, AnnData)
+        assert_type(optional_images.volcano_df, pd.DataFrame)
+        assert_type(optional_images.gene_sets, list[set[str]])
+        assert_type(optional_images.roc_df, pd.DataFrame)
+        assert_type(optional_images.slope_df, pd.DataFrame)
+        assert_type(optional_images.confusion_df, pd.DataFrame)
+        assert_type(optional_images.line_df, pd.DataFrame)
+        assert_type(optional_images.cumulative_incidence_df, pd.DataFrame)
+        assert_type(optional_images.forest_df, pd.DataFrame)
+        assert_type(optional_images.upset_sets, dict[str, set[str]])


### PR DESCRIPTION
Make packaged datasets discoverable and showcase results accessible by name while preserving existing positional use.

- Return typed `ShowcaseData` and `ShowcaseDataWithImages` named tuples, preserving the original 13/14 fields and their order. Callers can use `get_showcase_data().survival_df` without unpacking unrelated values.
- Export `get_dataset_names()` as a fresh, alphabetically sorted list from the loader registry, without loading datasets or contacting the network.
- Document the public APIs and add runtime, static typing, offline, and lazy-import regression coverage.

Validation: `make test` passed (1,079 tests, 100% coverage), and `make lint` passed, including type checks. A focused Sphinx/autodoc build for the new result classes and dataset functions passed with warnings treated as errors.

Compatibility: showcase results are now named tuple subclasses; tuple lengths, field positions, data generation, and packaged images are preserved. Callers relying on exact `type(result) is tuple` checks should use `isinstance(result, tuple)`. No follow-up work is required for these issues.

Closes #143
Closes #144
