### PR TITLE
✨ Add palette discovery and registration

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -220,12 +220,49 @@ settings
 
 ## Color Palettes
 
+Discover built-in and registered cnsplots palettes, optionally filtering by
+`"qualitative"` or `"continuous"`. Names available only in Matplotlib or Seaborn
+are outside this registry.
+
+```python
+cns.available_palettes()
+cns.available_palettes(kind="qualitative")
+cns.available_palettes(kind="continuous")
+```
+
+Register a nonempty sequence of Matplotlib-compatible colors to reuse a
+qualitative palette by name. Registration copies the colors and lasts for the
+current Python process. Existing cnsplots and Matplotlib palette names cannot
+be overwritten.
+
+```python
+cns.register_palette("MyLab", ["#4477AA", "#EE6677", "#228833"])
+colors = cns.palettes("MyLab")
+cns.figure(color_cycle="MyLab")
+```
+
+Use `get_palette_colors()` to select colors by zero-based index from a named
+palette or an explicit color sequence. It returns hex strings and defaults to
+`"Set1"` when `palette` is omitted or `None`. The original
+`get_hexcolors_from_apalette()` name remains supported, including its `alist`
+keyword.
+
+```python
+cns.get_palette_colors([0, 2])
+cns.get_palette_colors(indices=[2, 0], palette="MyLab")
+cns.get_palette_colors([1], palette=["red", "blue"])
+cns.get_hexcolors_from_apalette(alist=[0, 2], palette="Set1")
+```
+
 ```{eval-rst}
 .. apirootsummary::
    :toctree: api
    :nosignatures:
 
    palettes
+   available_palettes
+   register_palette
+   get_palette_colors
    get_hexcolors_from_apalette
 ```
 

--- a/examples/figure_setup.py
+++ b/examples/figure_setup.py
@@ -159,8 +159,9 @@ print(f"  GRAY: {cns.GRAY}")
 # %%
 # Selecting specific colors from palette
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``get_hexcolors_from_apalette()`` to pick specific colors.
-selected_colors = cns.get_hexcolors_from_apalette([0, 2, 4, 6])
+# Use ``get_palette_colors()`` to pick specific colors; the default is Set1.
+# The original ``get_hexcolors_from_apalette()`` name remains supported.
+selected_colors = cns.get_palette_colors([0, 2, 4, 6])
 cns.figure(100, 150, color_cycle=selected_colors)
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Selected Colors from Set1")

--- a/examples/palettes.py
+++ b/examples/palettes.py
@@ -25,6 +25,16 @@ iris = cns.datasets.load_dataset("iris")
 
 
 # %%
+# Discover palettes
+# ~~~~~~~~~~~~~~~~~
+# List built-in and registered cnsplots palettes, with optional kind filtering.
+# Names available only in Matplotlib or Seaborn are outside this registry.
+print(cns.available_palettes())
+print(cns.available_palettes(kind="qualitative"))
+print(cns.available_palettes(kind="continuous"))
+
+
+# %%
 # Visualize all available palettes
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Display all built-in palettes as color gradients.
@@ -65,43 +75,7 @@ def plot_palettes(cmap_list, width, height, title="", ncols=1):
 
 cns.setup_matplotlib()
 plot_palettes(
-    [
-        "Set1",
-        "Set2",
-        "Set3",
-        "Pastel1",
-        "Pastel2",
-        "Paired",
-        "Dark2",
-        "Accent",
-        "Tableau",
-        "Bold",
-        "BlueRed",
-        "ECharts",
-        "Ecotyper1",
-        "Ecotyper2",
-        "Ecotyper3",
-        "Ecotyper4",
-        "Ecotyper5",
-        "Ecotyper6",
-        "Cell",
-        "Nature",
-        "Science",
-        "Lancet",
-        "NEJM",
-        "JAMA",
-        "JCO",
-        "OkabeIto",
-        "TolBright",
-        "TolMuted",
-        "parula",
-        "gnuplot",
-        "hot",
-        "WhYlOrRd_custom",
-        "BuRd_custom",
-        "OrBu_custom",
-        "YlGnBu_custom",
-    ],
+    cns.available_palettes(),
     1200,
     1020,
     ncols=2,
@@ -246,8 +220,9 @@ ax.set_title("Ecotyper3 Palette")
 # %%
 # Selecting specific colors from palette
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Use ``get_hexcolors_from_apalette()`` to pick specific indices.
-cns.figure(color_cycle=cns.get_hexcolors_from_apalette([0, 2, 4, 6]))
+# Use ``get_palette_colors()`` to pick specific indices; the default is Set1.
+# ``get_hexcolors_from_apalette()`` remains supported with its ``alist`` keyword.
+cns.figure(color_cycle=cns.get_palette_colors([0, 2, 4, 6]))
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Selected Colors from Default Palette")
 
@@ -257,7 +232,7 @@ ax.set_title("Selected Colors from Default Palette")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Choose colors from any palettable palette.
 cns.figure(
-    color_cycle=cns.get_hexcolors_from_apalette(
+    color_cycle=cns.get_palette_colors(
         [5, 1, 3, 7], palette=palettable.colorbrewer.qualitative.Paired_12.hex_colors
     )
 )
@@ -282,6 +257,19 @@ custom_colors = ["#E41A1C", "#377EB8", "#4DAF4A", "#984EA3"]
 cns.figure(100, 150, color_cycle=custom_colors)
 ax = cns.barplot(data=tips, x="day", y="total_bill")
 ax.set_title("Custom Color List")
+
+
+# %%
+# Register a reusable palette
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Register once per Python process, then reuse the name. Registration copies
+# a nonempty color sequence and rejects existing cnsplots or Matplotlib names.
+cns.register_palette("MyLab", custom_colors)
+print("MyLab" in cns.available_palettes(kind="qualitative"))
+print(cns.get_palette_colors([0, 2], palette="MyLab"))
+cns.figure(100, 150, color_cycle="MyLab")
+ax = cns.barplot(data=tips, x="day", y="total_bill")
+ax.set_title("Registered MyLab Palette")
 
 
 # %%

--- a/src/cnsplots/__init__.py
+++ b/src/cnsplots/__init__.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from ._methods import LogisticModel as LogisticModel
     from ._methods import prerank as prerank
     from ._multipanels import multipanel as multipanel
+    from ._palettes import available_palettes as available_palettes
     from ._settings import settings as settings
     from ._setup import setup_ax as setup_ax
     from ._setup import setup_ggplot as setup_ggplot
@@ -32,7 +33,9 @@ if TYPE_CHECKING:
     from ._utils import apply_unicode_font as apply_unicode_font
     from ._utils import figure as figure
     from ._utils import get_hexcolors_from_apalette as get_hexcolors_from_apalette
+    from ._utils import get_palette_colors as get_palette_colors
     from ._utils import palettes as palettes
+    from ._utils import register_palette as register_palette
     from ._utils import savefig as savefig
     from ._utils import take_legend_out as take_legend_out
     from .plots import barplot as barplot
@@ -101,16 +104,19 @@ _LAZY_IMPORTS = {
     "setup_scanpy": ("cnsplots._setup", "setup_scanpy"),
     "add_panel_label": ("cnsplots._utils", "add_panel_label"),
     "apply_unicode_font": ("cnsplots._utils", "apply_unicode_font"),
+    "available_palettes": ("cnsplots._palettes", "available_palettes"),
     "figure": ("cnsplots._utils", "figure"),
     "multipanel": ("cnsplots._multipanels", "multipanel"),
     "save": ("cnsplots._utils", "savefig"),
     "savefig": ("cnsplots._utils", "savefig"),
     "palettes": ("cnsplots._utils", "palettes"),
+    "register_palette": ("cnsplots._utils", "register_palette"),
     "take_legend_out": ("cnsplots._utils", "take_legend_out"),
     "get_hexcolors_from_apalette": (
         "cnsplots._utils",
         "get_hexcolors_from_apalette",
     ),
+    "get_palette_colors": ("cnsplots._utils", "get_palette_colors"),
     "barplot": ("cnsplots.plots._categorical", "barplot"),
     "boxplot": ("cnsplots.plots._distribution", "boxplot"),
     "confusionplot": ("cnsplots.plots._heatmap", "confusionplot"),

--- a/src/cnsplots/_palettes.py
+++ b/src/cnsplots/_palettes.py
@@ -1,0 +1,576 @@
+"""Lightweight palette metadata and discovery with lazy color factories."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Literal, NamedTuple
+
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap
+    from matplotlib.typing import ColorType
+
+_PaletteKind = Literal["qualitative", "continuous"]
+_RGBColor = tuple[float, float, float]
+
+
+def _colorbrewer_palette(name: str, size: int) -> list[_RGBColor]:
+    from palettable.colorbrewer.colorbrewer import get_map
+
+    return get_map(name, "qualitative", size).mpl_colors
+
+
+def _tableau_palette(name: str) -> list[_RGBColor]:
+    from palettable.tableau.tableau import get_map
+
+    return get_map(name).mpl_colors
+
+
+def _cartocolor_palette(name: str) -> list[_RGBColor]:
+    from palettable.cartocolors.qualitative import get_map
+
+    return get_map(name).mpl_colors
+
+
+def _qualitative_palette(colors: Sequence[ColorType]) -> list[_RGBColor]:
+    import seaborn as sns
+
+    return sns.color_palette(colors)
+
+
+def _continuous_palette(name: str, colors: Sequence[Sequence[float]]) -> Colormap:
+    from matplotlib.colors import LinearSegmentedColormap
+
+    return LinearSegmentedColormap.from_list(name, colors)
+
+
+class _PaletteSpec(NamedTuple):
+    kind: _PaletteKind
+    factory: Callable[[], list[_RGBColor] | Colormap]
+
+
+_PALETTE_REGISTRY: dict[str, _PaletteSpec] = {
+    "Set1": _PaletteSpec("qualitative", lambda: _colorbrewer_palette("Set1", 9)),
+    "Set2": _PaletteSpec("qualitative", lambda: _colorbrewer_palette("Set2", 8)),
+    "Set3": _PaletteSpec("qualitative", lambda: _colorbrewer_palette("Set3", 12)),
+    "Pastel1": _PaletteSpec("qualitative", lambda: _colorbrewer_palette("Pastel1", 9)),
+    "Pastel2": _PaletteSpec("qualitative", lambda: _colorbrewer_palette("Pastel2", 8)),
+    "Paired": _PaletteSpec("qualitative", lambda: _colorbrewer_palette("Paired", 12)),
+    "Dark2": _PaletteSpec("qualitative", lambda: _colorbrewer_palette("Dark2", 8)),
+    "Accent": _PaletteSpec("qualitative", lambda: _colorbrewer_palette("Accent", 8)),
+    "Tableau": _PaletteSpec("qualitative", lambda: _tableau_palette("Tableau_10")),
+    "Bold": _PaletteSpec("qualitative", lambda: _cartocolor_palette("Bold_10")),
+    "BlueRed": _PaletteSpec("qualitative", lambda: _tableau_palette("BlueRed_6")),
+    "Cell": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#C84C3A",
+                "#2F7E8F",
+                "#E1A22E",
+                "#4E5A8A",
+                "#5F9862",
+                "#D07A6A",
+                "#8B6FA8",
+                "#7B8C9E",
+                "#B85F7A",
+                "#6B6B6B",
+            ]
+        ),
+    ),
+    "Nature": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#E64B35",
+                "#4DBBD5",
+                "#00A087",
+                "#3C5488",
+                "#F39B7F",
+                "#8491B4",
+                "#91D1C2",
+                "#DC0000",
+                "#7E6148",
+                "#B09C85",
+            ]
+        ),
+    ),
+    "Science": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#3B4992",
+                "#EE0000",
+                "#008B45",
+                "#631879",
+                "#008280",
+                "#BB0021",
+                "#5F559B",
+                "#A20056",
+                "#808180",
+                "#1B1919",
+            ]
+        ),
+    ),
+    "Lancet": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#00468B",
+                "#ED0000",
+                "#42B540",
+                "#0099B4",
+                "#925E9F",
+                "#FDAF91",
+                "#AD002A",
+                "#ADB6B6",
+                "#1B1919",
+            ]
+        ),
+    ),
+    "NEJM": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#BC3C29",
+                "#0072B5",
+                "#E18727",
+                "#20854E",
+                "#7876B1",
+                "#6F99AD",
+                "#FFDC91",
+                "#EE4C97",
+            ]
+        ),
+    ),
+    "JAMA": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#374E55",
+                "#DF8F44",
+                "#00A1D5",
+                "#B24745",
+                "#79AF97",
+                "#6A6599",
+                "#80796B",
+            ]
+        ),
+    ),
+    "JCO": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#0073C2",
+                "#EFC000",
+                "#868686",
+                "#CD534C",
+                "#7AA6DC",
+                "#003C67",
+                "#8F7700",
+                "#3B3B3B",
+                "#A73030",
+                "#4A6990",
+            ]
+        ),
+    ),
+    "OkabeIto": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#E69F00",
+                "#56B4E9",
+                "#009E73",
+                "#F0E442",
+                "#0072B2",
+                "#D55E00",
+                "#CC79A7",
+                "#000000",
+            ]
+        ),
+    ),
+    "TolBright": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#4477AA",
+                "#EE6677",
+                "#228833",
+                "#CCBB44",
+                "#66CCEE",
+                "#AA3377",
+                "#BBBBBB",
+            ]
+        ),
+    ),
+    "TolMuted": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#332288",
+                "#88CCEE",
+                "#44AA99",
+                "#117733",
+                "#999933",
+                "#DDCC77",
+                "#CC6677",
+                "#882255",
+                "#AA4499",
+                "#DDDDDD",
+            ]
+        ),
+    ),
+    "ECharts": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#5470c6",
+                "#91cc75",
+                "#fac858",
+                "#ee6666",
+                "#9a60b4",
+                "#73c0de",
+                "#3ba272",
+                "#fc8452",
+                "#27727b",
+                "#ea7ccc",
+                "#d7504b",
+                "#e87c25",
+                "#b5c334",
+                "#fe8463",
+                "#26c0c0",
+                "#f4e001",
+            ]
+        ),
+    ),
+    "Ecotyper1": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#D6372E",
+                "#5189BB",
+                "#70B460",
+                "#985EA8",
+                "#F08F35",
+                "#FADD4B",
+                "#A3A3A3",
+                "#B7D3E5",
+                "#E6D8C2",
+            ]
+        ),
+    ),
+    "Ecotyper2": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            ["#EB7D5B", "#FED23F", "#B5D33D", "#6CA2EA", "#442288"]
+        ),
+    ),
+    "Ecotyper3": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#D13570",
+                "#569AB4",
+                "#70AC58",
+                "#74509D",
+                "#ED7E30",
+                "#F5C945",
+                "#9C5732",
+                "#E787E5",
+            ]
+        ),
+    ),
+    "Ecotyper4": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#386cb0",
+                "#fdb462",
+                "#7fc97f",
+                "#ef3b2c",
+                "#662506",
+                "#a6cee3",
+                "#fb9a99",
+                "#984ea3",
+                "#ffff33",
+            ]
+        ),
+    ),
+    "Ecotyper5": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#E41A71",
+                "#379DB8",
+                "#5BAF4A",
+                "#7B4EA3",
+                "#FF7600",
+                "#FFC800",
+                "#A65328",
+                "#F781EC",
+                "#999999",
+                "#A6DCE3",
+                "#BBDF8A",
+                "#FB9A99",
+                "#FDB96F",
+                "#BEB2D6",
+                "#1B9E5E",
+                "#D95802",
+                "#707EB3",
+                "#E729D3",
+                "#E69F02",
+                "#8DD3B9",
+                "#FFFAB3",
+                "#BABFDA",
+                "#FB7F72",
+                "#80C5D3",
+                "#FDAE62",
+                "#BEDE69",
+                "#FCCDF7",
+            ]
+        ),
+    ),
+    "Ecotyper6": _PaletteSpec(
+        "qualitative",
+        lambda: _qualitative_palette(
+            [
+                "#FDC086",
+                "#386CB0",
+                "#F0027F",
+                "#FFFF99",
+                "#BF5B17",
+                "#7FC97F",
+                "lightblue",
+                "#BEAED4",
+                "#66C2A5",
+                "#FC8D62",
+                "#8DA0CB",
+                "#E78AC3",
+                "#A6D854",
+                "#FFD92F",
+                "#E5C494",
+                "#B3B3B3",
+                "#FBB4AE",
+                "#B3CDE3",
+                "#CCEBC5",
+                "#DECBE4",
+                "#FED9A6",
+                "#FFFFCC",
+                "#E5D8BD",
+                "#FDDAEC",
+            ]
+        ),
+    ),
+    "BuRd_custom": _PaletteSpec(
+        "continuous",
+        lambda: _continuous_palette(
+            "BuRd_custom",
+            [
+                [0.0588, 0.3412, 0.6157],
+                [0.1220, 0.3940, 0.6610],
+                [0.1843, 0.4471, 0.7059],
+                [0.2650, 0.5000, 0.7450],
+                [0.3451, 0.5529, 0.7843],
+                [0.5412, 0.6902, 0.8667],
+                [0.7294, 0.8275, 0.9333],
+                [0.8863, 0.9255, 0.9765],
+                [0.9500, 0.9700, 0.9900],
+                [1.0000, 1.0000, 1.0000],
+                [0.9900, 0.9500, 0.9400],
+                [0.9882, 0.9020, 0.8863],
+                [0.9650, 0.8200, 0.7900],
+                [0.9412, 0.7412, 0.6980],
+                [0.9080, 0.6330, 0.5840],
+                [0.8745, 0.5255, 0.4706],
+                [0.7961, 0.3137, 0.2784],
+                [0.7137, 0.1216, 0.1686],
+                [0.6196, 0.0588, 0.1373],
+            ],
+        ),
+    ),
+    "WhYlOrRd_custom": _PaletteSpec(
+        "continuous",
+        lambda: _continuous_palette(
+            "WhYlOrRd_custom",
+            [
+                [1.0000, 1.0000, 1.0000],
+                [1.0000, 1.0000, 0.8500],
+                [1.0000, 0.9800, 0.7000],
+                [1.0000, 0.9400, 0.5000],
+                [1.0000, 0.8500, 0.3000],
+                [0.9961, 0.7200, 0.2000],
+                [0.9961, 0.5500, 0.1000],
+                [0.9922, 0.4000, 0.0500],
+                [0.9882, 0.2500, 0.0200],
+                [0.9500, 0.1500, 0.0100],
+                [0.9000, 0.0800, 0.0100],
+                [0.8000, 0.0200, 0.0100],
+                [0.6500, 0.0000, 0.0100],
+                [0.5019, 0.0000, 0.0000],
+                [0.4000, 0.0000, 0.0000],
+            ],
+        ),
+    ),
+    "OrBu_custom": _PaletteSpec(
+        "continuous",
+        lambda: _continuous_palette(
+            "OrBu_custom",
+            [
+                [0.8500, 0.3800, 0.0500],
+                [1.0000, 0.4980, 0.0549],
+                [1.0000, 0.5841, 0.2169],
+                [1.0000, 0.6702, 0.3790],
+                [1.0000, 0.7563, 0.5410],
+                [1.0000, 0.8424, 0.7031],
+                [1.0000, 0.9284, 0.8651],
+                [1.0000, 1.0000, 1.0000],
+                [0.8608, 0.9235, 0.9745],
+                [0.7216, 0.8471, 0.9490],
+                [0.5824, 0.7706, 0.9235],
+                [0.4431, 0.6941, 0.8980],
+                [0.3039, 0.6176, 0.8725],
+                [0.1647, 0.5412, 0.8471],
+                [0.1216, 0.4667, 0.7059],
+            ],
+        ),
+    ),
+    "YlGnBu_custom": _PaletteSpec(
+        "continuous",
+        lambda: _continuous_palette(
+            "YlGnBu_custom",
+            [
+                [1.00, 1.00, 0.80],
+                [0.98, 0.99, 0.75],
+                [0.95, 0.98, 0.70],
+                [0.91, 0.97, 0.66],
+                [0.87, 0.96, 0.62],
+                [0.83, 0.95, 0.59],
+                [0.77, 0.93, 0.58],
+                [0.71, 0.91, 0.59],
+                [0.64, 0.89, 0.62],
+                [0.56, 0.87, 0.66],
+                [0.48, 0.84, 0.69],
+                [0.40, 0.81, 0.72],
+                [0.32, 0.78, 0.74],
+                [0.26, 0.74, 0.76],
+                [0.21, 0.70, 0.77],
+                [0.18, 0.65, 0.78],
+                [0.15, 0.60, 0.78],
+                [0.13, 0.55, 0.78],
+                [0.12, 0.50, 0.76],
+                [0.13, 0.44, 0.73],
+                [0.13, 0.39, 0.70],
+                [0.14, 0.33, 0.66],
+                [0.14, 0.28, 0.62],
+                [0.14, 0.22, 0.58],
+                [0.05, 0.18, 0.52],
+                [0.03, 0.15, 0.45],
+            ],
+        ),
+    ),
+    "parula": _PaletteSpec(
+        "continuous",
+        lambda: _continuous_palette(
+            "parula",
+            [
+                [0.2081, 0.1663, 0.5292],
+                [0.2116, 0.1898, 0.5777],
+                [0.2123, 0.2138, 0.6270],
+                [0.2081, 0.2386, 0.6771],
+                [0.1959, 0.2645, 0.7279],
+                [0.1707, 0.2919, 0.7792],
+                [0.1253, 0.3242, 0.8303],
+                [0.0591, 0.3598, 0.8683],
+                [0.0117, 0.3875, 0.8820],
+                [0.0060, 0.4086, 0.8828],
+                [0.0165, 0.4266, 0.8786],
+                [0.0329, 0.4430, 0.8720],
+                [0.0498, 0.4586, 0.8641],
+                [0.0629, 0.4737, 0.8554],
+                [0.0723, 0.4887, 0.8467],
+                [0.0779, 0.5040, 0.8384],
+                [0.0793, 0.5200, 0.8312],
+                [0.0749, 0.5375, 0.8263],
+                [0.0641, 0.5570, 0.8240],
+                [0.0488, 0.5772, 0.8228],
+                [0.0343, 0.5966, 0.8199],
+                [0.0265, 0.6137, 0.8135],
+                [0.0239, 0.6287, 0.8038],
+                [0.0231, 0.6418, 0.7913],
+                [0.0228, 0.6535, 0.7768],
+                [0.0267, 0.6642, 0.7607],
+                [0.0384, 0.6743, 0.7436],
+                [0.0590, 0.6838, 0.7254],
+                [0.0843, 0.6928, 0.7062],
+                [0.1133, 0.7015, 0.6859],
+                [0.1453, 0.7098, 0.6646],
+                [0.1801, 0.7177, 0.6424],
+                [0.2178, 0.7250, 0.6193],
+                [0.2586, 0.7317, 0.5954],
+                [0.3022, 0.7376, 0.5712],
+                [0.3482, 0.7424, 0.5473],
+                [0.3953, 0.7459, 0.5244],
+                [0.4420, 0.7481, 0.5033],
+                [0.4871, 0.7491, 0.4840],
+                [0.5300, 0.7491, 0.4661],
+                [0.5709, 0.7485, 0.4494],
+                [0.6099, 0.7473, 0.4337],
+                [0.6473, 0.7456, 0.4188],
+                [0.6834, 0.7435, 0.4044],
+                [0.7184, 0.7411, 0.3905],
+                [0.7525, 0.7384, 0.3768],
+                [0.7858, 0.7356, 0.3633],
+                [0.8185, 0.7327, 0.3498],
+                [0.8507, 0.7299, 0.3360],
+                [0.8824, 0.7274, 0.3217],
+                [0.9139, 0.7258, 0.3063],
+                [0.9450, 0.7261, 0.2886],
+                [0.9739, 0.7314, 0.2666],
+                [0.9938, 0.7455, 0.2403],
+                [0.9990, 0.7653, 0.2164],
+                [0.9955, 0.7861, 0.1967],
+                [0.9880, 0.8066, 0.1794],
+                [0.9789, 0.8271, 0.1633],
+                [0.9697, 0.8481, 0.1475],
+                [0.9626, 0.8705, 0.1309],
+                [0.9589, 0.8949, 0.1132],
+                [0.9598, 0.9218, 0.0948],
+                [0.9661, 0.9514, 0.0755],
+                [0.9763, 0.9831, 0.0538],
+            ],
+        ),
+    ),
+}
+
+
+def available_palettes(kind: _PaletteKind | None = None) -> list[str]:
+    """List built-in and registered palette names in registration order.
+
+    Parameters
+    ----------
+    kind : {"qualitative", "continuous"}, optional
+        Return only palettes of this kind. By default, return both kinds.
+
+    Returns
+    -------
+    list of str
+        A fresh list of palette names. Built-ins appear first, followed by
+        user palettes in registration order. External Matplotlib names are
+        not included, and no palette objects are created during discovery.
+
+    Raises
+    ------
+    ValueError
+        If ``kind`` is not ``None``, ``"qualitative"``, or ``"continuous"``.
+
+    See Also
+    --------
+    palettes : Resolve a palette by name.
+    register_palette : Register a custom qualitative palette.
+    """
+    if kind not in (None, "qualitative", "continuous"):
+        raise ValueError("kind must be 'qualitative', 'continuous', or None.")
+    return [
+        name
+        for name, spec in _PALETTE_REGISTRY.items()
+        if kind is None or spec.kind == kind
+    ]

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -25,14 +25,12 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.colors import Colormap
 from matplotlib.figure import Figure
 from matplotlib.typing import ColorType
-from palettable.cartocolors.qualitative import get_map as _get_cartocolor_map
-from palettable.colorbrewer.colorbrewer import get_map as _get_colorbrewer_map
-from palettable.tableau.tableau import get_map as _get_tableau_map
 from seaborn._base import categorical_order, infer_orient
 from statannotations.Annotator import Annotator
 from statannotations.PValueFormat import PValueFormat
 from statannotations.utils import DEFAULT
 
+import cnsplots._palettes as _palettes
 from cnsplots._settings import settings
 from cnsplots._setup import setup_matplotlib
 from cnsplots._sizing import _SizeUnit, _dimension_to_points
@@ -762,11 +760,9 @@ def add_panel_label(
     )
 
 
-def get_hexcolors_from_apalette(
-    alist: Sequence[int],
-    palette: str | Sequence[ColorType] = _get_colorbrewer_map(
-        "Set1", "qualitative", 9
-    ).hex_colors,
+def get_palette_colors(
+    indices: Sequence[int],
+    palette: str | Sequence[ColorType] | None = None,
 ) -> list[str]:
     """
     Extract specific colors from a palette by index.
@@ -776,12 +772,12 @@ def get_hexcolors_from_apalette(
 
     Parameters
     ----------
-    alist : list of int
-        List of indices specifying which colors to extract from the palette.
-        Indices are 0-based.
-    palette : str or list, default: Set1_9.hex_colors
+    indices : sequence of int
+        Indices specifying which colors to extract, in the requested order.
+        Indices are 0-based; negative indices and repeated indices are supported.
+    palette : str or sequence of colors, optional
         Either a palette name (str) that can be resolved by the palettes() function,
-        or a list of hex color codes.
+        or a sequence of Matplotlib colors. Defaults to Set1, resolved on each call.
 
     Returns
     -------
@@ -791,6 +787,7 @@ def get_hexcolors_from_apalette(
     See Also
     --------
     palettes : Get a complete color palette by name.
+    get_hexcolors_from_apalette : Compatible wrapper using the old parameter name.
 
     Notes
     -----
@@ -805,22 +802,55 @@ def get_hexcolors_from_apalette(
     --------
     >>> import cnsplots as cns
     >>> # Extract first two colors from Set1
-    >>> colors = cns.get_hexcolors_from_apalette([0, 1], "Set1")
+    >>> colors = cns.get_palette_colors([0, 1], "Set1")
     >>> colors
     ['#e41a1c', '#377eb8']
 
     >>> # Extract specific colors from custom palette
     >>> custom = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00"]
-    >>> selected = cns.get_hexcolors_from_apalette([0, 2], custom)
+    >>> selected = cns.get_palette_colors([0, 2], custom)
     >>> selected
     ['#ff0000', '#0000ff']
     """
+    if palette is None:
+        palette = "Set1"
     colors = (
         cast(Sequence[ColorType], palettes(palette))
         if isinstance(palette, str)
         else palette
     )
-    return [mcolors.to_hex(colors[index]) for index in alist]
+    return [mcolors.to_hex(colors[index]) for index in indices]
+
+
+def get_hexcolors_from_apalette(
+    alist: Sequence[int],
+    palette: str | Sequence[ColorType] | None = None,
+) -> list[str]:
+    """Extract palette colors using the original, compatible API.
+
+    Parameters
+    ----------
+    alist : sequence of int
+        Zero-based indices to select, including negative or repeated indices.
+    palette : str or sequence of colors, optional
+        Palette name or explicit Matplotlib colors. Defaults to Set1, resolved
+        on each call.
+
+    Returns
+    -------
+    list of str
+        Selected hexadecimal colors in the requested order.
+
+    See Also
+    --------
+    get_palette_colors : Preferred name for palette color selection.
+
+    Notes
+    -----
+    This wrapper preserves positional calls and the ``alist`` and ``palette``
+    keyword arguments. It returns the same colors as ``get_palette_colors``.
+    """
+    return get_palette_colors(alist, palette)
 
 
 def _is_qualitative_cmap(cmap_name):
@@ -1126,6 +1156,64 @@ def _p_value_helper(
         logger.info("P-values were determined by two-sided Chi-squared test.")
 
 
+def register_palette(name: str, colors: Sequence[ColorType]) -> None:
+    """Register a custom qualitative palette for the current Python process.
+
+    Parameters
+    ----------
+    name : str
+        Nonblank, case-sensitive palette name. Existing cnsplots and Matplotlib
+        palette names cannot be replaced.
+    colors : sequence of Matplotlib colors
+        Nonempty sequence of valid colors. Colors are copied into immutable RGB
+        tuples so later changes to the input cannot alter the palette.
+
+    Raises
+    ------
+    TypeError
+        If ``name`` is not a string or ``colors`` is not a color sequence.
+    ValueError
+        If the name is blank or already in use, or colors are empty or invalid.
+
+    See Also
+    --------
+    available_palettes : List built-in and registered palette names.
+    palettes : Resolve a palette by name.
+
+    Notes
+    -----
+    Registered palettes are available to :func:`palettes`, :func:`figure`, and
+    :func:`get_palette_colors` until the Python process exits. Each
+    lookup returns a fresh palette. Registration does not persist to disk.
+
+    Examples
+    --------
+    >>> import cnsplots as cns
+    >>> cns.register_palette("MyPalette", ["#336699", "#CC6633"])
+    >>> cns.palettes("MyPalette")
+    [(0.2, 0.4, 0.6), (0.8, 0.4, 0.2)]
+    """
+    if not isinstance(name, str):
+        raise TypeError("name must be a string.")
+    if not name.strip():
+        raise ValueError("name must not be blank.")
+    if name in _palettes._PALETTE_REGISTRY or name in mpl.colormaps:
+        raise ValueError(f"Palette name {name!r} is already in use.")
+    if isinstance(colors, (str, bytes)) or not isinstance(colors, Sequence):
+        raise TypeError("colors must be a sequence of Matplotlib colors.")
+    if not colors:
+        raise ValueError("colors must not be empty.")
+    try:
+        copied_colors = tuple(mcolors.to_rgb(color) for color in colors)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("colors must contain valid Matplotlib colors.") from exc
+    if not all(math.isfinite(channel) for color in copied_colors for channel in color):
+        raise ValueError("colors must contain finite RGB values.")
+    _palettes._PALETTE_REGISTRY[name] = _palettes._PaletteSpec(
+        "qualitative", lambda: sns.color_palette(copied_colors)
+    )
+
+
 @overload
 def palettes(color: _QualitativePaletteName) -> list[_RGBColor]: ...
 
@@ -1154,7 +1242,8 @@ def palettes(color: str | Sequence[ColorType]) -> list[_RGBColor] | Colormap:
     ----------
     color : str or list
         Palette name or list of color values. If a list is provided, it is
-        converted to a seaborn color palette.
+        converted to a seaborn color palette. Registered custom palette names
+        are also accepted; use :func:`available_palettes` to discover names.
 
         **Supported palette names:**
 
@@ -1190,7 +1279,9 @@ def palettes(color: str | Sequence[ColorType]) -> list[_RGBColor] | Colormap:
 
     See Also
     --------
-    get_hexcolors_from_apalette : Extract specific colors from a palette by index.
+    available_palettes : List built-in and registered palette names.
+    register_palette : Register a custom qualitative palette.
+    get_palette_colors : Extract specific colors from a palette by index.
     figure : Initialize a figure with custom color cycle.
 
     Notes
@@ -1223,440 +1314,7 @@ def palettes(color: str | Sequence[ColorType]) -> list[_RGBColor] | Colormap:
     """
     if not isinstance(color, str):
         return sns.color_palette(color)
-    else:
-        if color == "Set1":
-            return _get_colorbrewer_map("Set1", "qualitative", 9).mpl_colors
-        elif color == "Set2":
-            return _get_colorbrewer_map("Set2", "qualitative", 8).mpl_colors
-        elif color == "Set3":
-            return _get_colorbrewer_map("Set3", "qualitative", 12).mpl_colors
-        elif color == "Pastel1":
-            return _get_colorbrewer_map("Pastel1", "qualitative", 9).mpl_colors
-        elif color == "Pastel2":
-            return _get_colorbrewer_map("Pastel2", "qualitative", 8).mpl_colors
-        elif color == "Paired":
-            return _get_colorbrewer_map("Paired", "qualitative", 12).mpl_colors
-        elif color == "Dark2":
-            return _get_colorbrewer_map("Dark2", "qualitative", 8).mpl_colors
-        elif color == "Accent":
-            return _get_colorbrewer_map("Accent", "qualitative", 8).mpl_colors
-        elif color == "Tableau":
-            return _get_tableau_map("Tableau_10").mpl_colors
-        elif color == "Bold":
-            return _get_cartocolor_map("Bold_10").mpl_colors
-        elif color == "BlueRed":
-            return _get_tableau_map("BlueRed_6").mpl_colors
-        elif color == "Cell":
-            colors = [
-                "#C84C3A",
-                "#2F7E8F",
-                "#E1A22E",
-                "#4E5A8A",
-                "#5F9862",
-                "#D07A6A",
-                "#8B6FA8",
-                "#7B8C9E",
-                "#B85F7A",
-                "#6B6B6B",
-            ]
-            return sns.color_palette(colors)
-        elif color == "Nature":
-            colors = [
-                "#E64B35",
-                "#4DBBD5",
-                "#00A087",
-                "#3C5488",
-                "#F39B7F",
-                "#8491B4",
-                "#91D1C2",
-                "#DC0000",
-                "#7E6148",
-                "#B09C85",
-            ]
-            return sns.color_palette(colors)
-        elif color == "Science":
-            colors = [
-                "#3B4992",
-                "#EE0000",
-                "#008B45",
-                "#631879",
-                "#008280",
-                "#BB0021",
-                "#5F559B",
-                "#A20056",
-                "#808180",
-                "#1B1919",
-            ]
-            return sns.color_palette(colors)
-        elif color == "Lancet":
-            colors = [
-                "#00468B",
-                "#ED0000",
-                "#42B540",
-                "#0099B4",
-                "#925E9F",
-                "#FDAF91",
-                "#AD002A",
-                "#ADB6B6",
-                "#1B1919",
-            ]
-            return sns.color_palette(colors)
-        elif color == "NEJM":
-            colors = [
-                "#BC3C29",
-                "#0072B5",
-                "#E18727",
-                "#20854E",
-                "#7876B1",
-                "#6F99AD",
-                "#FFDC91",
-                "#EE4C97",
-            ]
-            return sns.color_palette(colors)
-        elif color == "JAMA":
-            colors = [
-                "#374E55",
-                "#DF8F44",
-                "#00A1D5",
-                "#B24745",
-                "#79AF97",
-                "#6A6599",
-                "#80796B",
-            ]
-            return sns.color_palette(colors)
-        elif color == "JCO":
-            colors = [
-                "#0073C2",
-                "#EFC000",
-                "#868686",
-                "#CD534C",
-                "#7AA6DC",
-                "#003C67",
-                "#8F7700",
-                "#3B3B3B",
-                "#A73030",
-                "#4A6990",
-            ]
-            return sns.color_palette(colors)
-        elif color == "OkabeIto":
-            colors = [
-                "#E69F00",
-                "#56B4E9",
-                "#009E73",
-                "#F0E442",
-                "#0072B2",
-                "#D55E00",
-                "#CC79A7",
-                "#000000",
-            ]
-            return sns.color_palette(colors)
-        elif color == "TolBright":
-            colors = [
-                "#4477AA",
-                "#EE6677",
-                "#228833",
-                "#CCBB44",
-                "#66CCEE",
-                "#AA3377",
-                "#BBBBBB",
-            ]
-            return sns.color_palette(colors)
-        elif color == "TolMuted":
-            colors = [
-                "#332288",
-                "#88CCEE",
-                "#44AA99",
-                "#117733",
-                "#999933",
-                "#DDCC77",
-                "#CC6677",
-                "#882255",
-                "#AA4499",
-                "#DDDDDD",
-            ]
-            return sns.color_palette(colors)
-        elif color == "ECharts":
-            colors = [
-                "#5470c6",
-                "#91cc75",
-                "#fac858",
-                "#ee6666",
-                "#9a60b4",
-                "#73c0de",
-                "#3ba272",
-                "#fc8452",
-                "#27727b",
-                "#ea7ccc",
-                "#d7504b",
-                "#e87c25",
-                "#b5c334",
-                "#fe8463",
-                "#26c0c0",
-                "#f4e001",
-            ]
-            return sns.color_palette(colors)
-        elif color == "Ecotyper1":
-            colors = [
-                "#D6372E",
-                "#5189BB",
-                "#70B460",
-                "#985EA8",
-                "#F08F35",
-                "#FADD4B",
-                "#A3A3A3",
-                "#B7D3E5",
-                "#E6D8C2",
-            ]
-            return sns.color_palette(colors)
-        elif color == "Ecotyper2":
-            colors = ["#EB7D5B", "#FED23F", "#B5D33D", "#6CA2EA", "#442288"]
-            return sns.color_palette(colors)
-        elif color == "Ecotyper3":
-            colors = [
-                "#D13570",
-                "#569AB4",
-                "#70AC58",
-                "#74509D",
-                "#ED7E30",
-                "#F5C945",
-                "#9C5732",
-                "#E787E5",
-            ]
-            return sns.color_palette(colors)
-        elif color == "Ecotyper4":
-            colors = [
-                "#386cb0",
-                "#fdb462",
-                "#7fc97f",
-                "#ef3b2c",
-                "#662506",
-                "#a6cee3",
-                "#fb9a99",
-                "#984ea3",
-                "#ffff33",
-            ]
-            return sns.color_palette(colors)
-        elif color == "Ecotyper5":
-            colors = [
-                "#E41A71",
-                "#379DB8",
-                "#5BAF4A",
-                "#7B4EA3",
-                "#FF7600",
-                "#FFC800",
-                "#A65328",
-                "#F781EC",
-                "#999999",
-                "#A6DCE3",
-                "#BBDF8A",
-                "#FB9A99",
-                "#FDB96F",
-                "#BEB2D6",
-                "#1B9E5E",
-                "#D95802",
-                "#707EB3",
-                "#E729D3",
-                "#E69F02",
-                "#8DD3B9",
-                "#FFFAB3",
-                "#BABFDA",
-                "#FB7F72",
-                "#80C5D3",
-                "#FDAE62",
-                "#BEDE69",
-                "#FCCDF7",
-            ]
-            return sns.color_palette(colors)
-        elif color == "Ecotyper6":
-            colors = [
-                "#FDC086",
-                "#386CB0",
-                "#F0027F",
-                "#FFFF99",
-                "#BF5B17",
-                "#7FC97F",
-                "lightblue",
-                "#BEAED4",
-                "#66C2A5",
-                "#FC8D62",
-                "#8DA0CB",
-                "#E78AC3",
-                "#A6D854",
-                "#FFD92F",
-                "#E5C494",
-                "#B3B3B3",
-                "#FBB4AE",
-                "#B3CDE3",
-                "#CCEBC5",
-                "#DECBE4",
-                "#FED9A6",
-                "#FFFFCC",
-                "#E5D8BD",
-                "#FDDAEC",
-            ]
-            return sns.color_palette(colors)
-        elif color == "BuRd_custom":
-            cm_data = [
-                [0.0588, 0.3412, 0.6157],
-                [0.1220, 0.3940, 0.6610],
-                [0.1843, 0.4471, 0.7059],
-                [0.2650, 0.5000, 0.7450],
-                [0.3451, 0.5529, 0.7843],
-                [0.5412, 0.6902, 0.8667],
-                [0.7294, 0.8275, 0.9333],
-                [0.8863, 0.9255, 0.9765],
-                [0.9500, 0.9700, 0.9900],
-                [1.0000, 1.0000, 1.0000],
-                [0.9900, 0.9500, 0.9400],
-                [0.9882, 0.9020, 0.8863],
-                [0.9650, 0.8200, 0.7900],
-                [0.9412, 0.7412, 0.6980],
-                [0.9080, 0.6330, 0.5840],
-                [0.8745, 0.5255, 0.4706],
-                [0.7961, 0.3137, 0.2784],
-                [0.7137, 0.1216, 0.1686],
-                [0.6196, 0.0588, 0.1373],
-            ]
-            return mpl.colors.LinearSegmentedColormap.from_list("BuRd_custom", cm_data)
-        elif color == "WhYlOrRd_custom":
-            cm_data = [
-                [1.0000, 1.0000, 1.0000],
-                [1.0000, 1.0000, 0.8500],
-                [1.0000, 0.9800, 0.7000],
-                [1.0000, 0.9400, 0.5000],
-                [1.0000, 0.8500, 0.3000],
-                [0.9961, 0.7200, 0.2000],
-                [0.9961, 0.5500, 0.1000],
-                [0.9922, 0.4000, 0.0500],
-                [0.9882, 0.2500, 0.0200],
-                [0.9500, 0.1500, 0.0100],
-                [0.9000, 0.0800, 0.0100],
-                [0.8000, 0.0200, 0.0100],
-                [0.6500, 0.0000, 0.0100],
-                [0.5019, 0.0000, 0.0000],
-                [0.4000, 0.0000, 0.0000],
-            ]
-            return mpl.colors.LinearSegmentedColormap.from_list(
-                "WhYlOrRd_custom", cm_data
-            )
-        elif color == "OrBu_custom":
-            cm_data = [
-                [0.8500, 0.3800, 0.0500],
-                [1.0000, 0.4980, 0.0549],
-                [1.0000, 0.5841, 0.2169],
-                [1.0000, 0.6702, 0.3790],
-                [1.0000, 0.7563, 0.5410],
-                [1.0000, 0.8424, 0.7031],
-                [1.0000, 0.9284, 0.8651],
-                [1.0000, 1.0000, 1.0000],
-                [0.8608, 0.9235, 0.9745],
-                [0.7216, 0.8471, 0.9490],
-                [0.5824, 0.7706, 0.9235],
-                [0.4431, 0.6941, 0.8980],
-                [0.3039, 0.6176, 0.8725],
-                [0.1647, 0.5412, 0.8471],
-                [0.1216, 0.4667, 0.7059],
-            ]
-            return mpl.colors.LinearSegmentedColormap.from_list("OrBu_custom", cm_data)
-        elif color == "YlGnBu_custom":
-            cm_data = [
-                [1.00, 1.00, 0.80],
-                [0.98, 0.99, 0.75],
-                [0.95, 0.98, 0.70],
-                [0.91, 0.97, 0.66],
-                [0.87, 0.96, 0.62],
-                [0.83, 0.95, 0.59],
-                [0.77, 0.93, 0.58],
-                [0.71, 0.91, 0.59],
-                [0.64, 0.89, 0.62],
-                [0.56, 0.87, 0.66],
-                [0.48, 0.84, 0.69],
-                [0.40, 0.81, 0.72],
-                [0.32, 0.78, 0.74],
-                [0.26, 0.74, 0.76],
-                [0.21, 0.70, 0.77],
-                [0.18, 0.65, 0.78],
-                [0.15, 0.60, 0.78],
-                [0.13, 0.55, 0.78],
-                [0.12, 0.50, 0.76],
-                [0.13, 0.44, 0.73],
-                [0.13, 0.39, 0.70],
-                [0.14, 0.33, 0.66],
-                [0.14, 0.28, 0.62],
-                [0.14, 0.22, 0.58],
-                [0.05, 0.18, 0.52],
-                [0.03, 0.15, 0.45],
-            ]
-            return mpl.colors.LinearSegmentedColormap.from_list(
-                "YlGnBu_custom", cm_data
-            )
-        elif color == "parula":
-            cm_data = [
-                [0.2081, 0.1663, 0.5292],
-                [0.2116, 0.1898, 0.5777],
-                [0.2123, 0.2138, 0.6270],
-                [0.2081, 0.2386, 0.6771],
-                [0.1959, 0.2645, 0.7279],
-                [0.1707, 0.2919, 0.7792],
-                [0.1253, 0.3242, 0.8303],
-                [0.0591, 0.3598, 0.8683],
-                [0.0117, 0.3875, 0.8820],
-                [0.0060, 0.4086, 0.8828],
-                [0.0165, 0.4266, 0.8786],
-                [0.0329, 0.4430, 0.8720],
-                [0.0498, 0.4586, 0.8641],
-                [0.0629, 0.4737, 0.8554],
-                [0.0723, 0.4887, 0.8467],
-                [0.0779, 0.5040, 0.8384],
-                [0.0793, 0.5200, 0.8312],
-                [0.0749, 0.5375, 0.8263],
-                [0.0641, 0.5570, 0.8240],
-                [0.0488, 0.5772, 0.8228],
-                [0.0343, 0.5966, 0.8199],
-                [0.0265, 0.6137, 0.8135],
-                [0.0239, 0.6287, 0.8038],
-                [0.0231, 0.6418, 0.7913],
-                [0.0228, 0.6535, 0.7768],
-                [0.0267, 0.6642, 0.7607],
-                [0.0384, 0.6743, 0.7436],
-                [0.0590, 0.6838, 0.7254],
-                [0.0843, 0.6928, 0.7062],
-                [0.1133, 0.7015, 0.6859],
-                [0.1453, 0.7098, 0.6646],
-                [0.1801, 0.7177, 0.6424],
-                [0.2178, 0.7250, 0.6193],
-                [0.2586, 0.7317, 0.5954],
-                [0.3022, 0.7376, 0.5712],
-                [0.3482, 0.7424, 0.5473],
-                [0.3953, 0.7459, 0.5244],
-                [0.4420, 0.7481, 0.5033],
-                [0.4871, 0.7491, 0.4840],
-                [0.5300, 0.7491, 0.4661],
-                [0.5709, 0.7485, 0.4494],
-                [0.6099, 0.7473, 0.4337],
-                [0.6473, 0.7456, 0.4188],
-                [0.6834, 0.7435, 0.4044],
-                [0.7184, 0.7411, 0.3905],
-                [0.7525, 0.7384, 0.3768],
-                [0.7858, 0.7356, 0.3633],
-                [0.8185, 0.7327, 0.3498],
-                [0.8507, 0.7299, 0.3360],
-                [0.8824, 0.7274, 0.3217],
-                [0.9139, 0.7258, 0.3063],
-                [0.9450, 0.7261, 0.2886],
-                [0.9739, 0.7314, 0.2666],
-                [0.9938, 0.7455, 0.2403],
-                [0.9990, 0.7653, 0.2164],
-                [0.9955, 0.7861, 0.1967],
-                [0.9880, 0.8066, 0.1794],
-                [0.9789, 0.8271, 0.1633],
-                [0.9697, 0.8481, 0.1475],
-                [0.9626, 0.8705, 0.1309],
-                [0.9589, 0.8949, 0.1132],
-                [0.9598, 0.9218, 0.0948],
-                [0.9661, 0.9514, 0.0755],
-                [0.9763, 0.9831, 0.0538],
-            ]
-            return mpl.colors.LinearSegmentedColormap.from_list("parula", cm_data)
-        else:
-            raise RuntimeError("Wrong Choice!")
+    spec = _palettes._PALETTE_REGISTRY.get(color)
+    if spec is None:
+        raise RuntimeError("Wrong Choice!")
+    return spec.factory()

--- a/tests/test_palette_colors.py
+++ b/tests/test_palette_colors.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import cast
+
+import numpy as np
+import pytest
+from matplotlib.typing import ColorType
+
+import cnsplots as cns
+from cnsplots import _utils
+
+
+@pytest.mark.parametrize("indices", [[0], (2, 0, 2, -1), range(3), []])
+@pytest.mark.parametrize(
+    "palette",
+    [None, "Set1", "Ecotyper2", ["red", (0, 1, 0), "#0000ff"]],
+)
+def test_palette_color_names_are_compatible(
+    indices: Sequence[int], palette: str | Sequence[ColorType] | None
+) -> None:
+    expected = cns.get_palette_colors(indices=indices, palette=palette)
+
+    assert cns.get_hexcolors_from_apalette(indices, palette) == expected
+    assert cns.get_hexcolors_from_apalette(alist=indices, palette=palette) == expected
+
+
+def test_palette_color_selection_preserves_colors_and_index_order() -> None:
+    assert cns.get_palette_colors([0]) == ["#e41a1c"]
+    assert cns.get_hexcolors_from_apalette(alist=[0]) == ["#e41a1c"]
+    assert cns.get_palette_colors([2, 0, 2, -1], "Ecotyper2") == [
+        "#b5d33d",
+        "#eb7d5b",
+        "#b5d33d",
+        "#442288",
+    ]
+    assert cns.get_palette_colors([2, 0, 1], ["red", (0, 1, 0), (0, 0, 1, 0.5)]) == [
+        "#0000ff",
+        "#ff0000",
+        "#00ff00",
+    ]
+
+
+def test_palette_color_selection_accepts_numpy_indices() -> None:
+    indices = cast(Sequence[int], np.array([0, 1, -1]))
+    expected = ["#e41a1c", "#377eb8", "#999999"]
+
+    assert cns.get_palette_colors(indices) == expected
+    assert cns.get_hexcolors_from_apalette(indices) == expected
+
+
+@pytest.mark.parametrize("indices", [[3], [-4]])
+def test_palette_color_selection_preserves_index_errors(indices: list[int]) -> None:
+    for select in (cns.get_palette_colors, cns.get_hexcolors_from_apalette):
+        with pytest.raises(IndexError):
+            select(indices, ["red", "green", "blue"])
+
+
+def test_palette_color_selection_preserves_unknown_name_error() -> None:
+    for select in (cns.get_palette_colors, cns.get_hexcolors_from_apalette):
+        with pytest.raises(RuntimeError, match="Wrong Choice!"):
+            select([0], "not-a-palette")
+
+
+def test_palette_color_default_resolves_on_each_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested: list[str] = []
+    colors = ["red"]
+
+    def resolve(name: str) -> list[str]:
+        requested.append(name)
+        return colors
+
+    monkeypatch.setattr(_utils, "palettes", resolve)
+
+    assert cns.get_palette_colors([0]) == ["#ff0000"]
+    colors[0] = "blue"
+    assert cns.get_hexcolors_from_apalette([0]) == ["#0000ff"]
+    assert requested == ["Set1", "Set1"]
+
+
+def test_palette_color_result_is_independent() -> None:
+    selected = cns.get_palette_colors([0])
+    selected[0] = "#000000"
+
+    assert cns.get_palette_colors([0]) == ["#e41a1c"]
+    assert cns.get_hexcolors_from_apalette([0]) == ["#e41a1c"]

--- a/tests/test_palette_registry.py
+++ b/tests/test_palette_registry.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+import hashlib
+import subprocess
+import sys
+from typing import Any, cast, get_args
+
+import matplotlib as mpl
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import seaborn as sns
+from matplotlib.colors import Colormap, LinearSegmentedColormap
+from matplotlib.typing import ColorType
+
+import cnsplots as cns
+from cnsplots import _palettes, _utils
+
+
+# Captured from main before replacing palette dispatch with the registry.
+_QUALITATIVE_COLORS = {
+    "Set1": "#e41a1c #377eb8 #4daf4a #984ea3 #ff7f00 #ffff33 #a65628 #f781bf #999999",
+    "Set2": "#66c2a5 #fc8d62 #8da0cb #e78ac3 #a6d854 #ffd92f #e5c494 #b3b3b3",
+    "Set3": "#8dd3c7 #ffffb3 #bebada #fb8072 #80b1d3 #fdb462 #b3de69 #fccde5 #d9d9d9 #bc80bd #ccebc5 #ffed6f",
+    "Pastel1": "#fbb4ae #b3cde3 #ccebc5 #decbe4 #fed9a6 #ffffcc #e5d8bd #fddaec #f2f2f2",
+    "Pastel2": "#b3e2cd #fdcdac #cbd5e8 #f4cae4 #e6f5c9 #fff2ae #f1e2cc #cccccc",
+    "Paired": "#a6cee3 #1f78b4 #b2df8a #33a02c #fb9a99 #e31a1c #fdbf6f #ff7f00 #cab2d6 #6a3d9a #ffff99 #b15928",
+    "Dark2": "#1b9e77 #d95f02 #7570b3 #e7298a #66a61e #e6ab02 #a6761d #666666",
+    "Accent": "#7fc97f #beaed4 #fdc086 #ffff99 #386cb0 #f0027f #bf5b17 #666666",
+    "Tableau": "#1f77b4 #ff7f0e #2ca02c #d62728 #9467bd #8c564b #e377c2 #7f7f7f #bcbd22 #17becf",
+    "Bold": "#7f3c8d #11a579 #3969ac #f2b701 #e73f74 #80ba5a #e68310 #008695 #cf1c90 #f97b72",
+    "BlueRed": "#2c69b0 #f02720 #ac613c #6ba3d6 #ea6b73 #e9c39b",
+    "Cell": "#c84c3a #2f7e8f #e1a22e #4e5a8a #5f9862 #d07a6a #8b6fa8 #7b8c9e #b85f7a #6b6b6b",
+    "Nature": "#e64b35 #4dbbd5 #00a087 #3c5488 #f39b7f #8491b4 #91d1c2 #dc0000 #7e6148 #b09c85",
+    "Science": "#3b4992 #ee0000 #008b45 #631879 #008280 #bb0021 #5f559b #a20056 #808180 #1b1919",
+    "Lancet": "#00468b #ed0000 #42b540 #0099b4 #925e9f #fdaf91 #ad002a #adb6b6 #1b1919",
+    "NEJM": "#bc3c29 #0072b5 #e18727 #20854e #7876b1 #6f99ad #ffdc91 #ee4c97",
+    "JAMA": "#374e55 #df8f44 #00a1d5 #b24745 #79af97 #6a6599 #80796b",
+    "JCO": "#0073c2 #efc000 #868686 #cd534c #7aa6dc #003c67 #8f7700 #3b3b3b #a73030 #4a6990",
+    "OkabeIto": "#e69f00 #56b4e9 #009e73 #f0e442 #0072b2 #d55e00 #cc79a7 #000000",
+    "TolBright": "#4477aa #ee6677 #228833 #ccbb44 #66ccee #aa3377 #bbbbbb",
+    "TolMuted": "#332288 #88ccee #44aa99 #117733 #999933 #ddcc77 #cc6677 #882255 #aa4499 #dddddd",
+    "ECharts": "#5470c6 #91cc75 #fac858 #ee6666 #9a60b4 #73c0de #3ba272 #fc8452 #27727b #ea7ccc #d7504b #e87c25 #b5c334 #fe8463 #26c0c0 #f4e001",
+    "Ecotyper1": "#d6372e #5189bb #70b460 #985ea8 #f08f35 #fadd4b #a3a3a3 #b7d3e5 #e6d8c2",
+    "Ecotyper2": "#eb7d5b #fed23f #b5d33d #6ca2ea #442288",
+    "Ecotyper3": "#d13570 #569ab4 #70ac58 #74509d #ed7e30 #f5c945 #9c5732 #e787e5",
+    "Ecotyper4": "#386cb0 #fdb462 #7fc97f #ef3b2c #662506 #a6cee3 #fb9a99 #984ea3 #ffff33",
+    "Ecotyper5": "#e41a71 #379db8 #5baf4a #7b4ea3 #ff7600 #ffc800 #a65328 #f781ec #999999 #a6dce3 #bbdf8a #fb9a99 #fdb96f #beb2d6 #1b9e5e #d95802 #707eb3 #e729d3 #e69f02 #8dd3b9 #fffab3 #babfda #fb7f72 #80c5d3 #fdae62 #bede69 #fccdf7",
+    "Ecotyper6": "#fdc086 #386cb0 #f0027f #ffff99 #bf5b17 #7fc97f #add8e6 #beaed4 #66c2a5 #fc8d62 #8da0cb #e78ac3 #a6d854 #ffd92f #e5c494 #b3b3b3 #fbb4ae #b3cde3 #ccebc5 #decbe4 #fed9a6 #ffffcc #e5d8bd #fddaec",
+}
+
+# Digests cover every color in the full 256-entry LUT and its under/over/bad colors.
+# Quantization ignores platform-level interpolation roundoff below 12 decimals.
+_CONTINUOUS_DIGESTS = {
+    "BuRd_custom": "4587995577590c256dfbcfb541675b616f3060bec4288a7997b68d3738182f53",
+    "WhYlOrRd_custom": "5ff215821beb27b6c5ae0e98e8d3fdfe16d77852745d069380f2f675dc831ae0",
+    "OrBu_custom": "be1c869700b3277bb8710aa0d5a5dc0110f4936d9bdd4bfe11ffd64b1f5c6891",
+    "YlGnBu_custom": "1331c9e6250663679fbe167cba07a3886e2c79d55714e0dd0d9744844e17b4a3",
+    "parula": "c92bd1f664a80f2b686330ba97985de329f1cb5152e29ba511b55d8f023ed575",
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        _palettes, "_PALETTE_REGISTRY", _palettes._PALETTE_REGISTRY.copy()
+    )
+
+
+@pytest.mark.parametrize("name", _QUALITATIVE_COLORS)
+def test_builtin_qualitative_palette_preserves_all_colors_and_type(name: str) -> None:
+    palette = cns.palettes(name)
+    expected = [mcolors.to_rgb(color) for color in _QUALITATIVE_COLORS[name].split()]
+
+    expected_type = (
+        list if name in list(_QUALITATIVE_COLORS)[:11] else sns.palettes._ColorPalette
+    )
+    assert type(palette) is expected_type
+    assert palette == expected
+
+
+@pytest.mark.parametrize("name", _CONTINUOUS_DIGESTS)
+def test_builtin_continuous_palette_preserves_full_lookup_table(name: str) -> None:
+    palette = cns.palettes(name)
+
+    assert type(palette) is LinearSegmentedColormap
+    assert palette.name == name
+    assert palette.N == 256
+    lut = np.vstack((palette(np.arange(-1, palette.N + 1)), palette(np.nan)))
+    digest = hashlib.sha256(np.rint(lut * 10**12).astype("<i8").tobytes()).hexdigest()
+    assert digest == _CONTINUOUS_DIGESTS[name]
+
+
+def test_palette_discovery_matches_builtin_types_and_order() -> None:
+    qualitative = list(_QUALITATIVE_COLORS)
+    continuous = list(_CONTINUOUS_DIGESTS)
+
+    assert cns.available_palettes() == qualitative + continuous
+    assert cns.available_palettes("qualitative") == qualitative
+    assert cns.available_palettes("continuous") == continuous
+    assert get_args(_utils._QualitativePaletteName) == tuple(qualitative)
+    assert get_args(_utils._ContinuousPaletteName) == tuple(continuous)
+    assert "viridis" not in cns.available_palettes()
+
+
+@pytest.mark.parametrize("kind", ["sequential", "", "Qualitative", 1, []])
+def test_palette_discovery_rejects_invalid_kind(kind: object) -> None:
+    with pytest.raises(ValueError, match="kind.*qualitative.*continuous"):
+        cns.available_palettes(cast(Any, kind))
+
+
+def test_palette_discovery_does_not_construct_palettes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_factory() -> None:
+        pytest.fail("Palette discovery must not resolve a palette")
+
+    for name, spec in _palettes._PALETTE_REGISTRY.items():
+        monkeypatch.setitem(
+            _palettes._PALETTE_REGISTRY,
+            name,
+            _palettes._PaletteSpec(spec.kind, cast(Any, unexpected_factory)),
+        )
+
+    assert cns.available_palettes() == list(_QUALITATIVE_COLORS) + list(
+        _CONTINUOUS_DIGESTS
+    )
+    assert cns.available_palettes("qualitative") == list(_QUALITATIVE_COLORS)
+    assert cns.available_palettes("continuous") == list(_CONTINUOUS_DIGESTS)
+
+
+def test_palette_discovery_does_not_import_plotting_dependencies() -> None:
+    script = """
+import sys
+import cnsplots as cns
+
+assert cns.available_palettes()
+assert cns.available_palettes("qualitative")
+assert cns.available_palettes("continuous")
+assert "cnsplots._utils" not in sys.modules
+heavy_modules = {
+    "Bio", "PyComplexHeatmap", "gseapy", "lifelines", "matplotlib", "numpy",
+    "palettable", "pandas", "scanpy", "scipy", "seaborn", "sklearn", "statsmodels",
+}
+assert not ({name.split(".")[0] for name in sys.modules} & heavy_modules)
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
+@pytest.mark.parametrize("name", ["NPG", "AAAS", "viridis", "missing", "set1"])
+def test_unknown_palette_name_preserves_error(name: str) -> None:
+    with pytest.raises(RuntimeError, match="^Wrong Choice!$"):
+        cns.palettes(name)
+
+
+@pytest.mark.parametrize("colors", [["red", "#00ff00"], ((0, 0, 1), "black"), []])
+def test_explicit_color_sequences_preserve_seaborn_conversion(
+    colors: Sequence[ColorType],
+) -> None:
+    palette = cns.palettes(colors)
+
+    assert type(palette) is sns.palettes._ColorPalette
+    assert palette == sns.color_palette(colors)
+
+
+def test_register_palette_resolves_and_extends_qualitative_discovery() -> None:
+    initial_names = cns.available_palettes()
+    initial_qualitative = cns.available_palettes("qualitative")
+    initial_continuous = cns.available_palettes("continuous")
+    colors: list[ColorType] = ["red", "#00ff00", (0, 0, 1, 0.5)]
+
+    assert cns.register_palette("Study palette", colors) is None
+    cns.register_palette("Second study", ("white", "black"))
+
+    assert cns.palettes("Study palette") == [mcolors.to_rgb(color) for color in colors]
+    expected_subset = ["#0000ff", "#ff0000", "#0000ff"]
+    assert cns.get_palette_colors([2, 0, 2], "Study palette") == expected_subset
+    assert (
+        cns.get_hexcolors_from_apalette([2, 0, 2], "Study palette") == expected_subset
+    )
+    assert cns.palettes("Second study") == [(1, 1, 1), (0, 0, 0)]
+    assert cns.available_palettes() == initial_names + ["Study palette", "Second study"]
+    assert cns.available_palettes("qualitative") == initial_qualitative + [
+        "Study palette",
+        "Second study",
+    ]
+    assert cns.available_palettes("continuous") == initial_continuous
+    assert "Study palette" not in mpl.colormaps
+
+
+def test_registered_palette_works_as_figure_color_cycle() -> None:
+    colors = ["#112233", "#445566", "#778899"]
+    cns.register_palette("Figure study", colors)
+
+    with mpl.rc_context():
+        cns.figure(color_cycle="Figure study")
+        ax = plt.gca()
+        lines = [ax.plot([0, 1], [index, index + 1])[0] for index in range(4)]
+
+    assert [mcolors.to_hex(line.get_color()) for line in lines] == colors + colors[:1]
+    assert cns.palettes("Figure study") == [mcolors.to_rgb(color) for color in colors]
+
+
+def test_registration_defensively_copies_mutable_inputs_and_outputs() -> None:
+    colors = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+    cns.register_palette("Mutable study", cast(Sequence[ColorType], colors))
+
+    colors[0][0] = 0.0
+    colors[1] = [0.0, 0.0, 1.0]
+    colors.append([0.5, 0.5, 0.5])
+    first = cns.palettes("Mutable study")
+    assert isinstance(first, list)
+    first[0] = (0.0, 0.0, 0.0)
+    first.append((1.0, 1.0, 1.0))
+
+    assert cns.palettes("Mutable study") == [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    discovered = cns.available_palettes()
+    discovered.clear()
+    assert "Mutable study" in cns.available_palettes()
+
+
+@pytest.mark.parametrize("name", _QUALITATIVE_COLORS)
+def test_builtin_palette_results_are_independent(name: str) -> None:
+    palette = cns.palettes(name)
+    assert isinstance(palette, list)
+    palette[0] = (0.0, 0.0, 0.0)
+    palette.clear()
+
+    assert cns.palettes(name) == [
+        mcolors.to_rgb(color) for color in _QUALITATIVE_COLORS[name].split()
+    ]
+
+
+@pytest.mark.parametrize("name", _CONTINUOUS_DIGESTS)
+def test_builtin_colormap_results_are_independent(name: str) -> None:
+    palette = cns.palettes(name)
+    assert isinstance(palette, Colormap)
+    palette.set_bad("red")
+
+    fresh = cns.palettes(name)
+    assert isinstance(fresh, Colormap)
+    assert fresh is not palette
+    assert fresh(np.nan) == (0.0, 0.0, 0.0, 0.0)
+
+
+@pytest.mark.parametrize("name", [None, 1, b"study"])
+def test_register_palette_rejects_nonstring_names(name: object) -> None:
+    with pytest.raises(TypeError, match="name.*string"):
+        cns.register_palette(cast(str, name), ["red"])
+
+
+@pytest.mark.parametrize("name", ["", " ", "\t\n"])
+def test_register_palette_rejects_blank_names(name: str) -> None:
+    with pytest.raises(ValueError, match="name.*(empty|blank|nonempty|non-empty)"):
+        cns.register_palette(name, ["red"])
+
+
+@pytest.mark.parametrize("name", ["Set1", "Nature", "parula", "viridis", "tab10"])
+def test_register_palette_rejects_builtin_and_matplotlib_collisions(name: str) -> None:
+    before = cns.available_palettes()
+    existing_cmap = mpl.colormaps[name] if name in mpl.colormaps else None
+
+    with pytest.raises(ValueError, match="already|exist|registered|reserved"):
+        cns.register_palette(name, ["red"])
+
+    assert cns.available_palettes() == before
+    if existing_cmap is not None:
+        np.testing.assert_array_equal(
+            mpl.colormaps[name](np.linspace(0, 1, 5)),
+            existing_cmap(np.linspace(0, 1, 5)),
+        )
+
+
+def test_register_palette_rejects_duplicate_custom_names() -> None:
+    cns.register_palette("Duplicate study", ["red"])
+
+    with pytest.raises(ValueError, match="already|exist|registered|reserved"):
+        cns.register_palette("Duplicate study", ["blue"])
+
+    assert cns.palettes("Duplicate study") == [(1.0, 0.0, 0.0)]
+    assert cns.available_palettes().count("Duplicate study") == 1
+
+
+@pytest.mark.parametrize("colors", [None, 1, "red", b"red", {"red"}, {"a": "red"}])
+def test_register_palette_requires_color_sequence(colors: object) -> None:
+    before = cns.available_palettes()
+    with pytest.raises(TypeError, match="colors.*sequence"):
+        cns.register_palette("Invalid study", cast(Sequence[ColorType], colors))
+    assert cns.available_palettes() == before
+
+
+@pytest.mark.parametrize("colors", [[], ()])
+def test_register_palette_rejects_empty_sequences(colors: Sequence[ColorType]) -> None:
+    with pytest.raises(ValueError, match="(empty|at least one)"):
+        cns.register_palette("Empty study", colors)
+    assert "Empty study" not in cns.available_palettes()
+
+
+@pytest.mark.parametrize(
+    "color", ["not-a-color", (1.1, 0.0, 0.0), (float("nan"), 0, 0), (0, 1), object()]
+)
+def test_register_palette_rejects_invalid_colors_without_partial_registration(
+    color: object,
+) -> None:
+    with pytest.raises(ValueError, match="(invalid|Invalid|color)"):
+        cns.register_palette("Invalid color study", ["red", cast(ColorType, color)])
+    assert "Invalid color study" not in cns.available_palettes()
+
+    cns.register_palette("Invalid color study", ["blue"])
+    assert cns.palettes("Invalid color study") == [(0.0, 0.0, 1.0)]

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -215,7 +215,7 @@ assert not {
     src_path = Path(__file__).parents[1] / "src"
     no_site_script = (
         f"import sys; sys.path.insert(0, {str(src_path)!r}); "
-        "import cnsplots; assert len(cnsplots.__all__) == 64"
+        "import cnsplots; assert len(cnsplots.__all__) == 67"
     )
     subprocess.run([sys.executable, "-S", "-c", no_site_script], check=True)
 

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -57,6 +57,17 @@ if TYPE_CHECKING:
         assert_type(cns.apply_unicode_font(ax), None)
         assert_type(cns.take_legend_out("Group"), None)
         assert_type(cns.get_hexcolors_from_apalette([0], "Set1"), list[str])
+        assert_type(
+            cns.get_hexcolors_from_apalette(alist=[0], palette="Set1"), list[str]
+        )
+        assert_type(cns.get_palette_colors([0]), list[str])
+        assert_type(cns.get_palette_colors([0], palette=None), list[str])
+        assert_type(cns.get_palette_colors(indices=(0, 2), palette="Set1"), list[str])
+        assert_type(cns.get_palette_colors([1], ["red", (0.1, 0.2, 0.3)]), list[str])
+        assert_type(cns.available_palettes(), list[str])
+        assert_type(cns.available_palettes(kind="qualitative"), list[str])
+        assert_type(cns.available_palettes(kind="continuous"), list[str])
+        assert_type(cns.register_palette("MyLab", ["red", (0.1, 0.2, 0.3)]), None)
         assert_type(cns.palettes("Set1"), list[tuple[float, float, float]])
         assert_type(cns.palettes("parula"), Colormap)
         assert_type(cns.boxplot(data, x="group", y="value"), Axes)


### PR DESCRIPTION
## What changed

Make palettes discoverable and reusable by name while preserving existing palette values and color-selection calls.

- Replace built-in dispatch with a shared lazy registry and expose `available_palettes()` with qualitative/continuous filtering. Discovery lists cnsplots and registered palettes without loading plotting dependencies.
- Add `register_palette()` for qualitative color sequences, with defensive copies and clear errors for invalid colors or existing cnsplots/Matplotlib names. Registered names work with `palettes()` and figure color cycles.
- Add `get_palette_colors(indices, palette=...)` with call-time Set1 defaults, retaining `get_hexcolors_from_apalette(alist, palette=...)` as a compatible wrapper.
- Update public exports, typing, API documentation, and examples; add regressions for every built-in palette and the new APIs.

## How it was tested

- `make test`
- `make lint` (using the existing repository-local tool cache offline)
- Compared all 33 built-in palettes against the original values and return types; tested lazy imports, registered figure cycles, mutation isolation, invalid colors, and legacy calls.

## Risks or follow-ups

Registration lasts for the current Python process and supports qualitative sequences only. Existing names cannot be overwritten, and external Matplotlib names are excluded from discovery. Existing palette values, ordering, return types, and unknown-name errors are preserved.

## Related issue

Closes #145
Closes #146
Closes #147

## Release Notes Label

`enhancement`
