### PR TITLE
✨ Add safe skill lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,21 @@ cnsplots skill install --agent claude --scope project
 ```
 
 Use `$cnsplots` in Codex or `/cnsplots` in Claude Code to invoke it explicitly.
-Pass `--force` to update an existing installation after upgrading cnsplots.
+Inspect, update, or remove an installation with the same agent and scope options:
+
+```bash
+cnsplots skill status
+cnsplots skill install --force
+cnsplots skill uninstall --agent claude --scope project
+cnsplots skill --help
+```
+
+Status reports the destination, installed version, and whether the content
+matches the bundled skill. Updates overwrite current packaged files and remove
+unchanged obsolete files, while preserving unrelated files and modified obsolete
+files. Uninstall removes only unchanged managed files and preserves local edits.
+See the [installation guide](docs/installation.md#install-the-agent-skill) for
+ownership tracking, legacy installations, and exit codes.
 
 ### For Development
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,7 +35,65 @@ cnsplots skill install --agent claude --scope project
 ```
 
 Invoke the installed skill as `$cnsplots` in Codex or `/cnsplots` in Claude
-Code. After upgrading cnsplots, pass `--force` to update an existing skill.
+Code. The `install`, `status`, and `uninstall` commands all accept
+`--agent all|codex|claude` (default: `all`) and `--scope user|project`
+(default: `user`). Project scope uses `.agents/skills/cnsplots` and
+`.claude/skills/cnsplots` beneath the current directory.
+
+Inspect installed skills without changing any files:
+
+```bash
+cnsplots skill status
+cnsplots skill status --agent codex --scope project
+```
+
+Status reports each resolved destination, installed cnsplots version (or
+`unknown`), and whether its content `matches` or `differs` from the bundled
+skill (`unavailable` when it cannot be compared). The installation state is
+`missing`, `current`, `modified`, `outdated`, or `unmanaged`. Installations
+without an ownership manifest are unmanaged. Changed or missing managed files
+are reported as modified; otherwise, a different version or packaged content
+is reported as outdated.
+
+After upgrading cnsplots, update an existing skill with:
+
+```bash
+cnsplots skill install --force
+```
+
+Each installation records its version and managed file hashes in
+`.cnsplots-manifest.json`. A forced update overwrites current packaged files,
+including local edits to those files. It removes obsolete managed files only
+when their content is unchanged, and preserves modified obsolete files and
+unrelated files. If a newly introduced packaged file conflicts with a different
+unrelated file in a managed installation, the update fails instead of overwriting
+that file.
+
+For legacy installations without a manifest, `install --force` overwrites the
+current package's file paths and starts ownership tracking. It preserves other
+existing files, including obsolete files that have no recorded ownership.
+
+Remove an installed skill with:
+
+```bash
+cnsplots skill uninstall
+cnsplots skill uninstall --agent claude --scope project
+```
+
+Uninstall removes unchanged managed files and the ownership manifest. Modified
+and unrelated files remain in place and become unmanaged. An already missing
+installation succeeds without changes. An existing installation without a
+manifest cannot be uninstalled automatically; use `install --force` first only
+if overwriting the current package's file paths is acceptable. Uninstall has no
+`--force` option.
+
+Commands refuse symlinked destinations, destination path components, or managed
+paths. Unrelated symlinks are preserved.
+
+Use `cnsplots skill --help` or `cnsplots skill <command> --help` for command
+options. Successful commands return exit code `0`; status also returns `0` for
+missing or differing installations. Operational errors return `1`, and invalid
+command usage returns `2`.
 
 ## Verify Installation
 

--- a/src/cnsplots/_cli.py
+++ b/src/cnsplots/_cli.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
+import re
+import shutil
 import sys
+import tempfile
 from collections.abc import Sequence
+from dataclasses import dataclass
 from importlib import resources
+from importlib.metadata import version
 from pathlib import Path
 
 if sys.version_info >= (3, 11):
@@ -17,20 +24,186 @@ _AGENT_SKILL_DIRS = {
     "codex": Path(".agents") / "skills",
     "claude": Path(".claude") / "skills",
 }
+_MANIFEST = ".cnsplots-manifest.json"
+_PACKAGE_VERSION = version("cnsplots")
+
+
+@dataclass
+class _Manifest:
+    version: str
+    files: dict[str, str]
+
+
+@dataclass
+class _SkillStatus:
+    agent: str
+    destination: Path
+    state: str
+    version: str | None
+    content_match: bool | None
+
+
+@dataclass
+class _Plan:
+    destination: Path
+    writes: dict[str, bytes]
+    removals: tuple[str, ...]
 
 
 def _skill_source() -> Traversable:
     return resources.files("cnsplots").joinpath("_agent_skill").joinpath("cnsplots")
 
 
-def _copy_skill_tree(source: Traversable, destination: Path) -> None:
-    destination.mkdir(parents=True, exist_ok=True)
-    for item in source.iterdir():
-        target = destination / item.name
-        if item.is_dir():
-            _copy_skill_tree(item, target)
+def _validate_name(name: str) -> None:
+    if (
+        not name
+        or "\\" in name
+        or ":" in name
+        or any(part in ("", ".", "..", _MANIFEST) for part in name.split("/"))
+    ):
+        raise ValueError(f"unsafe managed file name: {name!r}")
+
+
+def _checked_path(root: Path, name: str) -> Path:
+    path = root
+    for part in name.split("/"):
+        if path.exists() and not path.is_dir():
+            raise NotADirectoryError(f"not a skill directory: {path}")
+        path = path / part
+        if path.is_symlink():
+            raise ValueError(f"refusing to follow skill symlink: {path}")
+    return path
+
+
+def _destinations(agent: str, base_dir: Path) -> tuple[tuple[str, Path], ...]:
+    names = tuple(_AGENT_SKILL_DIRS) if agent == "all" else (agent,)
+    root = base_dir.resolve()
+    destinations = []
+    for name in names:
+        if name not in _AGENT_SKILL_DIRS:
+            raise ValueError(f"unsupported agent: {name}")
+        path = _checked_path(root, (_AGENT_SKILL_DIRS[name] / "cnsplots").as_posix())
+        if path.exists() and not path.is_dir():
+            raise NotADirectoryError(f"not a skill directory: {path}")
+        destinations.append((name, path))
+    return tuple(destinations)
+
+
+def _packaged_files() -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+
+    def read_tree(source: Traversable, prefix: str = "") -> None:
+        if isinstance(source, Path) and source.is_symlink():
+            raise ValueError(f"packaged skill contains a symlink: {source}")
+        if source.is_dir():
+            for item in source.iterdir():
+                name = f"{prefix}/{item.name}" if prefix else item.name
+                _validate_name(name)
+                read_tree(item, name)
+        elif source.is_file():
+            files[prefix] = source.read_bytes()
         else:
-            target.write_bytes(item.read_bytes())
+            raise ValueError(f"invalid packaged skill entry: {source}")
+
+    read_tree(_skill_source())
+    if not files.get("SKILL.md"):
+        raise ValueError("packaged skill must contain a nonempty SKILL.md")
+    return files
+
+
+def _digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _file_digest(destination: Path, name: str) -> str | None:
+    path = _checked_path(destination, name)
+    if not path.exists():
+        return None
+    if not path.is_file():
+        raise ValueError(f"expected a managed skill file: {path}")
+    return _digest(path.read_bytes())
+
+
+def _read_manifest(destination: Path) -> _Manifest | None:
+    path = _checked_path(destination, _MANIFEST)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        raise ValueError(f"invalid skill manifest: {path}") from exc
+    if (
+        not isinstance(data, dict)
+        or data.get("schema_version") != 1
+        or not isinstance(data.get("version"), str)
+        or not isinstance(data.get("files"), dict)
+    ):
+        raise ValueError(f"invalid skill manifest: {path}")
+    files = data["files"]
+    for name, digest in files.items():
+        _validate_name(name)
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError(f"invalid file hash in skill manifest: {path}")
+        if any(parent.as_posix() in files for parent in Path(name).parents):
+            raise ValueError(f"conflicting file paths in skill manifest: {path}")
+    return _Manifest(data["version"], files)
+
+
+def _apply_plans(plans: Sequence[_Plan]) -> None:
+    """Stage every target, then swap trees; restore originals on an I/O failure."""
+    staged: list[tuple[_Plan, Path]] = []
+    backups: list[tuple[Path, Path]] = []
+    installed: list[tuple[Path, Path]] = []
+    cleanup = True
+    try:
+        for plan in plans:
+            destination = plan.destination
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            work = Path(tempfile.mkdtemp(prefix=".cnsplots-", dir=destination.parent))
+            staged.append((plan, work))
+            tree = work / "new"
+            if destination.exists():
+                shutil.copytree(destination, tree, symlinks=True)
+            else:
+                tree.mkdir()
+            for name in plan.removals:
+                path = tree / name
+                path.unlink(missing_ok=True)
+                parent = path.parent
+                while parent != tree and parent.exists() and not any(parent.iterdir()):
+                    parent.rmdir()
+                    parent = parent.parent
+            for name, content in plan.writes.items():
+                path = tree / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(content)
+
+        for plan, work in staged:
+            destination = plan.destination
+            if destination.exists():
+                destination.rename(work / "old")
+                backups.append((destination, work / "old"))
+            tree = work / "new"
+            if any(tree.iterdir()):
+                tree.rename(destination)
+                installed.append((destination, tree))
+    except OSError:
+        try:
+            for destination, tree in reversed(installed):
+                destination.rename(tree)
+            for destination, backup in reversed(backups):
+                backup.rename(destination)
+        except OSError as exc:
+            cleanup = False
+            paths = ", ".join(str(work) for _, work in staged)
+            raise OSError(
+                f"skill rollback failed; recovery copies retained at {paths}"
+            ) from exc
+        raise
+    finally:
+        if cleanup:
+            for _, work in staged:
+                shutil.rmtree(work, ignore_errors=True)
 
 
 def install_skill(
@@ -39,12 +212,14 @@ def install_skill(
     force: bool,
     base_dir: Path,
 ) -> tuple[tuple[str, Path], ...]:
-    """Install the packaged skill into one or more agent skill directories."""
-    agent_names = tuple(_AGENT_SKILL_DIRS) if agent == "all" else (agent,)
-    destinations = tuple(
-        (name, base_dir / _AGENT_SKILL_DIRS[name] / "cnsplots") for name in agent_names
-    )
+    """Install and track packaged files, requiring force to update existing skills.
 
+    Forced updates overwrite current managed files, including local edits. Only
+    unchanged obsolete files are removed. Legacy installs are overlaid without
+    deleting untracked files; new conflicts in managed installs are refused.
+    All targets are validated and staged before replacing any installation.
+    """
+    destinations = _destinations(agent, base_dir)
     conflicts = tuple(path for _, path in destinations if path.exists())
     if conflicts and not force:
         paths = ", ".join(str(path) for path in conflicts)
@@ -52,9 +227,93 @@ def install_skill(
             f"refusing to overwrite existing skill at {paths}; pass --force to update"
         )
 
-    source = _skill_source()
+    files = _packaged_files()
+    hashes = {name: _digest(content) for name, content in files.items()}
+    manifest_bytes = (
+        json.dumps(
+            {"schema_version": 1, "version": _PACKAGE_VERSION, "files": hashes},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+    plans = []
     for _, destination in destinations:
-        _copy_skill_tree(source, destination)
+        manifest = _read_manifest(destination)
+        old_files = manifest.files if manifest else {}
+        old_hashes = {name: _file_digest(destination, name) for name in old_files}
+        for name, digest in hashes.items():
+            existing = _file_digest(destination, name)
+            if manifest and name not in old_files and existing not in (None, digest):
+                raise FileExistsError(
+                    f"untracked skill file conflicts with update: {destination / name}"
+                )
+        removals = tuple(
+            name
+            for name, digest in old_files.items()
+            if name not in files and old_hashes[name] == digest
+        )
+        plans.append(_Plan(destination, {**files, _MANIFEST: manifest_bytes}, removals))
+    _apply_plans(plans)
+    return destinations
+
+
+def skill_status(agent: str, *, base_dir: Path) -> tuple[_SkillStatus, ...]:
+    """Inspect selected paths without writes; unrelated files do not affect matches.
+
+    States are missing, unmanaged (no manifest), modified (managed files changed
+    or missing), outdated (unchanged but differs from this package), and current.
+    """
+    destinations = _destinations(agent, base_dir)
+    hashes = {name: _digest(content) for name, content in _packaged_files().items()}
+    statuses = []
+    for name, destination in destinations:
+        if not destination.exists():
+            statuses.append(_SkillStatus(name, destination, "missing", None, None))
+            continue
+        manifest = _read_manifest(destination)
+        installed = {name: _file_digest(destination, name) for name in hashes}
+        matches = installed == hashes
+        state = "unmanaged"
+        version = None
+        if manifest:
+            version = manifest.version
+            managed = {name: _file_digest(destination, name) for name in manifest.files}
+            if managed != manifest.files:
+                state = "modified"
+            elif manifest.files != hashes or version != _PACKAGE_VERSION:
+                state = "outdated"
+            else:
+                state = "current"
+            matches = matches and manifest.files.keys() == hashes.keys()
+        statuses.append(_SkillStatus(name, destination, state, version, matches))
+    return tuple(statuses)
+
+
+def uninstall_skill(agent: str, *, base_dir: Path) -> tuple[tuple[str, Path], ...]:
+    """Remove unchanged managed files; retain edits and unrelated content.
+
+    Missing paths succeed. Existing directories without a manifest are refused.
+    Retained files become unmanaged when the ownership manifest is removed.
+    """
+    destinations = _destinations(agent, base_dir)
+    plans = []
+    for _, destination in destinations:
+        if not destination.exists():
+            continue
+        manifest = _read_manifest(destination)
+        if manifest is None:
+            raise ValueError(
+                f"no ownership manifest at {destination}; run install --force to track "
+                "packaged files before uninstall (overwrites packaged paths)"
+            )
+        removals = tuple(
+            name
+            for name, digest in manifest.files.items()
+            if _file_digest(destination, name) == digest
+        )
+        plans.append(_Plan(destination, {}, (*removals, _MANIFEST)))
+    _apply_plans(plans)
     return destinations
 
 
@@ -63,43 +322,92 @@ def _build_parser() -> argparse.ArgumentParser:
     commands = parser.add_subparsers(dest="command", required=True)
     skill = commands.add_parser("skill", help="manage the cnsplots agent skill")
     skill_commands = skill.add_subparsers(dest="skill_command", required=True)
-    install = skill_commands.add_parser("install", help="install the agent skill")
-    install.add_argument(
-        "--agent",
-        choices=("all", "codex", "claude"),
-        default="all",
-        help="agent to configure (default: all)",
-    )
-    install.add_argument(
-        "--scope",
-        choices=("user", "project"),
-        default="user",
-        help="install globally for the user or into the current project",
-    )
-    install.add_argument(
-        "--force",
-        action="store_true",
-        help="update files in an existing cnsplots skill",
-    )
+    for command, description in (
+        ("install", "install the agent skill"),
+        (
+            "status",
+            "show read-only installation status (exit 0 even if missing or changed)",
+        ),
+        (
+            "uninstall",
+            "remove unchanged managed files; retain modified and unrelated files "
+            "(missing installations succeed)",
+        ),
+    ):
+        subparser = skill_commands.add_parser(
+            command,
+            help=description,
+            description=description,
+            epilog="Exit codes: 0 success, 1 operational error, 2 invalid arguments.",
+        )
+        subparser.add_argument(
+            "--agent",
+            choices=("all", "codex", "claude"),
+            default="all",
+            help="agent to target (default: all)",
+        )
+        subparser.add_argument(
+            "--scope",
+            choices=("user", "project"),
+            default="user",
+            help="target the user's home or the current project (default: user)",
+        )
+        if command == "install":
+            subparser.add_argument(
+                "--force",
+                action="store_true",
+                help="update existing files, overwriting edits to current packaged files",
+            )
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run the cnsplots command line interface."""
+    """Run the CLI; return 0 on success or 1 on operational errors.
+
+    Status reports succeed even for missing or differing installations. Invalid
+    arguments are handled by argparse with exit code 2.
+    """
     parser = _build_parser()
     args = parser.parse_args(argv)
-    base_dir = Path.home() if args.scope == "user" else Path.cwd()
-
     try:
-        destinations = install_skill(
-            args.agent,
-            force=args.force,
-            base_dir=base_dir,
-        )
-    except FileExistsError as exc:
+        base_dir = Path.home() if args.scope == "user" else Path.cwd()
+        if args.skill_command == "status":
+            for status in skill_status(args.agent, base_dir=base_dir):
+                state = (
+                    "missing"
+                    if status.state == "missing"
+                    else f"installed ({status.state})"
+                )
+                content = (
+                    "unavailable"
+                    if status.content_match is None
+                    else "matches packaged skill"
+                    if status.content_match
+                    else "differs from packaged skill"
+                )
+                print(
+                    f"{status.agent}: {state}; version {status.version or 'unknown'}; "
+                    f"content {content}; path {status.destination}"
+                )
+            return 0
+        if args.skill_command == "install":
+            destinations = install_skill(
+                args.agent, force=args.force, base_dir=base_dir
+            )
+        else:
+            destinations = uninstall_skill(args.agent, base_dir=base_dir)
+    except (OSError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
     for agent, destination in destinations:
-        print(f"Installed cnsplots skill for {agent}: {destination}")
+        if args.skill_command == "install":
+            print(f"Installed cnsplots skill for {agent}: {destination}")
+        else:
+            retained = (
+                "; retained modified or unrelated files" if destination.exists() else ""
+            )
+            print(
+                f"Uninstalled managed cnsplots skill files for {agent}: {destination}{retained}"
+            )
     return 0

--- a/tests/test_skill_lifecycle.py
+++ b/tests/test_skill_lifecycle.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from cnsplots import _cli
+
+
+@pytest.fixture
+def skill_source(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    source = tmp_path / "package"
+    _write(source / "SKILL.md", "# Original skill\n")
+    _write(source / "references" / "obsolete.md", "Original reference\n")
+    _write(source / "agents" / "openai.yaml", "name: cnsplots\n")
+    monkeypatch.setattr(_cli, "_skill_source", lambda: source)
+    return source
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _destination(base: Path, agent: str = "codex") -> Path:
+    directory = ".agents" if agent == "codex" else ".claude"
+    return base / directory / "skills" / "cnsplots"
+
+
+def _snapshot(path: Path) -> dict[str, bytes | str]:
+    return {
+        str(item.relative_to(path)): (
+            f"symlink:{item.readlink()}" if item.is_symlink() else item.read_bytes()
+        )
+        for item in path.rglob("*")
+        if item.is_file() or item.is_symlink()
+    }
+
+
+def test_install_records_file_ownership(tmp_path: Path, skill_source: Path) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("codex", force=False, base_dir=base)
+
+    destination = _destination(base)
+    manifest = json.loads((destination / _cli._MANIFEST).read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 1
+    assert isinstance(manifest["version"], str)
+    assert manifest["version"]
+    assert manifest["files"] == {
+        item.relative_to(skill_source).as_posix(): hashlib.sha256(
+            item.read_bytes()
+        ).hexdigest()
+        for item in skill_source.rglob("*")
+        if item.is_file()
+    }
+
+
+@pytest.mark.parametrize("modified_obsolete", [False, True])
+def test_upgrade_prunes_only_unchanged_obsolete_managed_files(
+    tmp_path: Path, skill_source: Path, modified_obsolete: bool
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("codex", force=False, base_dir=base)
+    destination = _destination(base)
+    obsolete = destination / "references" / "obsolete.md"
+    if modified_obsolete:
+        _write(obsolete, "Personal reference\n")
+    _write(destination / "notes" / "mine.md", "Personal notes\n")
+    _write(destination / "SKILL.md", "Locally edited current guide\n")
+    (skill_source / "references" / "obsolete.md").unlink()
+    _write(skill_source / "SKILL.md", "# Updated skill\n")
+    _write(skill_source / "references" / "new.md", "New reference\n")
+
+    _cli.install_skill("codex", force=True, base_dir=base)
+
+    assert (destination / "SKILL.md").read_text() == "# Updated skill\n"
+    assert (destination / "references" / "new.md").read_text() == "New reference\n"
+    assert (destination / "notes" / "mine.md").read_text() == "Personal notes\n"
+    assert obsolete.exists() == modified_obsolete
+    if modified_obsolete:
+        assert obsolete.read_text() == "Personal reference\n"
+    manifest = json.loads((destination / _cli._MANIFEST).read_text())
+    assert "references/obsolete.md" not in manifest["files"]
+    assert "notes/mine.md" not in manifest["files"]
+
+
+def test_force_migrates_legacy_install_without_purging_user_files(
+    tmp_path: Path, skill_source: Path
+) -> None:
+    base = tmp_path / "project"
+    destination = _destination(base)
+    _write(destination / "SKILL.md", "Legacy skill")
+    _write(destination / "references" / "legacy.md", "Keep this old reference")
+    _write(destination / "notes.txt", "User notes")
+
+    _cli.install_skill("codex", force=True, base_dir=base)
+
+    assert (destination / "SKILL.md").read_bytes() == (
+        skill_source / "SKILL.md"
+    ).read_bytes()
+    assert (destination / "references" / "legacy.md").read_text() == (
+        "Keep this old reference"
+    )
+    assert (destination / "notes.txt").read_text() == "User notes"
+    manifest = json.loads((destination / _cli._MANIFEST).read_text())
+    assert "notes.txt" not in manifest["files"]
+    assert "references/legacy.md" not in manifest["files"]
+
+
+@pytest.mark.parametrize("same_content", [False, True])
+def test_new_packaged_files_preserve_conflicting_untracked_files(
+    tmp_path: Path, skill_source: Path, same_content: bool
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    destination = _destination(base, "claude")
+    content = "Packaged addition" if same_content else "User addition"
+    _write(destination / "new.md", content)
+    _write(skill_source / "new.md", "Packaged addition")
+    before = _snapshot(base)
+
+    if same_content:
+        _cli.install_skill("all", force=True, base_dir=base)
+        manifest = json.loads((destination / _cli._MANIFEST).read_text())
+        assert "new.md" in manifest["files"]
+    else:
+        with pytest.raises((ValueError, FileExistsError), match="new.md"):
+            _cli.install_skill("all", force=True, base_dir=base)
+        assert _snapshot(base) == before
+    assert (destination / "new.md").read_text() == content
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        "not JSON",
+        json.dumps({"schema_version": 2, "version": "1", "files": {}}),
+        json.dumps({"schema_version": 1, "version": "1", "files": []}),
+        json.dumps(
+            {"schema_version": 1, "version": "1", "files": {"../escape": "a" * 64}}
+        ),
+        json.dumps(
+            {"schema_version": 1, "version": "1", "files": {"/escape": "a" * 64}}
+        ),
+        json.dumps({"schema_version": 1, "version": "1", "files": {"SKILL.md": "bad"}}),
+        json.dumps(
+            {
+                "schema_version": 1,
+                "version": "1",
+                "files": {"references": "a" * 64, "references/file.md": "b" * 64},
+            }
+        ),
+    ],
+)
+def test_invalid_manifests_preflight_all_agents(
+    tmp_path: Path, skill_source: Path, operation: str, manifest: str
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    _write(_destination(base, "claude") / _cli._MANIFEST, manifest)
+    before = _snapshot(base)
+
+    with pytest.raises(ValueError):
+        if operation == "install":
+            _cli.install_skill("all", force=True, base_dir=base)
+        else:
+            _cli.uninstall_skill("all", base_dir=base)
+
+    assert _snapshot(base) == before
+
+
+@pytest.mark.parametrize("entry", ["missing", "empty", "symlink", "unsafe"])
+def test_invalid_packaged_files_leave_installs_untouched(
+    tmp_path: Path, skill_source: Path, entry: str
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    before = _snapshot(base)
+    if entry == "missing":
+        (skill_source / "SKILL.md").unlink()
+    elif entry == "empty":
+        _write(skill_source / "SKILL.md", "")
+    elif entry == "symlink":
+        (skill_source / "link.md").symlink_to(skill_source / "SKILL.md")
+    else:
+        _write(skill_source / "unsafe\\name", "Invalid file name")
+
+    with pytest.raises(ValueError):
+        _cli.install_skill("all", force=True, base_dir=base)
+
+    assert _snapshot(base) == before
+
+
+def test_missing_package_source_leaves_installs_untouched(
+    tmp_path: Path, skill_source: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    before = _snapshot(base)
+    monkeypatch.setattr(_cli, "_skill_source", lambda: tmp_path / "missing")
+
+    with pytest.raises(ValueError, match="packaged skill"):
+        _cli.install_skill("all", force=True, base_dir=base)
+
+    assert _snapshot(base) == before
+
+
+@pytest.mark.parametrize("component", [".agents", ".agents/skills/cnsplots"])
+def test_install_refuses_nondirectory_destinations(
+    tmp_path: Path, skill_source: Path, component: str
+) -> None:
+    base = tmp_path / "project"
+    _write(base / component, "User file")
+    before = _snapshot(base)
+
+    with pytest.raises(NotADirectoryError):
+        _cli.install_skill("all", force=True, base_dir=base)
+
+    assert _snapshot(base) == before
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+def test_replaced_managed_file_directory_is_preserved(
+    tmp_path: Path, skill_source: Path, operation: str
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    path = _destination(base, "claude") / "SKILL.md"
+    path.unlink()
+    _write(path / "notes.md", "User directory")
+    before = _snapshot(base)
+
+    with pytest.raises(ValueError, match="managed skill file"):
+        if operation == "install":
+            _cli.install_skill("all", force=True, base_dir=base)
+        else:
+            _cli.uninstall_skill("all", base_dir=base)
+
+    assert _snapshot(base) == before
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+@pytest.mark.parametrize(
+    "component", [".agents", ".agents/skills", ".agents/skills/cnsplots"]
+)
+def test_selected_symlink_destinations_are_rejected(
+    tmp_path: Path, skill_source: Path, operation: str, component: str
+) -> None:
+    base = tmp_path / "project"
+    outside = tmp_path / "outside"
+    _write(outside / "keep.md", "Outside data")
+    link = base / component
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(outside, target_is_directory=True)
+    before = _snapshot(outside)
+
+    with pytest.raises((ValueError, OSError), match="symlink"):
+        if operation == "install":
+            _cli.install_skill("codex", force=True, base_dir=base)
+        else:
+            _cli.uninstall_skill("codex", base_dir=base)
+
+    assert link.is_symlink()
+    assert _snapshot(outside) == before
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+@pytest.mark.parametrize(
+    "relative", ["SKILL.md", "references", ".cnsplots-manifest.json"]
+)
+def test_managed_symlinks_are_rejected_without_following_them(
+    tmp_path: Path, skill_source: Path, operation: str, relative: str
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    destination = _destination(base, "claude")
+    target = destination / relative
+    outside = tmp_path / "outside"
+    if target.is_dir():
+        target.rename(outside)
+    else:
+        outside.write_bytes(target.read_bytes())
+        target.unlink()
+    target.symlink_to(outside, target_is_directory=outside.is_dir())
+    before = _snapshot(base)
+
+    with pytest.raises((ValueError, OSError), match="symlink"):
+        if operation == "install":
+            _cli.install_skill("all", force=True, base_dir=base)
+        else:
+            _cli.uninstall_skill("all", base_dir=base)
+
+    assert _snapshot(base) == before
+    assert target.is_symlink()
+
+
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+def test_unrelated_symlinks_survive(
+    tmp_path: Path, skill_source: Path, operation: str
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("codex", force=False, base_dir=base)
+    destination = _destination(base)
+    outside = tmp_path / "outside"
+    _write(outside / "notes.md", "Outside data")
+    link = destination / "personal"
+    link.symlink_to(outside, target_is_directory=True)
+    dangling = destination / "dangling"
+    dangling.symlink_to(tmp_path / "missing")
+
+    if operation == "install":
+        _cli.install_skill("codex", force=True, base_dir=base)
+    else:
+        _cli.uninstall_skill("codex", base_dir=base)
+
+    assert link.is_symlink()
+    assert link.readlink() == outside
+    assert dangling.is_symlink()
+    assert (outside / "notes.md").read_text() == "Outside data"
+
+
+def test_uninstall_removes_only_selected_skill(
+    tmp_path: Path, skill_source: Path
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    sibling = base / ".agents" / "skills" / "other" / "SKILL.md"
+    _write(sibling, "Another skill")
+    other_before = _snapshot(_destination(base, "claude"))
+
+    result = _cli.uninstall_skill("codex", base_dir=base)
+
+    assert result == (("codex", _destination(base)),)
+    assert not _destination(base).exists()
+    assert sibling.read_text() == "Another skill"
+    assert _snapshot(_destination(base, "claude")) == other_before
+
+
+def test_uninstall_preserves_modified_and_untracked_files(
+    tmp_path: Path, skill_source: Path
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("codex", force=False, base_dir=base)
+    destination = _destination(base)
+    _write(destination / "SKILL.md", "Personal skill edits")
+    _write(destination / "references" / "personal.md", "Personal reference")
+
+    _cli.uninstall_skill("codex", base_dir=base)
+
+    assert _snapshot(destination) == {
+        "SKILL.md": b"Personal skill edits",
+        "references/personal.md": b"Personal reference",
+    }
+    assert not (destination / "agents").exists()
+
+
+def test_uninstall_tolerates_missing_managed_files(
+    tmp_path: Path, skill_source: Path
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("codex", force=False, base_dir=base)
+    destination = _destination(base)
+    (destination / "SKILL.md").unlink()
+    (destination / "references" / "obsolete.md").unlink()
+    (destination / "references").rmdir()
+
+    _cli.uninstall_skill("codex", base_dir=base)
+
+    assert not destination.exists()
+
+
+def test_uninstall_missing_installations_is_idempotent(tmp_path: Path) -> None:
+    base = tmp_path / "project"
+    expected = (
+        ("codex", _destination(base)),
+        ("claude", _destination(base, "claude")),
+    )
+
+    assert _cli.uninstall_skill("all", base_dir=base) == expected
+    assert _cli.uninstall_skill("all", base_dir=base) == expected
+    assert not base.exists()
+
+
+def test_uninstall_refuses_legacy_install_before_modifying_any_agent(
+    tmp_path: Path, skill_source: Path
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("codex", force=False, base_dir=base)
+    _write(_destination(base, "claude") / "SKILL.md", "Legacy skill")
+    before = _snapshot(base)
+
+    with pytest.raises(ValueError, match="manifest"):
+        _cli.uninstall_skill("all", base_dir=base)
+
+    assert _snapshot(base) == before
+
+
+def test_upgrade_copy_failure_preserves_all_installed_files(
+    tmp_path: Path, skill_source: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    before = _snapshot(base)
+    _write(skill_source / "SKILL.md", "Updated skill")
+    original = Path.write_bytes
+
+    def fail_copy(path: Path, data: bytes) -> int:
+        if path.name == "SKILL.md":
+            raise OSError("injected copy failure")
+        return original(path, data)
+
+    monkeypatch.setattr(Path, "write_bytes", fail_copy)
+
+    with pytest.raises(OSError, match="injected copy failure"):
+        _cli.install_skill("all", force=True, base_dir=base)
+
+    assert _snapshot(base) == before
+
+
+@pytest.mark.parametrize("operation", ["upgrade", "uninstall"])
+def test_staged_removal_failure_preserves_original_installations(
+    tmp_path: Path, skill_source: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("all", force=False, base_dir=base)
+    before = _snapshot(base)
+    (skill_source / "references" / "obsolete.md").unlink()
+    original = Path.unlink
+
+    def fail_removal(path: Path, missing_ok: bool = False) -> None:
+        if path.name == "obsolete.md":
+            raise OSError("injected removal failure")
+        original(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_removal)
+
+    with pytest.raises(OSError, match="injected removal failure"):
+        if operation == "uninstall":
+            _cli.uninstall_skill("all", base_dir=base)
+        else:
+            _cli.install_skill("all", force=True, base_dir=base)
+
+    assert _snapshot(base) == before
+
+
+@pytest.mark.parametrize("operation", ["install", "upgrade", "uninstall"])
+def test_rename_failure_rolls_back_all_agents(
+    tmp_path: Path, skill_source: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    base = tmp_path / "project"
+    if operation != "install":
+        _cli.install_skill("all", force=False, base_dir=base)
+    before = _snapshot(base)
+    _write(skill_source / "SKILL.md", "Updated skill")
+    second = _destination(base, "claude")
+    original = Path.rename
+    failed = False
+
+    def fail_second(path: Path, target: Path) -> Path:
+        nonlocal failed
+        if not failed and (path == second or Path(target) == second):
+            failed = True
+            raise OSError("injected rename failure")
+        return original(path, target)
+
+    monkeypatch.setattr(Path, "rename", fail_second)
+
+    with pytest.raises(OSError, match="injected rename failure"):
+        if operation == "uninstall":
+            _cli.uninstall_skill("all", base_dir=base)
+        else:
+            _cli.install_skill("all", force=operation == "upgrade", base_dir=base)
+
+    assert failed
+    assert _snapshot(base) == before
+    if operation == "install":
+        assert not _destination(base).exists()
+        assert not second.exists()
+
+
+def test_failed_rollback_retains_recovery_copy(
+    tmp_path: Path, skill_source: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "project"
+    _cli.install_skill("codex", force=False, base_dir=base)
+    destination = _destination(base)
+    before = _snapshot(destination)
+    _write(skill_source / "SKILL.md", "Updated skill")
+    original = Path.rename
+
+    def fail_restore(path: Path, target: Path) -> Path:
+        if Path(target) == destination:
+            raise OSError("injected destination rename failure")
+        return original(path, target)
+
+    monkeypatch.setattr(Path, "rename", fail_restore)
+
+    with pytest.raises(OSError, match="recovery copies retained") as error:
+        _cli.install_skill("codex", force=True, base_dir=base)
+
+    backups = list(destination.parent.glob(".cnsplots-*/old"))
+    assert len(backups) == 1
+    assert _snapshot(backups[0]) == before
+    assert str(backups[0].parent) in str(error.value)
+
+
+@pytest.mark.parametrize("scope", ["user", "project"])
+def test_cli_uninstall_targets_scope_and_reports_result(
+    tmp_path: Path,
+    skill_source: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scope: str,
+) -> None:
+    project = tmp_path / "project"
+    home = tmp_path / "home"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    _cli.install_skill("all", force=False, base_dir=project)
+    _cli.install_skill("all", force=False, base_dir=home)
+    target = home if scope == "user" else project
+    other = project if scope == "user" else home
+    before = _snapshot(other)
+
+    result = _cli.main(["skill", "uninstall", "--agent", "claude", "--scope", scope])
+
+    assert result == 0
+    assert "claude" in capsys.readouterr().out
+    assert not _destination(target, "claude").exists()
+    assert _destination(target).exists()
+    assert _snapshot(other) == before
+
+
+def test_cli_reports_uninstall_manifest_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write(_destination(tmp_path) / "SKILL.md", "Legacy skill")
+
+    result = _cli.main(["skill", "uninstall", "--agent", "codex", "--scope", "project"])
+
+    assert result == 1
+    assert "manifest" in capsys.readouterr().err

--- a/tests/test_skill_status.py
+++ b/tests/test_skill_status.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from cnsplots import __version__, _cli
+
+
+@pytest.fixture
+def packaged_skill(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    source = tmp_path / "packaged"
+    source.mkdir()
+    (source / "SKILL.md").write_text("packaged skill\n", encoding="utf-8")
+    (source / "references").mkdir()
+    (source / "references" / "guide.md").write_text("guide\n", encoding="utf-8")
+    monkeypatch.setattr(_cli, "_skill_source", lambda: source)
+    return source
+
+
+def _destination(base: Path, agent: str) -> Path:
+    directory = ".agents" if agent == "codex" else ".claude"
+    return base / directory / "skills" / "cnsplots"
+
+
+def _installed_skill(source: Path, base: Path, agent: str = "codex") -> Path:
+    destination = _destination(base, agent)
+    files = {}
+    for item in source.rglob("*"):
+        if item.is_file():
+            relative = item.relative_to(source)
+            target = destination / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            content = item.read_bytes()
+            target.write_bytes(content)
+            files[relative.as_posix()] = hashlib.sha256(content).hexdigest()
+    (destination / _cli._MANIFEST).write_text(
+        json.dumps({"schema_version": 1, "version": __version__, "files": files}),
+        encoding="utf-8",
+    )
+    return destination
+
+
+def _snapshot(base: Path) -> dict[Path, tuple[int, bytes | None]]:
+    return {
+        path.relative_to(base): (
+            path.stat().st_mtime_ns,
+            path.read_bytes() if path.is_file() else None,
+        )
+        for path in [base, *sorted(base.rglob("*"))]
+    }
+
+
+def test_status_reports_missing_agents_without_creating_directories(
+    tmp_path: Path, packaged_skill: Path
+) -> None:
+    base = tmp_path / "not-created"
+
+    results = _cli.skill_status("all", base_dir=base)
+
+    assert [result.agent for result in results] == ["codex", "claude"]
+    for result in results:
+        assert result.destination == _destination(base, result.agent).resolve()
+        assert result.state == "missing"
+        assert result.version is None
+        assert result.content_match is None
+    assert not base.exists()
+
+
+def test_status_rejects_unsupported_agent_without_writes(tmp_path: Path) -> None:
+    before = _snapshot(tmp_path)
+
+    with pytest.raises(ValueError, match="unsupported agent"):
+        _cli.skill_status("other", base_dir=tmp_path)
+
+    assert _snapshot(tmp_path) == before
+
+
+def test_status_reports_current_skill_and_ignores_unrelated_files(
+    tmp_path: Path, packaged_skill: Path
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    (destination / "notes.txt").write_text("keep my notes", encoding="utf-8")
+    before = _snapshot(tmp_path)
+
+    (result,) = _cli.skill_status("codex", base_dir=tmp_path)
+
+    assert result.destination == destination.resolve()
+    assert result.state == "current"
+    assert result.version == __version__
+    assert result.content_match is True
+    assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("change", ["edit", "delete"])
+def test_status_reports_modified_managed_file(
+    tmp_path: Path, packaged_skill: Path, change: str
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    guide = destination / "references" / "guide.md"
+    if change == "edit":
+        guide.write_text("local changes", encoding="utf-8")
+    else:
+        guide.unlink()
+    before = _snapshot(tmp_path)
+
+    (result,) = _cli.skill_status("codex", base_dir=tmp_path)
+
+    assert result.state == "modified"
+    assert result.version == __version__
+    assert result.content_match is False
+    assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("change", ["version", "content", "added", "removed"])
+def test_status_distinguishes_outdated_from_locally_modified(
+    tmp_path: Path, packaged_skill: Path, change: str
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    version = __version__
+    if change == "version":
+        manifest = destination / _cli._MANIFEST
+        metadata = json.loads(manifest.read_text(encoding="utf-8"))
+        metadata["version"] = version = "0.0.0"
+        manifest.write_text(json.dumps(metadata), encoding="utf-8")
+    elif change == "content":
+        (packaged_skill / "SKILL.md").write_text("new release", encoding="utf-8")
+    elif change == "added":
+        (packaged_skill / "new.md").write_text("new guide", encoding="utf-8")
+    else:
+        (packaged_skill / "references" / "guide.md").unlink()
+    before = _snapshot(tmp_path)
+
+    (result,) = _cli.skill_status("codex", base_dir=tmp_path)
+
+    assert result.state == "outdated"
+    assert result.version == version
+    assert result.content_match is (change == "version")
+    assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("matches", [True, False])
+def test_status_compares_legacy_skill_without_claiming_its_version(
+    tmp_path: Path, packaged_skill: Path, matches: bool
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    (destination / _cli._MANIFEST).unlink()
+    if not matches:
+        (destination / "SKILL.md").write_text("old skill", encoding="utf-8")
+    before = _snapshot(tmp_path)
+
+    (result,) = _cli.skill_status("codex", base_dir=tmp_path)
+
+    assert result.state == "unmanaged"
+    assert result.version is None
+    assert result.content_match is matches
+    assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("scope", ["user", "project"])
+@pytest.mark.parametrize("agent", ["all", "codex", "claude"])
+def test_cli_status_targets_requested_scope_and_agents(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scope: str,
+    agent: str,
+) -> None:
+    user = tmp_path / "user"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: user))
+    monkeypatch.chdir(project)
+    base = user if scope == "user" else project
+    selected = ("codex", "claude") if agent == "all" else (agent,)
+    for selected_agent in selected:
+        _installed_skill(packaged_skill, base, selected_agent)
+    before = _snapshot(tmp_path)
+
+    result = _cli.main(["skill", "status", "--agent", agent, "--scope", scope])
+
+    assert result == 0
+    output = capsys.readouterr()
+    assert output.err == ""
+    for selected_agent in selected:
+        assert selected_agent in output.out
+        assert str(_destination(base, selected_agent).resolve()) in output.out
+    if agent != "all":
+        other = "claude" if agent == "codex" else "codex"
+        assert other not in output.out
+    assert "current" in output.out
+    assert __version__ in output.out
+    assert "matches" in output.out
+    assert _snapshot(tmp_path) == before
+
+
+def test_cli_status_defaults_to_all_user_skills(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    user = tmp_path / "user"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: user))
+    before = _snapshot(tmp_path)
+
+    assert _cli.main(["skill", "status"]) == 0
+
+    output = capsys.readouterr()
+    assert output.err == ""
+    for agent in ("codex", "claude"):
+        assert agent in output.out
+        assert str(_destination(user, agent).resolve()) in output.out
+    assert "missing" in output.out
+    assert "unknown" in output.out
+    assert "unavailable" in output.out
+    assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("state", ["modified", "outdated", "unmanaged"])
+def test_cli_status_reports_noncurrent_installations_successfully(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    state: str,
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    if state == "modified":
+        (destination / "SKILL.md").write_text("my edits", encoding="utf-8")
+    elif state == "outdated":
+        (packaged_skill / "SKILL.md").write_text("next release", encoding="utf-8")
+    else:
+        (destination / _cli._MANIFEST).unlink()
+    monkeypatch.chdir(tmp_path)
+    before = _snapshot(tmp_path)
+
+    assert _cli.main(["skill", "status", "--scope", "project"]) == 0
+
+    output = capsys.readouterr()
+    assert output.err == ""
+    assert state in output.out
+    assert "installed" in output.out
+    assert ("matches" if state == "unmanaged" else "differs") in output.out
+    assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("command", ["status", "uninstall"])
+def test_cli_help_describes_targeting_and_exit_codes(
+    command: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exc:
+        _cli.main(["skill", command, "--help"])
+
+    assert exc.value.code == 0
+    output = capsys.readouterr().out.lower()
+    assert "--agent" in output
+    assert "{all,codex,claude}" in output
+    assert "--scope" in output
+    assert "{user,project}" in output
+    assert "default: all" in output
+    assert "default: user" in output
+    assert "--force" not in output
+    assert "0" in output
+    assert "1" in output
+    assert "2" in output
+    if command == "status":
+        assert "read-only" in output
+    else:
+        assert "missing" in output
+        assert "modified" in output
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        [],
+        ["skill"],
+        ["skill", "status", "--agent", "other"],
+        ["skill", "status", "--scope", "global"],
+        ["skill", "status", "--force"],
+        ["skill", "uninstall", "--force"],
+    ],
+)
+def test_cli_invalid_usage_exits_two(
+    arguments: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exc:
+        _cli.main(arguments)
+
+    assert exc.value.code == 2
+    assert "error:" in capsys.readouterr().err
+
+
+def test_cli_status_reports_read_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fail_status(*args: object, **kwargs: object) -> None:
+        raise PermissionError("cannot read installed skill")
+
+    monkeypatch.setattr(_cli, "skill_status", fail_status)
+
+    assert _cli.main(["skill", "status", "--scope", "project"]) == 1
+    output = capsys.readouterr()
+    assert "error:" in output.err
+    assert "cannot read installed skill" in output.err
+
+
+def test_cli_status_rejects_invalid_manifest_without_changing_files(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    (destination / _cli._MANIFEST).write_text("not JSON", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    before = _snapshot(tmp_path)
+
+    assert _cli.main(["skill", "status", "--scope", "project"]) == 1
+
+    assert "manifest" in capsys.readouterr().err.lower()
+    assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("target", ["agent", "skill", "manifest", "file"])
+def test_cli_status_rejects_symlinks_without_changes(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    target: str,
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    paths = {
+        "agent": tmp_path / ".agents",
+        "skill": destination,
+        "manifest": destination / _cli._MANIFEST,
+        "file": destination / "SKILL.md",
+    }
+    path = paths[target]
+    outside = tmp_path / "outside"
+    path.rename(outside)
+    path.symlink_to(outside, target_is_directory=outside.is_dir())
+    monkeypatch.chdir(tmp_path)
+    before = _snapshot(tmp_path)
+
+    assert _cli.main(["skill", "status", "--scope", "project"]) == 1
+
+    assert "symlink" in capsys.readouterr().err.lower()
+    assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize("scope", ["user", "project"])
+@pytest.mark.parametrize("agent", ["all", "codex", "claude"])
+def test_cli_uninstall_targets_requested_scope_and_agents(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scope: str,
+    agent: str,
+) -> None:
+    user = tmp_path / "user"
+    project = tmp_path / "project"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: user))
+    for base in (user, project):
+        for installed_agent in ("codex", "claude"):
+            _installed_skill(packaged_skill, base, installed_agent)
+    monkeypatch.chdir(project)
+
+    assert _cli.main(["skill", "uninstall", "--agent", agent, "--scope", scope]) == 0
+
+    selected_base = user if scope == "user" else project
+    selected_agents = ("codex", "claude") if agent == "all" else (agent,)
+    output = capsys.readouterr()
+    assert output.err == ""
+    for base in (user, project):
+        for installed_agent in ("codex", "claude"):
+            destination = _destination(base, installed_agent)
+            selected = base == selected_base and installed_agent in selected_agents
+            assert destination.exists() is not selected
+            if selected:
+                assert installed_agent in output.out
+                assert str(destination.resolve()) in output.out
+
+
+def test_cli_uninstall_missing_is_idempotent_and_defaults_to_user(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    user = tmp_path / "user"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: user))
+    before = _snapshot(tmp_path)
+
+    assert _cli.main(["skill", "uninstall"]) == 0
+    assert _cli.main(["skill", "uninstall"]) == 0
+
+    output = capsys.readouterr()
+    assert output.err == ""
+    for agent in ("codex", "claude"):
+        assert agent in output.out
+        assert str(_destination(user, agent).resolve()) in output.out
+    assert _snapshot(tmp_path) == before
+
+
+def test_cli_uninstall_reports_retained_local_files(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    skill = destination / "SKILL.md"
+    skill.write_text("local edits", encoding="utf-8")
+    notes = destination / "notes.txt"
+    notes.write_text("my notes", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert _cli.main(["skill", "uninstall", "--scope", "project"]) == 0
+
+    output = capsys.readouterr()
+    assert output.err == ""
+    assert "retain" in output.out.lower()
+    assert str(destination.resolve()) in output.out
+    assert skill.read_text(encoding="utf-8") == "local edits"
+    assert notes.read_text(encoding="utf-8") == "my notes"
+    assert not (destination / "references" / "guide.md").exists()
+    assert not (destination / _cli._MANIFEST).exists()
+
+
+def test_cli_uninstall_refuses_unmanaged_skill_without_changes(
+    tmp_path: Path,
+    packaged_skill: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    destination = _installed_skill(packaged_skill, tmp_path)
+    (destination / _cli._MANIFEST).unlink()
+    monkeypatch.chdir(tmp_path)
+    before = _snapshot(tmp_path)
+
+    assert _cli.main(["skill", "uninstall", "--scope", "project"]) == 1
+
+    assert "manifest" in capsys.readouterr().err.lower()
+    assert _snapshot(tmp_path) == before


### PR DESCRIPTION
## What changed

Add ownership tracking and lifecycle commands for the bundled agent skill so users can update, inspect, and remove their selected Codex or Claude installation safely.

- Record packaged file hashes and the installed version. Forced updates remove only unchanged obsolete managed files, preserve unrelated or modified obsolete files, and migrate legacy installations without purging their directories.
- Add read-only `cnsplots skill status` with resolved paths, installed version, content comparison, and missing/current/modified/outdated/unmanaged states.
- Add scoped `cnsplots skill uninstall`, retaining modified and unrelated files and treating missing installations as a successful no-op.
- Preflight all selected agents, reject unsafe paths and symlinks, stage updates before replacement, and restore originals on filesystem failures. Retain recovery copies with an explicit error if rollback fails.
- Document command examples, ownership and legacy policies, and exit codes.

## How it was tested

- `make test` — 1,314 passed, 100% coverage
- `make lint` — passed
- 108 focused CLI tests cover both agents and scopes, read-only status, conflicts, modified files, legacy installs, symlinks, and injected staging/replacement/rollback failures; CLI coverage is 100%.

## Risks or follow-ups

- As before, `install --force` overwrites local edits at current packaged file paths. Modified obsolete files survive as unmanaged files.
- Uninstall requires ownership metadata for existing installations. Legacy installs must first be updated, and retained files become unmanaged after uninstall.
- Staging requires temporary disk space for copies of the selected skill directories.
- No dependencies, build configuration, or CI files changed.

## Related issue

Closes #152
Closes #153
Closes #154

## Release Notes Label

`enhancement`
