### PR TITLE
✨ Expose categorical comparison results

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -111,6 +111,73 @@ diagram object, respectively.
    placeholderplot
 ```
 
+## Statistical Comparison Results
+
+After calling `boxplot`, `violinplot`, `barplot`, `lollipopplot`, or `stackplot`
+with `pairs`, use `get_comparison_results(ax)` to retrieve the statistics used
+for its annotations. The plot still returns its Matplotlib axes; the accessor
+returns a separate DataFrame without rerunning any tests.
+
+This example uses the bundled tips dataset:
+
+```python
+import cnsplots as cns
+
+tips = cns.datasets.load_dataset("tips")
+cns.figure(width=180, height=140)
+with cns.settings.context(pvalue_format="threshold"):
+    ax = cns.boxplot(
+        tips,
+        x="day",
+        y="total_bill",
+        pairs="all",
+        p_adjust="holm",
+    )
+comparisons = cns.get_comparison_results(ax)
+print(comparisons.to_string(index=False))
+```
+
+Each row identifies `group1`, `group2`, the test, its alternative, whether
+observations are paired, and the contributing counts `n1` and `n2`. Hue groups
+use `(category, hue)` tuples. Rows follow annotation drawing order, with shorter
+brackets first; group order follows the categorical axis rather than the order
+of each supplied pair. The p-value columns distinguish computation from display:
+
+| Column | Meaning |
+| --- | --- |
+| `pvalue_raw` | Uncorrected test p-value. |
+| `pvalue_adjusted` | Numerical p-value after the requested correction. |
+| `pvalue_annotation` | P-value used to format the rendered label. |
+| `p_adjust` | Correction method, or `None` when no correction was requested. |
+| `significant` | Significance decision after correction. |
+| `annotation` | Exact rendered label, including any correction suffix. |
+
+Without correction, all three p-value columns agree. Bonferroni labels use
+adjusted p-values. Holm and FDR labels preserve the raw p-values and add a
+nonsignificance suffix when correction removes significance; read
+`pvalue_adjusted` for their numerical corrected values. Correction covers all
+resolved pairs in one plot call, including every category with `pairs="hue"`.
+It does not combine comparisons from separate calls.
+
+Continuous comparisons count complete rows after category and hue filters.
+Stackplot comparisons use original complete category/stack counts before
+normalization or `n_factor` scaling. Missing stack values can therefore make
+these counts differ from the raw category counts on its ticks.
+
+Each accessor call returns a copy. On reused axes it returns the latest call
+that added comparisons; drawing another plot without `pairs` leaves those
+results available. Clearing the axes or removing their annotations makes the
+result empty. Axes without stored comparisons return an empty table with the
+same columns. Omitting `ax` selects the current axes.
+
+```{eval-rst}
+.. apirootsummary::
+   :toctree: api
+   :nosignatures:
+
+   get_comparison_results
+```
+
 ## Statistical Models
 
 ```{eval-rst}

--- a/src/cnsplots/__init__.py
+++ b/src/cnsplots/__init__.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from ._utils import add_panel_label as add_panel_label
     from ._utils import apply_unicode_font as apply_unicode_font
     from ._utils import figure as figure
+    from ._utils import get_comparison_results as get_comparison_results
     from ._utils import get_hexcolors_from_apalette as get_hexcolors_from_apalette
     from ._utils import get_palette_colors as get_palette_colors
     from ._utils import palettes as palettes
@@ -106,6 +107,7 @@ _LAZY_IMPORTS = {
     "apply_unicode_font": ("cnsplots._utils", "apply_unicode_font"),
     "available_palettes": ("cnsplots._palettes", "available_palettes"),
     "figure": ("cnsplots._utils", "figure"),
+    "get_comparison_results": ("cnsplots._utils", "get_comparison_results"),
     "multipanel": ("cnsplots._multipanels", "multipanel"),
     "save": ("cnsplots._utils", "savefig"),
     "savefig": ("cnsplots._utils", "savefig"),

--- a/src/cnsplots/_comparison_types.py
+++ b/src/cnsplots/_comparison_types.py
@@ -1,0 +1,12 @@
+"""Shared input types for categorical statistical comparisons."""
+
+from collections.abc import Sequence
+from typing import Literal, TypeAlias
+
+CategoryLabel: TypeAlias = str | int | float
+CategoryPair: TypeAlias = tuple[CategoryLabel, CategoryLabel]
+HuePair: TypeAlias = tuple[
+    tuple[CategoryLabel, CategoryLabel], tuple[CategoryLabel, CategoryLabel]
+]
+CategoryComparisons: TypeAlias = Literal["all"] | Sequence[CategoryPair]
+HueComparisons: TypeAlias = Literal["all", "hue"] | Sequence[CategoryPair | HuePair]

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -28,9 +28,10 @@ from matplotlib.typing import ColorType
 from seaborn._base import categorical_order, infer_orient
 from statannotations.Annotator import Annotator
 from statannotations.PValueFormat import PValueFormat
-from statannotations.utils import DEFAULT
+from statsmodels.stats.multitest import multipletests
 
 import cnsplots._palettes as _palettes
+from cnsplots._comparison_types import HueComparisons
 from cnsplots._settings import settings
 from cnsplots._setup import setup_matplotlib
 from cnsplots._sizing import _SizeUnit, _dimension_to_points
@@ -77,6 +78,21 @@ _ContinuousPaletteName = Literal[
 ]
 _RGBColor = tuple[float, float, float]
 _P_ADJUST_METHODS = ("bonferroni", "holm", "fdr_bh", "fdr_by")
+_COMPARISON_COLUMNS = [
+    "group1",
+    "group2",
+    "test",
+    "alternative",
+    "paired",
+    "n1",
+    "n2",
+    "pvalue_raw",
+    "pvalue_adjusted",
+    "p_adjust",
+    "pvalue_annotation",
+    "significant",
+    "annotation",
+]
 
 RED = "#D6372E"
 BLUE = "#5189BB"
@@ -974,12 +990,156 @@ def _prepare_categorical_plot_data(plotting):
     return cleaned
 
 
+class _PValueFormatter(PValueFormat):
+    """Format p-value annotations with explicit, per-instance configuration."""
+
+    def __init__(self, resolved_format: str, fontsize: str | int | float) -> None:
+        super().__init__()
+        self._resolved_format = resolved_format
+        self.fontsize = fontsize
+        self.p_capitalized = True
+
+    def format_data(self, result):
+        if self._resolved_format == "full":
+            text = f"{result.test_short_name} " if self.show_test_name else ""
+            return r"${}P = {}{}$".format("{}", self.pvalue_format_string, "{}").format(
+                text, num2tex.num2tex(result.pvalue), result.significance_suffix
+            )
+
+        if self._resolved_format == "threshold":
+            pvalue_threshold_labels = (
+                (1e-4, "P < 0.0001"),
+                (1e-3, "P < 0.001"),
+                (1e-2, "P < 0.01"),
+                (0.05, "P < 0.05"),
+            )
+            for threshold, label in pvalue_threshold_labels:
+                if result.pvalue <= threshold:
+                    adjust = getattr(result, "adjust", None)
+                    return adjust(label) if callable(adjust) else label
+            adjust = getattr(result, "adjust", None)
+            return adjust("P > 0.05") if callable(adjust) else "P > 0.05"
+
+        return super().format_data(result)
+
+
+def get_comparison_results(ax: Axes | None = None) -> pd.DataFrame:
+    """Return the results used by the latest categorical annotations on an axes.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes, optional
+        Axes returned by boxplot, violinplot, barplot, lollipopplot, or stackplot.
+        Defaults to the current axes. The plot must have been called with pairs.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A detached table with one row per comparison, in annotation drawing
+        order (shorter brackets first). ``group1`` and ``group2`` follow the
+        categorical axis order, not necessarily the supplied pair order. They
+        are category labels, or ``(category, hue)`` tuples for hue comparisons.
+        ``test``, ``alternative``, and ``paired`` identify the test; all currently
+        supported tests use independent observations (``paired=False``).
+        ``alternative`` is ``'two-sided'`` for continuous tests and 2-by-2 Fisher
+        tests, and None for chi-squared and larger Fisher independence tests.
+        ``n1`` and ``n2`` count contributing observations. ``pvalue_raw`` and
+        ``pvalue_adjusted`` contain raw and corrected p-values; without correction
+        they are equal and ``p_adjust`` is None. ``pvalue_annotation``,
+        ``significant``, and ``annotation`` describe the exact rendered result.
+        No effect size is estimated. Returns an empty table with these columns
+        if there are no stored comparisons or their annotations were removed.
+
+    Notes
+    -----
+    Results come from the same computation used for rendering; this accessor
+    does not rerun tests. Each call returns a copy. On reused axes only the latest
+    comparison call is returned; a plot without pairs does not replace it.
+    Clearing the axes also clears the available results.
+
+    Continuous plots exclude rows missing x, y, or hue and levels excluded by
+    order/hue_order, just as rendering does. Stackplot tests use original counts
+    of complete category/stack rows, before normalization or n_factor scaling;
+    these can differ from its raw category tick counts when stack values are
+    missing. Correction covers all resolved pairs in one plot call, including
+    all categories for pairs='hue', and does not extend across plot calls.
+
+    Existing statannotations display semantics are preserved: Bonferroni uses
+    adjusted p-values in labels; Holm and FDR methods display raw p-values with
+    a nonsignificance suffix when correction removes significance. Use
+    pvalue_adjusted for the numerical corrected values for every method.
+
+    Examples
+    --------
+    >>> ax = cns.boxplot(df, x="group", y="value", pairs="all", p_adjust="holm")
+    >>> comparisons = cns.get_comparison_results(ax)
+    >>> comparisons.to_csv("comparisons.csv", index=False)
+    """
+    if ax is None:
+        ax = plt.gca()
+    stored = getattr(ax, "_cnsplots_comparison_results", None)
+    if stored is None:
+        return pd.DataFrame(columns=pd.Index(_COMPARISON_COLUMNS))
+    results, artists = stored
+    if not artists or any(artist not in ax.texts for artist in artists):
+        return pd.DataFrame(columns=pd.Index(_COMPARISON_COLUMNS))
+    return results.copy(deep=True)
+
+
+def _collect_comparison_results(annotator, test, correction, p_adjust, contingency):
+    """Correct the computed results in place and snapshot them before rendering."""
+    annotations = annotator.annotations
+    results = [annotation.data for annotation in annotations]
+    raw = np.asarray([result.pvalue for result in results])
+    adjusted = raw.copy()
+    if correction is not None:
+        adjusted = multipletests(raw, method=p_adjust)[1]
+        if correction.type == 0:
+            for result, pvalue in zip(results, correction(raw)):
+                result.pvalue = pvalue
+        correction.apply(results)
+
+    rows = []
+    for annotation, pvalue_raw, pvalue_adjusted in zip(annotations, raw, adjusted):
+        first, second = annotation.structs
+        group1, group2 = first["group"], second["group"]
+        if contingency is None:
+            n1, n2 = len(first["group_data"]), len(second["group_data"])
+        else:
+            n1 = int(contingency.loc[group1[0]].sum())
+            n2 = int(contingency.loc[group2[0]].sum())
+        alternative = (
+            None
+            if test == "chi-squared"
+            or (contingency is not None and contingency.shape[1] != 2)
+            else "two-sided"
+        )
+        rows.append(
+            {
+                "group1": group1[0] if len(group1) == 1 else group1,
+                "group2": group2[0] if len(group2) == 1 else group2,
+                "test": test,
+                "alternative": alternative,
+                "paired": False,
+                "n1": n1,
+                "n2": n2,
+                "pvalue_raw": pvalue_raw,
+                "pvalue_adjusted": pvalue_adjusted,
+                "p_adjust": p_adjust,
+                "pvalue_annotation": annotation.data.pvalue,
+                "significant": annotation.data.is_significant,
+                "annotation": annotation.text,
+            }
+        )
+    return pd.DataFrame(rows, columns=pd.Index(_COMPARISON_COLUMNS))
+
+
 def _p_value_helper(
     test,
     data,
     ax,
     plotting,
-    pairs,
+    pairs: HueComparisons,
     contingency=None,
     format=None,
     label_clearance=None,
@@ -990,44 +1150,6 @@ def _p_value_helper(
         raise ValueError("format must be one of: 'star', 'threshold', 'full'")
 
     pvalue_fontsize = settings.pvalue_fontsize
-
-    class PValueFormatNew(PValueFormat):
-        def __init__(self):
-            super(PValueFormat, self).__init__()
-            self._pvalue_format_string = "{:.3e}"
-            self._simple_format_string = "{:.2f}"
-            self._text_format = "star"
-            self.fontsize = pvalue_fontsize
-            self._default_pvalue_thresholds = True
-            self._pvalue_thresholds = self._get_pvalue_thresholds(DEFAULT)
-            self._correction_format = "{star} ({suffix})"
-            self.show_test_name = True
-            self.p_capitalized = True
-
-        def format_data(self, result):
-            if resolved_format == "full":
-                text = f"{result.test_short_name} " if self.show_test_name else ""
-                return r"${}P = {}{}$".format(
-                    "{}", self.pvalue_format_string, "{}"
-                ).format(
-                    text, num2tex.num2tex(result.pvalue), result.significance_suffix
-                )
-
-            if resolved_format == "threshold":
-                pvalue_threshold_labels = (
-                    (1e-4, "P < 0.0001"),
-                    (1e-3, "P < 0.001"),
-                    (1e-2, "P < 0.01"),
-                    (0.05, "P < 0.05"),
-                )
-                for threshold, label in pvalue_threshold_labels:
-                    if result.pvalue <= threshold:
-                        adjust = getattr(result, "adjust", None)
-                        return adjust(label) if callable(adjust) else label
-                adjust = getattr(result, "adjust", None)
-                return adjust("P > 0.05") if callable(adjust) else "P > 0.05"
-
-            return super().format_data(result)
 
     plotting["orient"] = _resolve_categorical_orientation(
         data, plotting["x"], plotting["y"], plotting.get("orient")
@@ -1106,7 +1228,7 @@ def _p_value_helper(
             contingency_tables.append(table)
 
     annotator = Annotator(ax, pairs, **plotting)
-    annotator._pvalue_format = PValueFormatNew()
+    annotator._pvalue_format = _PValueFormatter(resolved_format, pvalue_fontsize)
     annotator.configure(
         test=test if contingency is None else None,
         comparisons_correction=p_adjust,
@@ -1133,18 +1255,25 @@ def _p_value_helper(
         for table in contingency_tables:
             pvalues.append(stats.chi2_contingency(table)[1])
 
-    if contingency is not None:
-        annotator.set_pvalues(pvalues=pvalues)
-
-    if line_offset_to_group is None:
-        if contingency is None:
-            annotator.apply_and_annotate()
-        else:
-            annotator.annotate()
+    # Preserve raw values before statannotations' type-0 corrections overwrite
+    # them. Apply the same correction to these results once, then render them.
+    correction = annotator.comparisons_correction
+    annotator.comparisons_correction = None
+    if contingency is None:
+        annotator.apply_test()
     else:
-        if contingency is None:
-            annotator.apply_test()
+        annotator.set_pvalues(pvalues=pvalues)
+    results = _collect_comparison_results(
+        annotator, test, correction, p_adjust, contingency
+    )
+    annotator.comparisons_correction = correction
+
+    text_start = len(ax.texts)
+    if line_offset_to_group is None:
+        annotator.annotate()
+    else:
         annotator.annotate(line_offset_to_group=line_offset_to_group)
+    ax._cnsplots_comparison_results = (results, tuple(ax.texts)[text_start:])
 
     if test == "Mann-Whitney":
         logger.info("P-values were determined by two-sided Mann-Whitney U test.")

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Union, cast
+from typing import Any, Literal, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -13,6 +13,7 @@ from matplotlib.textpath import TextPath
 from scipy import stats
 
 import cnsplots._utils as utils
+from cnsplots._comparison_types import CategoryComparisons, HueComparisons
 from cnsplots._utils import _legend_fontsize, _resize_legend_markers
 from cnsplots._validation import (
     validate_column_exists,
@@ -23,7 +24,6 @@ from cnsplots._validation import (
     validate_no_nulls,
 )
 
-LollipopPair = Union[tuple[str, str], tuple[tuple[str, str], tuple[str, str]]]
 LollipopError = float | tuple[float, float]
 
 _LOLLIPOP_BOOTSTRAP_SAMPLES = 1000
@@ -235,7 +235,7 @@ def barplot(
     data: pd.DataFrame,
     x: str,
     y: str,
-    pairs: list[tuple[str, str]] | None = None,
+    pairs: HueComparisons | None = None,
     add_tip: bool = False,
     *,
     hue: str | None = None,
@@ -261,9 +261,13 @@ def barplot(
         Column name for the categorical variable on the x-axis.
     y : str
         Column name for the continuous variable whose means are plotted on the y-axis.
-    pairs : list of tuple of str, optional
-        List of pairs of category names from x for pairwise statistical comparisons
-        using Welch's t-test.
+    pairs : sequence of pairs or {'all', 'hue'}, optional
+        Category pairs for statistical comparisons, using string or numeric labels.
+        Without ``hue``, use pairs such as ``[("A", "B")]`` or ``"all"`` to
+        compare all displayed categories. With ``hue``, use nested pairs such as
+        ``[(("A", "control"), ("A", "treated"))]`` or ``"hue"`` to compare
+        hue levels within each displayed category. The categorical axis follows
+        the plot orientation. ``None`` disables comparisons.
     add_tip : bool, default: False
         Whether to add text labels showing the mean value above each bar.
     hue : str, optional
@@ -291,6 +295,12 @@ def barplot(
     boxplot : Create a box plot showing full distribution.
     violinplot : Create a violin plot with distribution shape.
     stackplot : Create a stacked bar plot for categorical data.
+    get_comparison_results : Retrieve the statistics and rendered comparison labels.
+
+    Notes
+    -----
+    When ``pairs`` is provided, ``get_comparison_results(ax)`` returns the
+    comparison table without rerunning the statistical tests.
 
     Examples
     --------
@@ -422,7 +432,7 @@ def lollipopplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
-    pairs: list[LollipopPair] | None = None,
+    pairs: HueComparisons | None = None,
     add_tip: bool = False,
     estimator: str = "mean",
     errorbar: str | None = None,
@@ -459,9 +469,13 @@ def lollipopplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
-    pairs : list of tuple of str, optional
-        List of pairs of category names for pairwise statistical comparisons
-        using Welch's t-test.
+    pairs : sequence of pairs or {'all', 'hue'}, optional
+        Category pairs for statistical comparisons, using string or numeric labels.
+        Without ``hue``, use pairs such as ``[("A", "B")]`` or ``"all"`` to
+        compare all displayed categories. With ``hue``, use nested pairs such as
+        ``[(("A", "control"), ("A", "treated"))]`` or ``"hue"`` to compare
+        hue levels within each displayed category. The categorical axis follows
+        the plot orientation. ``None`` disables comparisons.
     add_tip : bool, default: False
         Whether to add text labels showing the aggregated value at each dot.
     estimator : {'mean', 'median'}, default: 'mean'
@@ -504,6 +518,12 @@ def lollipopplot(
     barplot : Create a bar plot showing mean values.
     stripplot : Create a strip plot showing individual data points.
     boxplot : Create a box plot showing full distribution.
+    get_comparison_results : Retrieve the statistics and rendered comparison labels.
+
+    Notes
+    -----
+    When ``pairs`` is provided, ``get_comparison_results(ax)`` returns the
+    comparison table without rerunning the statistical tests.
 
     Examples
     --------
@@ -904,7 +924,7 @@ def stackplot(
     stack_order: list[str] | None = None,
     width: float = 0.5,
     normalize: bool = True,
-    pairs: list[tuple[str, str]] | None = None,
+    pairs: CategoryComparisons | None = None,
     test: Literal["auto", "fisher-exact", "chi-squared"] = "auto",
     p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     add_count: bool = False,
@@ -941,9 +961,10 @@ def stackplot(
         Width of the bars.
     normalize : bool, default: True
         Whether to normalize counts to frequencies (proportions summing to 1).
-    pairs : list of tuple of str, optional
-        List of pairs of bar-category names for pairwise statistical comparisons
-        from the selected bar variable.
+    pairs : sequence of pairs or {'all'}, optional
+        Pairs of string or numeric labels from the selected bar variable, such as
+        ``[("A", "B")]`` or ``[(0, 1)]``. Use ``"all"`` to compare all displayed
+        bar categories. ``None`` disables comparisons.
     test : {'auto', 'fisher-exact', 'chi-squared'}, default: 'auto'
         Statistical test used for pairwise comparisons. Automatic selection uses
         Fisher's exact test for two stack levels and chi-squared otherwise.
@@ -967,6 +988,12 @@ def stackplot(
     barplot : Create a bar plot of means.
     pieplot : Create a pie chart for categorical proportions.
     donutplot : Create a donut chart for categorical proportions.
+    get_comparison_results : Retrieve the statistics and rendered comparison labels.
+
+    Notes
+    -----
+    When ``pairs`` is provided, ``get_comparison_results(ax)`` returns the
+    comparison table without rerunning the statistical tests.
 
     Examples
     --------

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -16,6 +16,7 @@ from matplotlib.axes import Axes
 from matplotlib.typing import ColorType
 
 import cnsplots._utils as utils
+from cnsplots._comparison_types import HueComparisons
 from cnsplots._utils import _legend_fontsize
 from cnsplots._validation import (
     validate_column_exists,
@@ -32,7 +33,7 @@ def boxplot(
     data: pd.DataFrame,
     x: str,
     y: str,
-    pairs: list[tuple[str, str]] | None = None,
+    pairs: HueComparisons | None = None,
     showoutliers: bool = False,
     add_count: bool = False,
     whis: float | tuple[float, float] = 1.5,
@@ -60,9 +61,13 @@ def boxplot(
         Column name for the categorical variable on the x-axis.
     y : str
         Column name for the continuous variable on the y-axis.
-    pairs : list of tuple of str, optional
-        List of pairs of category names from x for pairwise statistical comparisons
-        using Mann-Whitney U test.
+    pairs : sequence of pairs or {'all', 'hue'}, optional
+        Category pairs for statistical comparisons, using string or numeric labels.
+        Without ``hue``, use pairs such as ``[("A", "B")]`` or ``"all"`` to
+        compare all displayed categories. With ``hue``, use nested pairs such as
+        ``[(("A", "control"), ("A", "treated"))]`` or ``"hue"`` to compare
+        hue levels within each displayed category. The categorical axis follows
+        the plot orientation. ``None`` disables comparisons.
     showoutliers : bool, default: False
         Whether to display outlier points beyond the whiskers.
     add_count : bool, default: False
@@ -98,6 +103,12 @@ def boxplot(
     violinplot : Create a violin plot showing full distribution shape.
     stripplot : Create a strip plot showing all individual points.
     barplot : Create a bar plot showing means with error bars.
+    get_comparison_results : Retrieve the statistics and rendered comparison labels.
+
+    Notes
+    -----
+    When ``pairs`` is provided, ``get_comparison_results(ax)`` returns the
+    comparison table without rerunning the statistical tests.
 
     Examples
     --------
@@ -223,7 +234,7 @@ def violinplot(
     data: pd.DataFrame,
     x: str,
     y: str,
-    pairs: list[tuple[str, str]] | None = None,
+    pairs: HueComparisons | None = None,
     width: float = 0.6,
     add_box: bool = True,
     add_count: bool = False,
@@ -253,8 +264,13 @@ def violinplot(
         Column name for the categorical variable on the x-axis.
     y : str
         Column name for the continuous variable on the y-axis.
-    pairs : list of tuple of str, optional
-        List of pairs of category names from x for pairwise statistical comparisons.
+    pairs : sequence of pairs or {'all', 'hue'}, optional
+        Category pairs for statistical comparisons, using string or numeric labels.
+        Without ``hue``, use pairs such as ``[("A", "B")]`` or ``"all"`` to
+        compare all displayed categories. With ``hue``, use nested pairs such as
+        ``[(("A", "control"), ("A", "treated"))]`` or ``"hue"`` to compare
+        hue levels within each displayed category. The categorical axis follows
+        the plot orientation. ``None`` disables comparisons.
     width : float, default: 0.6
         Width of each violin body.
     add_box : bool, default: True
@@ -303,6 +319,12 @@ def violinplot(
     boxplot : Create a box plot showing quartiles without density.
     kdeplot : Create a kernel density plot.
     distplot : Create a distribution plot with histogram and KDE.
+    get_comparison_results : Retrieve the statistics and rendered comparison labels.
+
+    Notes
+    -----
+    When ``pairs`` is provided, ``get_comparison_results(ax)`` returns the
+    comparison table without rerunning the statistical tests.
 
     Examples
     --------

--- a/tests/test_comparison_results.py
+++ b/tests/test_comparison_results.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import stats
+from statannotations.stats.StatTest import StatTest
+from statsmodels.stats.multitest import multipletests
+
+import cnsplots as cns
+
+_CONTINUOUS_PLOTS = ("boxplot", "violinplot", "barplot", "lollipopplot")
+_COLUMNS = [
+    "group1",
+    "group2",
+    "test",
+    "alternative",
+    "paired",
+    "n1",
+    "n2",
+    "pvalue_raw",
+    "pvalue_adjusted",
+    "p_adjust",
+    "pvalue_annotation",
+    "significant",
+    "annotation",
+]
+
+
+@pytest.fixture
+def result_annotations(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    instances = []
+    original = cns.utils.Annotator
+
+    def capture(*args: Any, **kwargs: Any) -> Any:
+        annotator = original(*args, **kwargs)
+        instances.append(annotator)
+        return annotator
+
+    monkeypatch.setattr(cns.utils, "Annotator", capture)
+    return instances
+
+
+@pytest.mark.parametrize("plot_name", _CONTINUOUS_PLOTS)
+@pytest.mark.parametrize("p_adjust", [None, "bonferroni", "holm", "fdr_bh", "fdr_by"])
+def test_results_match_tests_and_rendered_annotations(
+    plot_name: str,
+    p_adjust: str | None,
+    categorical_df: pd.DataFrame,
+    result_annotations: list[Any],
+) -> None:
+    ax = getattr(cns, plot_name)(
+        categorical_df,
+        x="group",
+        y="value",
+        order=["C", "B", "A"],
+        pairs=[("A", "C"), ("A", "B"), ("B", "C")],
+        p_adjust=p_adjust,
+    )
+    results = cns.get_comparison_results(ax)
+    annotations = result_annotations[0].annotations
+
+    assert list(results.columns) == _COLUMNS
+    assert len(results) == 3
+    assert list(zip(results.group1, results.group2)) == [
+        (item.structs[0]["group"][0], item.structs[1]["group"][0])
+        for item in annotations
+    ]
+    test = "Mann-Whitney" if plot_name in {"boxplot", "violinplot"} else "t-test_welch"
+    expected_pvalues = []
+    for (_, row), annotation in zip(results.iterrows(), annotations):
+        first = categorical_df.loc[categorical_df.group == row.group1, "value"]
+        second = categorical_df.loc[categorical_df.group == row.group2, "value"]
+        expected = (
+            stats.mannwhitneyu(first, second, alternative="two-sided")
+            if test == "Mann-Whitney"
+            else stats.ttest_ind(first, second, equal_var=False)
+        )
+        expected_pvalues.append(expected.pvalue)
+        assert row.test == test
+        assert row.alternative == "two-sided"
+        assert not row.paired
+        assert (row.n1, row.n2) == (len(first), len(second))
+        assert row.pvalue_raw == pytest.approx(expected.pvalue)
+        assert row.p_adjust == p_adjust
+        assert row.pvalue_annotation == annotation.data.pvalue
+        assert row.significant == annotation.data.is_significant
+        assert row.annotation == annotation.text
+        assert row.annotation in [text.get_text() for text in ax.texts]
+
+    adjusted = (
+        expected_pvalues
+        if p_adjust is None
+        else multipletests(expected_pvalues, method=p_adjust)[1]
+    )
+    np.testing.assert_allclose(results.pvalue_adjusted, adjusted)
+    np.testing.assert_array_equal(results.significant, np.asarray(adjusted) <= 0.05)
+    np.testing.assert_allclose(
+        results.pvalue_annotation,
+        adjusted if p_adjust == "bonferroni" else expected_pvalues,
+    )
+
+
+@pytest.mark.parametrize("plot_name", _CONTINUOUS_PLOTS)
+@pytest.mark.parametrize("horizontal", [False, True])
+def test_hue_results_use_displayed_complete_observations(
+    plot_name: str, horizontal: bool, result_annotations: list[Any]
+) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A"] * 8 + ["B"] * 8 + ["C", None],
+            "value": [1, 2, 3, np.nan, 5, 6, 7, 8] + list(range(9, 19)),
+            "hue": ["H1", "H1", "H2", "H2", "H2", "H3", None, "H1"] * 2 + ["H1", "H1"],
+            "unrelated": np.nan,
+        }
+    )
+    ax = getattr(cns, plot_name)(
+        data,
+        x="value" if horizontal else "group",
+        y="group" if horizontal else "value",
+        order=["B", "A"],
+        hue="hue",
+        hue_order=["H2", "H1"],
+        pairs="hue",
+        test="Mann-Whitney",
+        p_adjust="holm",
+    )
+    results = cns.get_comparison_results(ax)
+    assert set(zip(results.group1, results.group2)) == {
+        (("B", "H2"), ("B", "H1")),
+        (("A", "H2"), ("A", "H1")),
+    }
+    assert list(zip(results.group1, results.group2)) == [
+        (item.structs[0]["group"], item.structs[1]["group"])
+        for item in result_annotations[0].annotations
+    ]
+    expected_pvalues = []
+    for _, row in results.iterrows():
+        groups = [
+            data.loc[(data.group == group) & (data.hue == hue), "value"].dropna()
+            for group, hue in (row.group1, row.group2)
+        ]
+        expected = stats.mannwhitneyu(*groups, alternative="two-sided")
+        expected_pvalues.append(expected.pvalue)
+        assert (row.n1, row.n2) == tuple(map(len, groups))
+        assert row.pvalue_raw == pytest.approx(expected.pvalue)
+    np.testing.assert_allclose(
+        results.pvalue_adjusted, multipletests(expected_pvalues, method="holm")[1]
+    )
+
+
+@pytest.mark.parametrize("plot_name", _CONTINUOUS_PLOTS)
+def test_results_preserve_numeric_category_labels(
+    plot_name: str, categorical_df: pd.DataFrame
+) -> None:
+    data = categorical_df.assign(
+        group=categorical_df.group.map({"A": 0, "B": 1, "C": 2})
+    )
+    ax = getattr(cns, plot_name)(
+        data, x="group", y="value", order=[2, 1, 0], pairs=[(0, 2)]
+    )
+    results = cns.get_comparison_results(ax)
+    assert list(zip(results.group1, results.group2)) == [(2, 0)]
+    assert list(zip(results.n1, results.n2)) == [(4, 4)]
+
+
+def test_results_preserve_saturated_raw_values_and_corrected_ns() -> None:
+    data = pd.DataFrame(
+        {
+            "group": np.repeat(["A", "B", "C"], 4),
+            "value": [0, 1, 2, 3, 1, 2, 3, 4, 2, 3, 4, 5],
+        }
+    )
+    ax = cns.boxplot(data, x="group", y="value", pairs="all", p_adjust="bonferroni")
+    results = cns.get_comparison_results(ax)
+    assert (results.pvalue_adjusted == 1).any()
+    for _, row in results.iterrows():
+        expected = stats.mannwhitneyu(
+            data.loc[data.group == row.group1, "value"],
+            data.loc[data.group == row.group2, "value"],
+            alternative="two-sided",
+        )
+        assert row.pvalue_raw == pytest.approx(expected.pvalue)
+        assert row.pvalue_adjusted == pytest.approx(min(expected.pvalue * 3, 1))
+
+    data["value"] = np.arange(12)
+    _, ax = plt.subplots()
+    cns.boxplot(data, x="group", y="value", pairs="all", p_adjust="holm", ax=ax)
+    results = cns.get_comparison_results(ax)
+    assert (results.pvalue_raw < 0.05).all()
+    assert (results.pvalue_adjusted > 0.05).all()
+    assert not results.significant.any()
+    assert results.annotation.str.contains("ns").all()
+
+
+@pytest.mark.parametrize("horizontal", [False, True])
+@pytest.mark.parametrize("normalize", [False, True])
+@pytest.mark.parametrize("test", ["auto", "chi-squared"])
+def test_stack_results_count_raw_contingency_observations(
+    horizontal: bool, normalize: bool, test: Literal["auto", "chi-squared"]
+) -> None:
+    counts = pd.DataFrame(
+        [[8, 2], [3, 7], [5, 4]],
+        index=pd.Index(list("ABC")),
+        columns=pd.Index(["no", "yes"]),
+    )
+    data = pd.DataFrame(
+        [
+            (group, outcome)
+            for group in counts.index
+            for outcome in counts.columns
+            for _ in range(counts.loc[group, outcome])
+        ]
+        + [("A", None), (None, "yes")],
+        columns=pd.Index(["group", "outcome"]),
+    )
+    ax = cns.stackplot(
+        data,
+        x=None if horizontal else "group",
+        y="group" if horizontal else None,
+        stack="outcome",
+        order=["C", "A", "B"],
+        normalize=normalize,
+        n_factor=2,
+        pairs="all",
+        test=test,
+        p_adjust="bonferroni",
+    )
+    results = cns.get_comparison_results(ax)
+    assert len(results) == 3
+    for _, row in results.iterrows():
+        table = counts.loc[[row.group1, row.group2]].to_numpy()
+        expected = (
+            stats.fisher_exact(table)
+            if test == "auto"
+            else stats.chi2_contingency(table)
+        )
+        assert row.test == ("fisher-exact" if test == "auto" else "chi-squared")
+        assert row.alternative == ("two-sided" if test == "auto" else None)
+        assert not row.paired
+        assert (row.n1, row.n2) == tuple(table.sum(axis=1))
+        assert row.pvalue_raw == pytest.approx(expected[1])
+        assert row.pvalue_adjusted == pytest.approx(min(expected[1] * 3, 1))
+
+
+def test_statistics_are_computed_once(
+    categorical_df: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    test = StatTest.from_library("Mann-Whitney")
+    original = test._func
+    calls = []
+
+    def capture(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(test, "_func", capture)
+    ax = cns.boxplot(
+        categorical_df, x="group", y="value", pairs="all", p_adjust="bonferroni"
+    )
+    first = cns.get_comparison_results(ax)
+    second = cns.get_comparison_results(ax)
+    assert len(calls) == 3
+    pd.testing.assert_frame_equal(first, second)
+
+
+def test_multiclass_fisher_results_reuse_the_computed_pvalue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A"] * 6 + ["B"] * 5,
+            "outcome": ["one", "two", "three", "one", "two", "three"]
+            + ["one", "two", "three", "one", "one"],
+        }
+    )
+    original = stats.fisher_exact
+    computed = []
+
+    def capture(*args: Any, **kwargs: Any) -> Any:
+        result = original(*args, **kwargs)
+        computed.append(result.pvalue)
+        return result
+
+    monkeypatch.setattr(cns.utils.stats, "fisher_exact", capture)
+    ax = cns.stackplot(
+        data,
+        x="group",
+        stack="outcome",
+        order=["B", "A"],
+        pairs=[("A", "B")],
+        test="fisher-exact",
+        p_adjust="holm",
+    )
+    row = cns.get_comparison_results(ax).iloc[0]
+    assert len(computed) == 1
+    assert (row.group1, row.group2) == ("B", "A")
+    assert (row.n1, row.n2) == (5, 6)
+    assert row.alternative is None
+    assert row.pvalue_raw == computed[0]
+    assert row.pvalue_adjusted == computed[0]
+    assert row.pvalue_annotation == computed[0]
+
+
+def test_results_are_detached_and_follow_axes_lifecycle(
+    categorical_df: pd.DataFrame,
+) -> None:
+    _, (ax, other) = plt.subplots(1, 2)
+    empty = cns.get_comparison_results(ax)
+    assert list(empty.columns) == _COLUMNS
+    assert empty.empty
+    cns.boxplot(categorical_df, x="group", y="value", pairs="all", ax=ax)
+    original = cns.get_comparison_results(ax)
+    modified = cns.get_comparison_results(ax)
+    modified.loc[0, "pvalue_raw"] = -1
+    modified.drop(columns="group1", inplace=True)
+    pd.testing.assert_frame_equal(cns.get_comparison_results(ax), original)
+    assert cns.get_comparison_results(other).empty
+    plt.sca(ax)
+    pd.testing.assert_frame_equal(cns.get_comparison_results(), original)
+    cns.boxplot(categorical_df, x="group", y="value", pairs=[("A", "B")], ax=ax)
+    assert len(cns.get_comparison_results(ax)) == 1
+    ax.clear()
+    assert cns.get_comparison_results(ax).empty
+    assert list(cns.get_comparison_results(ax).columns) == _COLUMNS

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1259,6 +1259,8 @@ def test_utils_helpers_and_showcase_data(
             self.pairs = list(pairs)
             self.plotting = plotting
             self._pvalue_format: Any = None
+            self.comparisons_correction = None
+            self.annotations: list[Any] = []
             self.configured: dict[str, object] = {}
             self.pvalues = None
             DummyAnnotator.last = self
@@ -1266,7 +1268,7 @@ def test_utils_helpers_and_showcase_data(
         def configure(self, **kwargs: object) -> None:
             self.configured = kwargs
 
-        def apply_and_annotate(self) -> None:
+        def apply_test(self) -> None:
             return None
 
         def set_pvalues(self, pvalues: list[float]) -> None:

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -459,11 +459,13 @@ def test_utils_internal_coverage(
     class DummyAnnotator:
         def __init__(self, ax: object, pairs: object, **plotting: object) -> None:
             self._pvalue_format: Any = None
+            self.comparisons_correction = None
+            self.annotations: list[Any] = []
 
         def configure(self, **kwargs: object) -> None:
             return None
 
-        def apply_and_annotate(self) -> None:
+        def apply_test(self) -> None:
             return None
 
         def set_pvalues(self, pvalues: list[float]) -> None:

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -215,7 +215,7 @@ assert not {
     src_path = Path(__file__).parents[1] / "src"
     no_site_script = (
         f"import sys; sys.path.insert(0, {str(src_path)!r}); "
-        "import cnsplots; assert len(cnsplots.__all__) == 67"
+        "import cnsplots; assert len(cnsplots.__all__) == 68"
     )
     subprocess.run([sys.executable, "-S", "-c", no_site_script], check=True)
 

--- a/tests/test_pvalue_formatter.py
+++ b/tests/test_pvalue_formatter.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from statannotations.stats.StatResult import StatResult
+
+from cnsplots._utils import _PValueFormatter
+
+
+@pytest.mark.parametrize(
+    ("pvalue", "star", "threshold"),
+    [
+        (0, "****", "P < 0.0001"),
+        (1e-4, "****", "P < 0.0001"),
+        (1.1e-4, "***", "P < 0.001"),
+        (1e-3, "***", "P < 0.001"),
+        (1.1e-3, "**", "P < 0.01"),
+        (1e-2, "**", "P < 0.01"),
+        (1.1e-2, "*", "P < 0.05"),
+        (0.05, "*", "P < 0.05"),
+        (0.051, "ns", "P > 0.05"),
+        (1, "ns", "P > 0.05"),
+    ],
+)
+def test_pvalue_formatter_star_and_threshold_boundaries(
+    pvalue: float, star: str, threshold: str
+) -> None:
+    result = StatResult("Test", "T", None, None, pvalue)
+
+    assert _PValueFormatter("star", 9).format_data(result) == star
+    assert _PValueFormatter("threshold", 9).format_data(result) == threshold
+
+
+@pytest.mark.parametrize(
+    ("pvalue", "expected"),
+    [
+        (0, r"$P = 0.0 \times 10^{0}$"),
+        (0.0000123, r"$P = 1.2 \times 10^{-5}$"),
+        (0.2, r"$P = 2.0 \times 10^{-1}$"),
+        (1, r"$P = 1.0 \times 10^{0}$"),
+    ],
+)
+def test_pvalue_formatter_full_preserves_scientific_notation(
+    pvalue: float, expected: str
+) -> None:
+    result = StatResult("Test", "T", None, None, pvalue)
+    formatter = _PValueFormatter("full", 9)
+    formatter.config(show_test_name=False, pvalue_format_string="{:.1e}")
+
+    assert formatter.format_data(result) == expected
+
+    formatter.config(show_test_name=True)
+    assert formatter.format_data(result) == expected.replace("$P", "$T P")
+
+
+@pytest.mark.parametrize(
+    ("format", "expected"),
+    [
+        ("star", "** (ns)"),
+        ("threshold", "P < 0.01 (ns)"),
+        ("full", r"$P = 1.0 \times 10^{-2}ns$"),
+    ],
+)
+def test_pvalue_formatter_preserves_corrected_significance(
+    format: str, expected: str
+) -> None:
+    result = StatResult("Test", "T", None, None, 0.01)
+    result.correction_method = "Holm-Bonferroni"
+    result.corrected_significance = False
+    formatter = _PValueFormatter(format, 9)
+    formatter.config(show_test_name=False, pvalue_format_string="{:.1e}")
+
+    assert formatter.format_data(result) == expected
+
+    result.corrected_significance = True
+    assert formatter.format_data(result) == expected.replace(" (ns)", "").replace(
+        "ns$", "$"
+    )
+
+
+@pytest.mark.parametrize(
+    ("pvalue", "expected"), [(0.01, "P < 0.01"), (0.2, "P > 0.05")]
+)
+def test_pvalue_formatter_threshold_accepts_result_without_adjust(
+    pvalue: float, expected: str
+) -> None:
+    result = SimpleNamespace(pvalue=pvalue)
+
+    assert _PValueFormatter("threshold", 9).format_data(result) == expected
+
+
+def test_pvalue_formatter_instances_keep_configuration_independent() -> None:
+    first = _PValueFormatter("star", 7)
+    second = _PValueFormatter("star", 11)
+    full = _PValueFormatter("full", "small")
+    result = StatResult("Test", "T", None, None, 0.00001)
+
+    first.pvalue_thresholds[0][1] = "custom"
+    first.config(fontsize=13, show_test_name=False, pvalue_format_string="{:.1e}")
+
+    assert first.format_data(result) == "custom"
+    assert second.format_data(result) == "****"
+    assert full.format_data(result) == r"$T P = 1.000 \times 10^{-5}$"
+    assert first.fontsize == 13
+    assert second.fontsize == 11
+    assert full.fontsize == "small"
+    assert second.show_test_name is True
+    assert second.pvalue_format_string == "{:.3e}"
+
+    result.correction_method = "Holm-Bonferroni"
+    result.corrected_significance = False
+    first.config(correction_format="replace")
+
+    assert first.format_data(result) == "ns"
+    assert second.format_data(result) == "**** (ns)"

--- a/tests/test_statistical_options.py
+++ b/tests/test_statistical_options.py
@@ -186,12 +186,14 @@ def test_p_value_helper_corrects_all_resolved_pairs(
             self.configured: dict[str, object] = {}
             self.pvalues: list[float] | None = None
             self._pvalue_format: object = None
+            self.comparisons_correction = None
+            self.annotations: list[Any] = []
             self.instances.append(self)
 
         def configure(self, **kwargs: object) -> None:
             self.configured = kwargs
 
-        def apply_and_annotate(self) -> None:
+        def apply_test(self) -> None:
             return None
 
         def set_pvalues(self, pvalues: list[float]) -> None:

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -20,6 +20,38 @@ if TYPE_CHECKING:
     import cnsplots as cns
     from cnsplots._settings import CNSSettings
 
+    def _check_comparison_types(data: pd.DataFrame) -> None:
+        string_pairs: list[tuple[str, str]] = [("A", "B")]
+        numeric_pairs: list[tuple[int, float]] = [(0, 1.5)]
+        hue_pairs: list[tuple[tuple[int, str], tuple[int, str]]] = [
+            ((0, "control"), (0, "treated"))
+        ]
+        for plotter in (
+            cns.boxplot,
+            cns.violinplot,
+            cns.barplot,
+            cns.lollipopplot,
+        ):
+            assert_type(plotter(data, x="group", y="value", pairs="all"), Axes)
+            assert_type(
+                plotter(data, x="group", y="value", hue="condition", pairs="hue"),
+                Axes,
+            )
+            assert_type(plotter(data, x="group", y="value", pairs=string_pairs), Axes)
+            assert_type(plotter(data, x="group", y="value", pairs=numeric_pairs), Axes)
+            assert_type(
+                plotter(data, x="group", y="value", hue="condition", pairs=hue_pairs),
+                Axes,
+            )
+            assert_type(plotter(data, x="group", y="value", pairs=(("A", "B"),)), Axes)
+        assert_type(cns.stackplot(data, x="group", stack="outcome", pairs="all"), Axes)
+        assert_type(
+            cns.stackplot(data, x="group", stack="outcome", pairs=string_pairs), Axes
+        )
+        assert_type(
+            cns.stackplot(data, y="group", stack="outcome", pairs=numeric_pairs), Axes
+        )
+
     def _check_public_types(data: pd.DataFrame, ax: Axes, include_images: bool) -> None:
         assert_type(cns.settings, CNSSettings)
         assert_type(cns.settings.palette_qual, str)
@@ -71,6 +103,8 @@ if TYPE_CHECKING:
         assert_type(cns.palettes("Set1"), list[tuple[float, float, float]])
         assert_type(cns.palettes("parula"), Colormap)
         assert_type(cns.boxplot(data, x="group", y="value"), Axes)
+        assert_type(cns.get_comparison_results(ax), pd.DataFrame)
+        assert_type(cns.get_comparison_results(), pd.DataFrame)
         assert_type(cns.histplot(data, x="x", ax=ax), Axes)
         assert_type(cns.lineplot(data, x="x", y="y", ax=ax), Axes)
         assert_type(cns.regplot(data, x="x", y="y", color=(0.1, 0.2, 0.3)), Axes)


### PR DESCRIPTION
Expose the exact categorical comparisons used by plot annotations so callers can inspect and export them through `cns.get_comparison_results(ax)`.

- Return compared groups, test/alternative and independent-test metadata, contributing sample counts, raw/adjusted/displayed p-values, correction method, significance, and annotation text for box, violin, bar, lollipop, and stack plots.
- Compute each test once and render those same results, preserving existing correction and annotation semantics and default axes return types.
- Extract the p-value formatter into an independently configurable module-level class and align shared pair types with supported selectors, nested hue pairs, and numeric labels.
- Document ordering, missing-data handling, correction scope, result copies, and axes lifecycle, with a runnable example.

Validation:

- `make test`: 1,378 passed with 100% coverage.
- `make lint`: passed, including the static typing contract.
- 75 same-host pixel comparisons against `main` matched exactly across five plots, three formats, and five correction options, with deterministic bootstrap seeds.
- The documented bundled-tips example ran successfully.

Risks and follow-ups: Linux visual hash validation remains for CI; `make test-visual` skips all 32 cases on this macOS host because the baselines require Linux x86_64. Paired tests remain outside this change (#166), and no effect-size estimates are fabricated.

Closes #149
Closes #161
Closes #168
