### PR TITLE
✨ Add diagnostics and grouped cross-validation

### DIFF
--- a/examples/forestplot.py
+++ b/examples/forestplot.py
@@ -145,7 +145,7 @@ model.results.head()
 # %%
 # Logistic regression forest plot
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Display odds ratios from logistic regression.
+# Display cross-validated ROC-AUC from logistic regression.
 model = cns.methods.LogisticModel(
     data=gbsg2,
     event="cens",
@@ -167,6 +167,46 @@ model.fit()
 cns.figure(150, 150)
 cns.forestplot(model)
 model.results.head()
+
+
+# %%
+# Inspect logistic analysis diagnostics
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Each formula and hue group has a diagnostic row, including failed fits.
+# Counts describe the rows remaining after formula-specific missing values
+# are dropped; ``failure_reason`` explains analyses missing from results.
+model.diagnostics
+
+# %%
+# Nested cross-validation defaults to five unshuffled stratified folds at both
+# levels. Use ``inner_cv`` and ``outer_cv`` to supply fold counts or scikit-learn
+# splitters. Repeated observations need group-aware splitters at both levels,
+# for example with a dataset containing a ``patient_id`` column:
+#
+# .. code-block:: python
+#
+#    from sklearn.model_selection import GroupKFold
+#
+#    grouped_model = cns.LogisticModel(
+#        data=repeated_data,
+#        event="outcome",
+#        variates=["age"],
+#        inner_cv=GroupKFold(3),
+#        outer_cv=GroupKFold(5),
+#        groups="patient_id",
+#        random_state=42,
+#        retain_estimators=True,
+#    )
+#    grouped_model.fit()
+#    analysis_id = grouped_model.diagnostics.query("status == 'success'").iloc[0][
+#        "analysis_id"
+#    ]
+#    fold_models = grouped_model.estimators[analysis_id]
+#
+# ``retain_estimators=True`` keeps the selected fitted pipeline for each outer
+# training fold, keyed by the diagnostic ``analysis_id``. It adds no full-data
+# refit. By default, ``estimators`` is empty. Each call to ``fit()`` replaces
+# previous results, diagnostics, and retained models.
 
 
 # %%

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 if TYPE_CHECKING:
     import numpy as np
@@ -19,8 +20,8 @@ from patsy.eval import EvalEnvironment
 from patsy.highlevel import dmatrix
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.linear_model import LogisticRegression
-from sklearn.model_selection import GridSearchCV, cross_val_predict
-from sklearn.pipeline import make_pipeline
+from sklearn.model_selection import GridSearchCV, StratifiedKFold, check_cv
+from sklearn.pipeline import Pipeline, make_pipeline
 from sklearn.preprocessing import StandardScaler
 
 from cnsplots._validation import (
@@ -57,6 +58,9 @@ class CoxModel:
     hue : str, optional
         Column name for grouping variable. If provided, fits separate models
         for each group. Default is None (single model for all data).
+    retain_estimators : bool, optional
+        Retain successful fitted lifelines estimators in ``estimators``.
+        Default is False because these objects contain training data.
 
     Attributes
     ----------
@@ -64,6 +68,17 @@ class CoxModel:
         Results DataFrame containing hazard ratios, confidence intervals,
         p-values, and -log10(p-values) for all fitted models. Available after
         calling fit().
+    diagnostics : pd.DataFrame
+        One row per requested formula and hue group, including failed fits.
+        Columns are ``analysis_id``, ``analysis``, ``hue_group``, ``status``,
+        ``n_input``, ``n_analyzed``, ``n_dropped``, ``event_count``, and
+        ``failure_reason``. Counts describe rows with complete formula
+        predictors, even when fitting fails; unknown counts are null.
+    estimators : dict of int to lifelines.CoxPHFitter
+        Successful fitted estimators keyed by diagnostic ``analysis_id``,
+        populated only when ``retain_estimators=True``. IDs follow requested
+        group/formula order, starting at zero. These are the estimators used
+        for the reported hazard ratios; no additional refit is performed.
     name : str
         Model type identifier, always 'cox'.
 
@@ -121,13 +136,18 @@ class CoxModel:
         event: str,
         variates: list[str],
         hue: str | None = None,
+        *,
+        retain_estimators: bool = False,
     ) -> None:
         self.data = data
         self.duration = duration
         self.event = event
         self.variates = variates
         self.hue = hue
+        self.retain_estimators = retain_estimators
         self.results = None
+        self.diagnostics = pd.DataFrame()
+        self.estimators: dict[int, Any] = {}
         self.name = "cox"
 
     def fit(self) -> None:
@@ -136,6 +156,8 @@ class CoxModel:
 
         This method fits a separate Cox model for each variate, optionally
         stratified by hue groups. Results are stored in the results attribute.
+        Each call first clears results, diagnostics, and retained estimators,
+        including calls that fail input validation.
 
         Returns
         -------
@@ -167,15 +189,29 @@ class CoxModel:
         coefficients, it combines the formula and coefficient names so every
         estimate remains distinct in visualizations.
 
+        Diagnostics use ``status='success'`` or ``status='failed'``. For a
+        failed fit, ``failure_reason`` contains the exception message.
+        ``n_input`` is the group size; ``n_analyzed`` counts rows retained by
+        the formula's missing-value handling, ``n_dropped`` is the difference,
+        and ``event_count`` counts observed events in those retained rows.
+        These counts describe eligible rows, not a successful fit. As in
+        lifelines, missing formula predictors can cause a fit failure; this
+        method does not automatically drop rows before fitting. If the
+        formula cannot be evaluated, the eligible-row counts are null.
+
         Examples
         --------
         >>> model = cns.CoxModel(df, "time", "event", ["age", "treatment"])
         >>> model.fit()
         >>> print(model.results[["display_label", "exp(coef)", "p"]])
         """
-        import lifelines as ll
-
         self.results = None
+        self.diagnostics = pd.DataFrame()
+        self.estimators = {}
+
+        import lifelines as ll
+        from lifelines.utils import CovariateParameterMappings
+
         validate_dataframe(self.data, "data", "CoxModel.fit")
         validate_dataframe_not_empty(self.data, "CoxModel.fit")
         required_columns = [self.duration, self.event]
@@ -213,6 +249,7 @@ class CoxModel:
 
         df = self.data.copy()
         all_results = []
+        diagnostics = []
 
         if self.hue is None:
             hue_groups = [("All", df)]
@@ -224,6 +261,18 @@ class CoxModel:
 
         for hue_group, hue_data in hue_groups:
             for var in self.variates:
+                analysis_id = len(diagnostics)
+                diagnostic: dict[str, Any] = {
+                    "analysis_id": analysis_id,
+                    "analysis": var,
+                    "hue_group": hue_group,
+                    "status": "failed",
+                    "n_input": len(hue_data),
+                    "n_analyzed": None,
+                    "n_dropped": None,
+                    "event_count": None,
+                    "failure_reason": None,
+                }
                 try:
                     cph = ll.CoxPHFitter()
                     cph.fit(
@@ -240,12 +289,50 @@ class CoxModel:
                     summary["analysis"] = var
                     summary["hue_group"] = hue_group
                     all_results.append(summary)
+                    diagnostic.update(
+                        status="success",
+                        n_analyzed=len(hue_data),
+                        n_dropped=0,
+                        event_count=int(hue_data[self.event].sum()),
+                    )
+                    if self.retain_estimators:
+                        self.estimators[analysis_id] = cph
                 except Exception as exc:
+                    diagnostic["failure_reason"] = str(exc)
+                    # Recover eligibility using lifelines' formula engine without
+                    # changing its fit behavior or emitting duplicate warnings.
+                    try:
+                        with warnings.catch_warnings():
+                            warnings.simplefilter("ignore")
+                            indexed_data = hue_data.reset_index(drop=True).sort_values(
+                                [self.duration, self.event]
+                            )
+                            predictors = indexed_data.drop(
+                                columns=[self.duration, self.event]
+                            )
+                            mapping = CovariateParameterMappings(
+                                {"beta_": var}, predictors, force_no_intercept=True
+                            )
+                            design = mapping.mappings["beta_"].get_model_matrix(
+                                predictors
+                            )
+                        diagnostic.update(
+                            n_analyzed=len(design),
+                            n_dropped=len(hue_data) - len(design),
+                            event_count=int(
+                                indexed_data.loc[design.index, self.event].sum()
+                            ),
+                        )
+                    except Exception:
+                        pass
                     warnings.warn(
                         f"Error fitting {var} for hue group {hue_group}: {exc}",
                         RuntimeWarning,
                         stacklevel=2,
                     )
+                diagnostics.append(diagnostic)
+
+        self.diagnostics = pd.DataFrame(diagnostics)
 
         if not all_results:
             warnings.warn("No successful model fits", RuntimeWarning, stacklevel=2)
@@ -324,12 +411,67 @@ class _LogisticDesign(TransformerMixin, BaseEstimator):
         return design.drop("Intercept", axis=1)
 
 
+class _CVSplitter(Protocol):
+    def split(
+        self, X: Any, y: Any, groups: Any = None
+    ) -> Iterable[tuple[np.ndarray, np.ndarray]]: ...
+
+
+def _logistic_splits(
+    cv: int | _CVSplitter,
+    X: pd.DataFrame,
+    y: np.ndarray,
+    groups: np.ndarray | None,
+    level: str,
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    """Validate the actual partitions before learning any preprocessing state."""
+    splitter = check_cv(cv, y=y, classifier=True)
+    if isinstance(splitter, StratifiedKFold):
+        if pd.Series(y).value_counts().min() < splitter.n_splits:
+            raise ValueError(
+                f"{level} {splitter.n_splits}-fold cross-validation requires at least "
+                f"{splitter.n_splits} observations in each outcome class"
+            )
+        splits = list(splitter.split(X, y))
+    else:
+        splits = list(splitter.split(X, y, groups))
+    if not splits:
+        raise ValueError(f"{level} cross-validation yielded no splits")
+    validated = []
+    for train, test in splits:
+        train, test = np.asarray(train), np.asarray(test)
+        for indices in (train, test):
+            if (
+                indices.ndim != 1
+                or not np.issubdtype(indices.dtype, np.integer)
+                or len(indices) == 0
+                or (indices < 0).any()
+                or (indices >= len(y)).any()
+                or len(np.unique(indices)) != len(indices)
+            ):
+                raise ValueError(f"{level} cross-validation has invalid row indices")
+        if np.intersect1d(train, test).size:
+            raise ValueError(f"{level} cross-validation train/validation rows overlap")
+        if any(len(np.unique(y[indices])) != 2 for indices in (train, test)):
+            raise ValueError(
+                f"{level} cross-validation requires both outcome classes in every "
+                "training and validation partition for ROC-AUC"
+            )
+        if groups is not None and pd.Index(groups[train]).isin(groups[test]).any():
+            raise ValueError(
+                f"{level} cross-validation splits a group between training and "
+                "validation; use group-aware splitters at both levels"
+            )
+        validated.append((train, test))
+    return validated
+
+
 class LogisticModel:
     """
     Logistic regression model with cross-validation for binary classification.
 
     This class fits L1-regularized logistic regression models with nested
-    5-fold cross-validation to predict binary outcomes and assess predictor
+    cross-validation to predict binary outcomes and assess predictor
     performance using ROC-AUC with bootstrap confidence intervals.
 
     Parameters
@@ -346,12 +488,48 @@ class LogisticModel:
     hue : str, optional
         Column name for grouping variable. If provided, fits separate models
         for each group. Default is None (single model for all data).
+    inner_cv, outer_cv : int or cross-validation splitter, default: 5
+        Splitters for tuning and out-of-fold evaluation, respectively. Integers
+        select unshuffled stratified folds. Splitters receive the complete
+        predictor rows for each analysis; inner splitters receive only the
+        current outer training subset. Every training and validation partition
+        must contain both outcome classes. Outer validation partitions must
+        cover every analyzed row exactly once (repeated CV and partial-coverage
+        splitters such as TimeSeriesSplit are therefore unsupported).
+    groups : str or one-dimensional array-like, optional
+        Column containing subject/group identifiers, or one identifier per input
+        row, aligned by position even for a Series. Identifiers are subset with
+        hue groups and predictor exclusions. Missing identifiers are rejected.
+        Use group-aware splitters at both levels; any train/validation group
+        overlap is rejected. This is separate from ``hue``, which fits separate
+        analyses.
+    random_state : int or None, default: 42
+        Seed for the logistic solver and AUC bootstrap. Configure shuffling and
+        its seed on supplied splitters themselves. None permits nondeterminism.
+    retain_estimators : bool, default: False
+        Retain the selected pipeline from each outer fold for successful
+        analyses. No additional model is fitted on the full dataset.
 
     Attributes
     ----------
     results : pd.DataFrame
         Results DataFrame containing AUC values and confidence intervals for
         all fitted models. Available after calling fit().
+    diagnostics : pd.DataFrame
+        One row per requested formula/hue pair, in request order, with
+        ``analysis_id``, ``analysis``, ``hue_group``, ``status`` (success/failed),
+        ``n_input``, ``n_analyzed``, ``n_dropped``, ``class_counts``, and
+        ``failure_reason``. Analyzed counts describe complete predictor rows,
+        including when fitting fails. Counts are missing if formula evaluation
+        fails. Counts are aggregate; diagnostics do not store input row copies.
+    estimators : dict of int to list of sklearn.pipeline.Pipeline
+        When retention is enabled, maps diagnostics ``analysis_id`` to fitted
+        outer-fold pipelines in splitter order. These are evaluation models
+        refitted on each outer training subset after inner tuning, not a final
+        full-data refit. Pipelines include learned Patsy encoding, scaling, and
+        classifier state, without storing training rows or outcomes. Empty
+        otherwise. All fit state is cleared at the start of every fit, including
+        when input validation fails.
     name : str
         Model type identifier, always 'logistic'.
 
@@ -364,8 +542,8 @@ class LogisticModel:
     Notes
     -----
     The fit() method performs:
-    - Outer 5-fold cross-validation for out-of-fold predictions
-    - Inner 5-fold ROC-AUC tuning of the complete preprocessing/model pipeline
+    - Outer cross-validation for out-of-fold predictions (5 folds by default)
+    - Inner ROC-AUC tuning of the complete pipeline (5 folds by default)
     - Bootstrap confidence intervals for AUC (1000 iterations, alpha=0.05)
 
     Models use the liblinear solver optimized for L1 regularization and are
@@ -394,6 +572,21 @@ class LogisticModel:
     ... )
     >>> model.fit()
     >>> print(model.results)
+    >>> print(model.diagnostics)
+
+    >>> # Keep repeated subjects together at both validation levels
+    >>> from sklearn.model_selection import GroupKFold
+    >>> model = cns.LogisticModel(
+    ...     df,
+    ...     event="response",
+    ...     variates=["age"],
+    ...     groups="subject_id",
+    ...     outer_cv=GroupKFold(3),
+    ...     inner_cv=GroupKFold(2),
+    ...     retain_estimators=True,
+    ... )
+    >>> model.fit()
+    >>> outer_pipelines = model.estimators[0]
     """
 
     def __init__(
@@ -402,12 +595,25 @@ class LogisticModel:
         event: str,
         variates: list[str],
         hue: str | None = None,
+        *,
+        inner_cv: int | _CVSplitter = 5,
+        outer_cv: int | _CVSplitter = 5,
+        groups: str | Sequence[Any] | np.ndarray | pd.Series | None = None,
+        random_state: int | None = 42,
+        retain_estimators: bool = False,
     ) -> None:
         self.data = data
         self.event = event
         self.variates = variates
         self.hue = hue
+        self.inner_cv = inner_cv
+        self.outer_cv = outer_cv
+        self.groups = groups
+        self.random_state = random_state
+        self.retain_estimators = retain_estimators
         self.results = None
+        self.diagnostics = pd.DataFrame()
+        self.estimators: dict[int, list[Pipeline]] = {}
         self.name = "logistic"
 
     def _compute_auc_ci(
@@ -441,7 +647,7 @@ class LogisticModel:
         y_pred_proba = np.asarray(y_pred_proba)
         auc = skl.metrics.roc_auc_score(y_true, y_pred_proba)
         aucs = []
-        rng = np.random.default_rng(42)
+        rng = np.random.default_rng(self.random_state)
         n = len(y_true)
         for _ in range(n_bootstrap):
             indices = rng.choice(n, n, replace=True)
@@ -461,7 +667,7 @@ class LogisticModel:
         Fit logistic regression models for all specified variates.
 
         This method fits a separate L1-regularized logistic regression model
-        with nested 5-fold cross-validation for each variate, optionally stratified
+        with nested cross-validation for each variate, optionally stratified
         by hue groups. Results are stored in the results attribute.
 
         Returns
@@ -483,15 +689,19 @@ class LogisticModel:
         1. Stateful Patsy transforms are rejected before learning any design state.
            A stateless formula evaluation identifies complete predictor rows and
            aligns their outcomes; its design information is discarded.
-        2. Outer 5-fold stratified CV holds out each row once. Within each outer
-           training fold, inner 5-fold stratified CV tunes 10 values of C,
+        2. Outer CV holds out each row once. Within each outer
+           training fold, inner CV tunes 10 values of C,
            logarithmically spaced from 1e-4 to 1e4, using ROC-AUC.
         3. Each inner fit learns Patsy encoding and standardization on its training
            rows only, followed by L1 logistic regression. The selected pipeline
            is refitted on the outer training rows to predict the outer held-out
-           rows. Both CV levels use unshuffled folds; the solver seed is 42.
+           rows. Defaults use unshuffled stratified 5-fold CV at both levels
+           and a solver seed of 42. Feasibility is checked against the actual
+           partitions after predictor exclusions.
         4. AUC is computed from all out-of-fold predictions. The existing 1000
            bootstrap resamples of these predictions provide the 95% CI.
+           Bootstrap resamples individual observations; groups control CV
+           splitting only, not the confidence-interval method.
 
         Formulas must use row-wise expressions. Stateful Patsy transforms
         (including splines, centering, and standardization) are unsupported until
@@ -502,7 +712,10 @@ class LogisticModel:
         pandas categorical dtype.
 
         Runtime warnings are emitted for hue groups with no outcome variance.
-        Errors during fitting are caught and surfaced as warnings.
+        Errors during fitting are caught and surfaced as warnings, with one
+        diagnostics entry for every requested analysis. Invalid required input
+        columns or group arrays raise ValueError before any analysis. Results,
+        diagnostics, and retained estimators are reset before validation.
 
         Examples
         --------
@@ -511,6 +724,8 @@ class LogisticModel:
         >>> print(model.results[["predictor", "auc", "hue_group"]])
         """
         self.results = None
+        self.diagnostics = pd.DataFrame()
+        self.estimators = {}
         validate_dataframe(self.data, "data", "LogisticModel.fit")
         validate_dataframe_not_empty(self.data, "LogisticModel.fit")
         required_columns = [self.event]
@@ -519,8 +734,26 @@ class LogisticModel:
         validate_columns_exist(self.data, required_columns, "LogisticModel.fit")
         validate_no_nulls(self.data, required_columns, "LogisticModel.fit")
 
-        df = self.data.copy()
+        groups = None
+        if self.groups is not None:
+            if isinstance(self.groups, str):
+                validate_columns_exist(self.data, [self.groups], "LogisticModel.fit")
+                groups = self.data[self.groups].to_numpy()
+            else:
+                groups = np.asarray(self.groups)
+            if groups.ndim != 1 or len(groups) != len(self.data):
+                raise ValueError(
+                    "[LogisticModel.fit] groups must be one-dimensional with one "
+                    "identifier per input row"
+                )
+            if pd.isna(groups).any():
+                raise ValueError(
+                    "[LogisticModel.fit] groups must not contain missing values"
+                )
+
+        df = self.data.reset_index(drop=True)
         all_results = []
+        diagnostics: list[dict[str, Any]] = []
         regularization_options: dict[str, Any] = (
             {"l1_ratio": 1}
             if inspect.signature(LogisticRegression).parameters["l1_ratio"].default == 0
@@ -536,8 +769,19 @@ class LogisticModel:
             ]
 
         for hue_group, hue_data in hue_groups:
-            hue_data = hue_data.reset_index(drop=True)
             for var in self.variates:
+                diagnostic: dict[str, Any] = {
+                    "analysis_id": len(diagnostics),
+                    "analysis": var,
+                    "hue_group": hue_group,
+                    "status": "failed",
+                    "n_input": len(hue_data),
+                    "n_analyzed": None,
+                    "n_dropped": None,
+                    "class_counts": None,
+                    "failure_reason": None,
+                }
+                diagnostics.append(diagnostic)
                 try:
                     formula = ModelDesc.from_formula(var)
                     eval_env = EvalEnvironment.capture(0)
@@ -558,7 +802,13 @@ class LogisticModel:
                     X = hue_data.loc[complete_rows]
                     y = X[self.event].to_numpy()
                     class_counts = pd.Series(y).value_counts()
+                    diagnostic.update(
+                        n_analyzed=len(y),
+                        n_dropped=len(hue_data) - len(y),
+                        class_counts=class_counts.to_dict(),
+                    )
                     if len(class_counts) < 2:
+                        diagnostic["failure_reason"] = "No variance in outcome"
                         warnings.warn(
                             f"No variance in outcome for {var} in hue group {hue_group}",
                             RuntimeWarning,
@@ -570,40 +820,48 @@ class LogisticModel:
                             "Logistic regression requires exactly two outcome classes"
                         )
 
-                    n_splits = 5
-                    if (class_counts < n_splits).any():
-                        raise ValueError(
-                            "Outer 5-fold cross-validation requires at least 5 "
-                            "observations in each outcome class after removing rows "
-                            f"with missing predictor values; got {class_counts.to_dict()}"
-                        )
-                    outer_training_counts = class_counts - np.ceil(
-                        class_counts / n_splits
-                    ).astype(int)
-                    if (outer_training_counts < n_splits).any():
-                        raise ValueError(
-                            "Inner 5-fold cross-validation requires at least 5 "
-                            "observations in each outcome class in every outer training "
-                            "fold; at least 7 observations per class are required"
-                        )
-                    model = GridSearchCV(
-                        make_pipeline(
-                            _LogisticDesign(var),
-                            StandardScaler(),
-                            LogisticRegression(
-                                solver="liblinear",
-                                random_state=42,
-                                **regularization_options,
-                            ),
-                        ),
-                        {"logisticregression__C": np.logspace(-4, 4, 10)},
-                        cv=n_splits,
-                        scoring="roc_auc",
-                        error_score="raise",
+                    analysis_groups = None if groups is None else groups[X.index]
+                    outer_splits = _logistic_splits(
+                        self.outer_cv, X, y, analysis_groups, "Outer"
                     )
-                    y_pred_proba = cross_val_predict(
-                        model, X, y, cv=n_splits, method="predict_proba"
-                    )[:, 1]
+                    held_out = np.concatenate([test for _, test in outer_splits])
+                    if not np.array_equal(np.sort(held_out), np.arange(len(y))):
+                        raise ValueError(
+                            "Outer cross-validation must hold out each analyzed row "
+                            "exactly once"
+                        )
+                    inner_splits = [
+                        _logistic_splits(
+                            self.inner_cv,
+                            X.iloc[train],
+                            y[train],
+                            None if analysis_groups is None else analysis_groups[train],
+                            "Inner",
+                        )
+                        for train, _ in outer_splits
+                    ]
+                    y_pred_proba = np.empty(len(y), dtype=float)
+                    fitted_estimators = []
+                    for (train, test), inner in zip(outer_splits, inner_splits):
+                        model = GridSearchCV(
+                            make_pipeline(
+                                _LogisticDesign(var),
+                                StandardScaler(),
+                                LogisticRegression(
+                                    solver="liblinear",
+                                    random_state=self.random_state,
+                                    **regularization_options,
+                                ),
+                            ),
+                            {"logisticregression__C": np.logspace(-4, 4, 10)},
+                            cv=inner,
+                            scoring="roc_auc",
+                            error_score="raise",
+                        )
+                        model.fit(X.iloc[train], y[train])
+                        y_pred_proba[test] = model.predict_proba(X.iloc[test])[:, 1]
+                        if self.retain_estimators:
+                            fitted_estimators.append(model.best_estimator_)
                     auc, auc_lower, auc_upper = self._compute_auc_ci(y, y_pred_proba)
                     model_result = {
                         "predictor": var,
@@ -613,13 +871,18 @@ class LogisticModel:
                         "hue_group": hue_group,
                     }
                     all_results.append(model_result)
+                    diagnostic["status"] = "success"
+                    if self.retain_estimators:
+                        self.estimators[diagnostic["analysis_id"]] = fitted_estimators
                 except Exception as exc:
+                    diagnostic["failure_reason"] = str(exc)
                     warnings.warn(
                         f"Error fitting {var} for hue group {hue_group}: {exc}",
                         RuntimeWarning,
                         stacklevel=2,
                     )
 
+        self.diagnostics = pd.DataFrame(diagnostics)
         results_df = pd.DataFrame(all_results)
         if len(results_df) == 0:
             warnings.warn(

--- a/tests/test_cox_diagnostics.py
+++ b/tests/test_cox_diagnostics.py
@@ -1,0 +1,181 @@
+"""Auditable fit outcomes and opt-in retained Cox estimators."""
+
+from __future__ import annotations
+
+import lifelines as ll
+import numpy as np
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+@pytest.fixture
+def cox_data() -> pd.DataFrame:
+    rng = np.random.default_rng(13)
+    return pd.DataFrame(
+        {
+            "time": rng.exponential(10, 120),
+            "event": rng.integers(0, 2, 120),
+            "x": rng.normal(size=120),
+            "z": rng.normal(size=120),
+            "group": ["A"] * 60 + ["B"] * 60,
+        }
+    )
+
+
+def test_cox_diagnostics_include_every_group_formula_and_missing_row(
+    cox_data: pd.DataFrame,
+) -> None:
+    data = cox_data.copy()
+    data.loc[[2, 5], "z"] = np.nan
+    # Counts must identify rows by position even when input labels repeat.
+    data.index = pd.Index([0] * len(data))
+    original = data.copy(deep=True)
+    model = cns.CoxModel(
+        data,
+        "time",
+        "event",
+        ["x", "z", "missing"],
+        hue="group",
+        retain_estimators=True,
+    )
+    assert model.diagnostics.empty
+    assert model.estimators == {}
+
+    with pytest.warns(RuntimeWarning, match="Error fitting") as caught:
+        model.fit()
+
+    assert len(caught) == 3
+    diagnostics = model.diagnostics
+    assert diagnostics["analysis_id"].tolist() == list(range(6))
+    assert diagnostics["analysis"].tolist() == ["x", "z", "missing"] * 2
+    assert diagnostics["hue_group"].tolist() == ["A"] * 3 + ["B"] * 3
+    assert diagnostics["status"].tolist() == [
+        "success",
+        "failed",
+        "failed",
+        "success",
+        "success",
+        "failed",
+    ]
+    assert diagnostics["n_input"].tolist() == [60] * 6
+    assert diagnostics.loc[[0, 1, 3, 4], "n_analyzed"].tolist() == [60, 58, 60, 60]
+    assert diagnostics.loc[[0, 1, 3, 4], "n_dropped"].tolist() == [0, 2, 0, 0]
+    assert (
+        diagnostics.loc[1, "event_count"]
+        == cox_data.loc[cox_data.index[:60].difference([2, 5]), "event"].sum()
+    )
+    assert diagnostics.loc[3, "event_count"] == cox_data.iloc[60:]["event"].sum()
+    assert (
+        diagnostics.loc[[2, 5], ["n_analyzed", "n_dropped", "event_count"]]
+        .isna()
+        .all()
+        .all()
+    )
+    assert diagnostics.loc[[0, 3, 4], "failure_reason"].isna().all()
+    assert diagnostics.loc[[1, 2, 5], "failure_reason"].str.len().gt(0).all()
+    assert set(model.estimators) == {0, 3, 4}
+    assert all(
+        isinstance(fitter, ll.CoxPHFitter) for fitter in model.estimators.values()
+    )
+    assert model.results is not None
+    assert len(model.results) == 3
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_cox_estimator_retention_preserves_results_and_fitted_predictions(
+    cox_data: pd.DataFrame,
+) -> None:
+    default = cns.CoxModel(cox_data, "time", "event", ["x + z"])
+    retained = cns.CoxModel(
+        cox_data, "time", "event", ["x + z"], retain_estimators=True
+    )
+
+    default.fit()
+    retained.fit()
+
+    assert default.estimators == {}
+    assert default.results is not None
+    assert retained.results is not None
+    pd.testing.assert_frame_equal(default.results, retained.results)
+    pd.testing.assert_frame_equal(default.diagnostics, retained.diagnostics)
+    assert len(retained.results) == 2
+    assert len(retained.diagnostics) == 1
+    reference = ll.CoxPHFitter().fit(
+        cox_data, duration_col="time", event_col="event", formula="x + z"
+    )
+    pd.testing.assert_frame_equal(retained.estimators[0].summary, reference.summary)
+    pd.testing.assert_series_equal(
+        retained.estimators[0].predict_partial_hazard(cox_data),
+        reference.predict_partial_hazard(cox_data),
+    )
+    assert retained.diagnostics.loc[0, "event_count"] == cox_data["event"].sum()
+
+
+def test_cox_diagnostics_and_estimators_reset_for_each_fit(
+    cox_data: pd.DataFrame,
+) -> None:
+    model = cns.CoxModel(cox_data, "time", "event", ["x"], retain_estimators=True)
+    model.fit()
+    first_estimator = model.estimators[0]
+    model.variates = ["z", "x"]
+    model.fit()
+
+    assert model.diagnostics["analysis"].tolist() == ["z", "x"]
+    assert model.diagnostics["analysis_id"].tolist() == [0, 1]
+    assert set(model.estimators) == {0, 1}
+    assert model.estimators[0] is not first_estimator
+
+    model.variates = ["missing"]
+    with pytest.warns(RuntimeWarning):
+        model.fit()
+
+    assert model.results is None
+    assert model.estimators == {}
+    assert model.diagnostics["analysis"].tolist() == ["missing"]
+    assert model.diagnostics["status"].tolist() == ["failed"]
+
+    model.data = cox_data.drop(columns="event")
+    with pytest.raises(ValueError, match="event"):
+        model.fit()
+
+    assert model.results is None
+    assert model.diagnostics.empty
+    assert model.estimators == {}
+
+
+def test_cox_all_missing_predictors_have_zero_eligible_rows(
+    cox_data: pd.DataFrame,
+) -> None:
+    model = cns.CoxModel(cox_data.assign(x=np.nan), "time", "event", ["x"])
+
+    with pytest.warns(RuntimeWarning):
+        model.fit()
+
+    row = model.diagnostics.iloc[0]
+    assert row["status"] == "failed"
+    assert row["n_input"] == len(cox_data)
+    assert row["n_analyzed"] == 0
+    assert row["n_dropped"] == len(cox_data)
+    assert row["event_count"] == 0
+    assert row["failure_reason"]
+    assert model.results is None
+
+
+def test_cox_failure_counts_use_lifelines_formula_row_order(
+    cox_data: pd.DataFrame,
+) -> None:
+    data = cox_data.assign(time=np.arange(120, 0, -1), event=[0] + [1] * 119)
+    model = cns.CoxModel(data, "time", "event", ["x.shift(1)"])
+
+    with pytest.warns(RuntimeWarning):
+        model.fit()
+
+    row = model.diagnostics.iloc[0]
+    assert row["status"] == "failed"
+    assert row["n_analyzed"] == 119
+    assert row["n_dropped"] == 1
+    # lifelines sorts by duration before evaluating the shift, excluding the
+    # final input row (event=1), not the first input row (event=0).
+    assert row["event_count"] == 118

--- a/tests/test_logistic_cv.py
+++ b/tests/test_logistic_cv.py
@@ -1,0 +1,340 @@
+"""Regression coverage for configurable nested logistic cross-validation."""
+
+from __future__ import annotations
+
+from collections import Counter
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.base import clone
+from sklearn.model_selection import (
+    BaseCrossValidator,
+    GridSearchCV,
+    GroupKFold,
+    StratifiedKFold,
+    cross_val_predict,
+)
+from sklearn.preprocessing import StandardScaler
+
+import cnsplots as cns
+from cnsplots import _methods
+
+
+class RecordingGroupKFold(GroupKFold):
+    def __init__(self, n_splits: int) -> None:
+        super().__init__(n_splits=n_splits)
+        self.calls = []
+
+    def split(self, X, y=None, groups=None):
+        splits = list(super().split(X, y, groups))
+        self.calls.append((X.copy(), np.asarray(y), np.asarray(groups), splits))
+        return iter(splits)
+
+
+@pytest.mark.parametrize("groups_as_column", [True, False])
+def test_grouped_nested_cv_keeps_subjects_and_preprocessing_separate(
+    monkeypatch: pytest.MonkeyPatch, groups_as_column: bool
+) -> None:
+    data = pd.DataFrame(
+        {
+            "event": [0, 1] * 24,
+            "score": np.arange(48, dtype=float),
+            "row_id": np.arange(48),
+            "subject": np.repeat(np.arange(24), 2),
+            "cohort": ["A"] * 24 + ["B"] * 24,
+        },
+        index=np.full(48, 100),
+    )
+    data.iloc[[0, 5, 28], data.columns.get_loc("score")] = np.nan
+    groups = (
+        "subject"
+        if groups_as_column
+        else pd.Series(data["subject"].to_numpy(), index=np.arange(48)[::-1])
+    )
+    outer = RecordingGroupKFold(3)
+    inner = RecordingGroupKFold(2)
+    design_rows = []
+    scaler_rows = []
+    original_design_fit = _methods._LogisticDesign.fit
+
+    def track_design_fit(self, X, y=None):
+        design_rows.append(tuple(X["row_id"]))
+        return original_design_fit(self, X, y)
+
+    class TrackingScaler(StandardScaler):
+        def fit(self, X, y=None, sample_weight=None):
+            scaler_rows.append(tuple(X["score"].astype(int)))
+            return super().fit(X, y, sample_weight=sample_weight)
+
+    monkeypatch.setattr(_methods._LogisticDesign, "fit", track_design_fit)
+    monkeypatch.setattr(_methods, "StandardScaler", TrackingScaler)
+    monkeypatch.setattr(
+        cns.LogisticModel, "_compute_auc_ci", lambda self, y, p: (0.5, 0.4, 0.6)
+    )
+    model = cns.LogisticModel(
+        data,
+        event="event",
+        variates=["score"],
+        hue="cohort",
+        groups=groups,
+        outer_cv=outer,
+        inner_cv=inner,
+        retain_estimators=True,
+    )
+
+    model.fit()
+
+    assert model.results is not None
+    assert len(outer.calls) == 2
+    assert len(inner.calls) == 6
+    expected_fits = Counter()
+    for cohort_index, (X, y, received_groups, outer_splits) in enumerate(outer.calls):
+        cohort = "AB"[cohort_index]
+        expected = data[(data["cohort"] == cohort) & data["score"].notna()]
+        np.testing.assert_array_equal(X["row_id"], expected["row_id"])
+        np.testing.assert_array_equal(y, expected["event"])
+        np.testing.assert_array_equal(received_groups, expected["subject"])
+        analysis_id = model.diagnostics.loc[
+            model.diagnostics["hue_group"] == cohort, "analysis_id"
+        ].iloc[0]
+        retained = model.estimators[analysis_id]
+        assert len(retained) == 3
+        for fold, (outer_train, outer_test) in enumerate(outer_splits):
+            train_subjects = set(received_groups[outer_train])
+            test_subjects = set(received_groups[outer_test])
+            assert train_subjects.isdisjoint(test_subjects)
+            outer_rows = X["row_id"].to_numpy()[outer_train]
+            expected_fits[tuple(outer_rows)] += 1
+            inner_X, inner_y, inner_groups, inner_splits = inner.calls[
+                cohort_index * 3 + fold
+            ]
+            np.testing.assert_array_equal(inner_X["row_id"], outer_rows)
+            np.testing.assert_array_equal(inner_y, y[outer_train])
+            np.testing.assert_array_equal(inner_groups, received_groups[outer_train])
+            for inner_train, inner_test in inner_splits:
+                assert set(inner_groups[inner_train]).isdisjoint(
+                    inner_groups[inner_test]
+                )
+                assert set(inner_groups[inner_train]).isdisjoint(test_subjects)
+                expected_fits[tuple(outer_rows[inner_train])] += 10
+            pipeline = retained[fold]
+            assert pipeline.steps[0][1].formula == "score"
+            np.testing.assert_allclose(pipeline.steps[1][1].mean_, [outer_rows.mean()])
+            assert pipeline.steps[2][1].classes_.tolist() == [0, 1]
+    assert Counter(design_rows) == expected_fits
+    assert Counter(scaler_rows) == expected_fits
+    assert len(design_rows) == 2 * 3 * (2 * 10 + 1)
+
+
+def test_nondefault_folds_fit_fewer_than_seven_rows_per_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame({"event": [0, 1] * 6, "score": np.arange(12)})
+    monkeypatch.setattr(
+        cns.LogisticModel, "_compute_auc_ci", lambda self, y, p: (0.5, 0.4, 0.6)
+    )
+    model = cns.LogisticModel(data, "event", ["score"], outer_cv=3, inner_cv=2)
+
+    model.fit()
+
+    assert model.results is not None
+    assert model.estimators == {}
+    assert model.diagnostics["status"].tolist() == ["success"]
+
+
+def test_default_predictions_match_previous_nested_cross_val_predict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event = np.tile([0, 1], 15)
+    data = pd.DataFrame(
+        {"event": event, "score": event + np.random.default_rng(20).normal(size=30)}
+    )
+    probabilities = []
+
+    def capture_auc(self, y, p):
+        probabilities.append(p)
+        return 0.5, 0.4, 0.6
+
+    monkeypatch.setattr(cns.LogisticModel, "_compute_auc_ci", capture_auc)
+    model = cns.LogisticModel(data, "event", ["score"], retain_estimators=True)
+    model.fit()
+    pipeline = clone(model.estimators[0][0])
+    previous_estimator = GridSearchCV(
+        pipeline,
+        {"logisticregression__C": np.logspace(-4, 4, 10)},
+        cv=5,
+        scoring="roc_auc",
+        error_score="raise",
+    )
+
+    previous_probabilities = cross_val_predict(
+        previous_estimator, data, event, cv=5, method="predict_proba"
+    )[:, 1]
+
+    np.testing.assert_array_equal(probabilities[0], previous_probabilities)
+
+
+def test_shuffled_splitters_and_model_seed_are_reproducible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = pd.DataFrame({"event": [0, 1] * 12, "score": np.arange(24)})
+    seeds = []
+    original_rng = np.random.default_rng
+    original_auc = cns.LogisticModel._compute_auc_ci
+
+    def record_rng(seed=None):
+        seeds.append(seed)
+        return original_rng(seed)
+
+    def short_bootstrap(self, y, probabilities):
+        return original_auc(self, y, probabilities, n_bootstrap=30)
+
+    monkeypatch.setattr(_methods.np.random, "default_rng", record_rng)
+    monkeypatch.setattr(cns.LogisticModel, "_compute_auc_ci", short_bootstrap)
+    outer = StratifiedKFold(3, shuffle=True, random_state=11)
+    model = cns.LogisticModel(
+        data,
+        "event",
+        ["score"],
+        outer_cv=outer,
+        inner_cv=StratifiedKFold(2, shuffle=True, random_state=7),
+        random_state=17,
+        retain_estimators=True,
+    )
+    model.fit()
+    assert model.results is not None
+    first_results = model.results.copy()
+    first_estimators = next(iter(model.estimators.values()))
+
+    model.fit()
+
+    pd.testing.assert_frame_equal(model.results, first_results)
+    assert seeds == [17, 17]
+    second_estimators = next(iter(model.estimators.values()))
+    for (train, _), first, second in zip(
+        outer.split(data, data["event"]), first_estimators, second_estimators
+    ):
+        assert first is not second
+        np.testing.assert_allclose(
+            first.steps[1][1].mean_, [data.iloc[train].score.mean()]
+        )
+        assert second.steps[2][1].random_state == 17
+        np.testing.assert_array_equal(
+            first.predict_proba(data), second.predict_proba(data)
+        )
+
+
+@pytest.mark.parametrize(
+    "groups", [[0, 1], np.zeros((12, 1)), "missing_subject", [None] * 12]
+)
+def test_invalid_groups_clear_stale_state_before_fitting(
+    monkeypatch: pytest.MonkeyPatch, groups
+) -> None:
+    data = pd.DataFrame({"event": [0, 1] * 6, "score": np.arange(12)})
+    model = cns.LogisticModel(data, "event", ["score"], groups=groups)
+    model.results = pd.DataFrame({"old": [True]})
+    model.diagnostics = pd.DataFrame({"old": [True]})
+    model.estimators = {99: []}
+    fit = Mock()
+    monkeypatch.setattr(_methods._LogisticDesign, "fit", fit)
+
+    with pytest.raises(ValueError):
+        model.fit()
+
+    fit.assert_not_called()
+    assert model.results is None
+    assert model.diagnostics.empty
+    assert model.estimators == {}
+
+
+class InvalidCV(BaseCrossValidator):
+    def __init__(self, problem: str) -> None:
+        self.problem = problem
+
+    def get_n_splits(self, X=None, y=None, groups=None):
+        return 2
+
+    def split(self, X, y=None, groups=None):
+        train = np.arange(len(X) - 2)
+        test = np.arange(len(X) - 2, len(X))
+        if self.problem == "overlap":
+            train = np.arange(len(X))
+        elif self.problem == "one class":
+            test = np.flatnonzero(np.asarray(y) == 0)
+            train = np.flatnonzero(np.asarray(y) == 1)
+        elif self.problem == "out of range":
+            test = np.array([len(X), len(X) + 1])
+        elif self.problem == "no splits":
+            return
+        yield train, test
+        if self.problem == "repeated heldout":
+            yield train, test
+
+
+@pytest.mark.parametrize("layer", ["inner", "outer"])
+@pytest.mark.parametrize(
+    "problem", ["overlap", "one class", "out of range", "no splits"]
+)
+def test_invalid_nested_splits_fail_before_learning(
+    monkeypatch: pytest.MonkeyPatch, layer: str, problem: str
+) -> None:
+    data = pd.DataFrame({"event": [0, 1] * 12, "score": np.arange(24)})
+    model = cns.LogisticModel(
+        data,
+        "event",
+        ["score"],
+        inner_cv=InvalidCV(problem) if layer == "inner" else 2,
+        outer_cv=InvalidCV(problem) if layer == "outer" else 3,
+    )
+    fit = Mock()
+    monkeypatch.setattr(_methods._LogisticDesign, "fit", fit)
+
+    with pytest.warns(RuntimeWarning):
+        model.fit()
+
+    fit.assert_not_called()
+    assert model.results is None
+    assert model.diagnostics["status"].tolist() == ["failed"]
+    assert layer.capitalize() in model.diagnostics.iloc[0]["failure_reason"]
+
+
+@pytest.mark.parametrize("problem", ["missing heldout", "repeated heldout"])
+def test_outer_validation_requires_each_row_exactly_once(problem: str) -> None:
+    data = pd.DataFrame({"event": [0, 1] * 12, "score": np.arange(24)})
+    model = cns.LogisticModel(
+        data, "event", ["score"], outer_cv=InvalidCV(problem), inner_cv=2
+    )
+
+    with pytest.warns(RuntimeWarning):
+        model.fit()
+
+    assert model.results is None
+    assert "exactly once" in model.diagnostics.iloc[0]["failure_reason"]
+
+
+@pytest.mark.parametrize("layer", ["inner", "outer"])
+def test_groups_cannot_be_silently_ignored_by_splitter(layer: str) -> None:
+    data = pd.DataFrame(
+        {
+            "event": [0, 1] * 24,
+            "score": np.arange(48),
+            "subject": np.tile(np.repeat(np.arange(6), 2), 4),
+        }
+    )
+    model = cns.LogisticModel(
+        data,
+        "event",
+        ["score"],
+        groups="subject",
+        inner_cv=2,
+        outer_cv=GroupKFold(3) if layer == "inner" else 3,
+    )
+
+    with pytest.warns(RuntimeWarning):
+        model.fit()
+
+    assert model.results is None
+    assert "group" in model.diagnostics.iloc[0]["failure_reason"].lower()
+    assert layer.capitalize() in model.diagnostics.iloc[0]["failure_reason"]

--- a/tests/test_logistic_diagnostics.py
+++ b/tests/test_logistic_diagnostics.py
@@ -1,0 +1,234 @@
+"""Regression coverage for logistic analysis diagnostics and retained models."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.model_selection import GridSearchCV
+from sklearn.pipeline import Pipeline
+
+import cnsplots as cns
+
+
+@pytest.fixture
+def logistic_data(monkeypatch: pytest.MonkeyPatch) -> pd.DataFrame:
+    monkeypatch.setattr(
+        cns.LogisticModel,
+        "_compute_auc_ci",
+        lambda self, y, predictions: (0.5, 0.4, 0.6),
+    )
+    return pd.DataFrame({"event": [0, 1] * 12, "score": np.arange(24, dtype=float)})
+
+
+@pytest.mark.parametrize("retain_estimators", [False, True])
+def test_diagnostics_record_every_hue_and_formula(
+    logistic_data: pd.DataFrame, retain_estimators: bool
+) -> None:
+    successful = logistic_data.assign(cohort="A")
+    successful.loc[:1, "score"] = np.nan
+    data = pd.concat(
+        [successful, logistic_data.assign(event=0, cohort="B")], ignore_index=True
+    )
+    data["only_zero"] = np.where(data["event"] == 0, 1.0, np.nan)
+    model = cns.LogisticModel(
+        data,
+        "event",
+        ["score", "only_zero", "unknown_predictor"],
+        hue="cohort",
+        inner_cv=2,
+        outer_cv=2,
+        retain_estimators=retain_estimators,
+    )
+
+    with pytest.warns(RuntimeWarning) as caught:
+        model.fit()
+
+    assert len(caught) == 5
+    diagnostics = model.diagnostics
+    assert diagnostics.columns.tolist() == [
+        "analysis_id",
+        "analysis",
+        "hue_group",
+        "status",
+        "n_input",
+        "n_analyzed",
+        "n_dropped",
+        "class_counts",
+        "failure_reason",
+    ]
+    assert diagnostics["analysis_id"].is_unique
+    assert diagnostics[["hue_group", "analysis"]].to_records(index=False).tolist() == [
+        (hue, formula)
+        for hue in ["A", "B"]
+        for formula in ["score", "only_zero", "unknown_predictor"]
+    ]
+    assert diagnostics["status"].tolist() == ["success"] + ["failed"] * 5
+    assert diagnostics["n_input"].tolist() == [24] * 6
+    rows = diagnostics.set_index(["hue_group", "analysis"])
+    success = rows.loc[("A", "score")]
+    assert success["n_analyzed"] == 22
+    assert success["n_dropped"] == 2
+    assert success["class_counts"] == {0: 11, 1: 11}
+    assert success["failure_reason"] is None
+    for hue, formula, n_analyzed in [
+        ("A", "only_zero", 12),
+        ("B", "score", 24),
+        ("B", "only_zero", 24),
+    ]:
+        row = rows.loc[(hue, formula)]
+        assert row["n_analyzed"] == n_analyzed
+        assert row["n_dropped"] == 24 - n_analyzed
+        assert row["class_counts"] == {0: n_analyzed}
+        assert row["failure_reason"] == "No variance in outcome"
+    for hue in ["A", "B"]:
+        row = rows.loc[(hue, "unknown_predictor")]
+        assert pd.isna(row["n_analyzed"])
+        assert pd.isna(row["n_dropped"])
+        assert row["class_counts"] is None
+        assert "unknown_predictor" in row["failure_reason"]
+
+    assert model.results is not None
+    assert model.results.columns.tolist() == [
+        "predictor",
+        "auc",
+        "lower_ci",
+        "upper_ci",
+        "hue_group",
+    ]
+    assert model.results[["predictor", "hue_group"]].to_dict("records") == [
+        {"predictor": "score", "hue_group": "A"}
+    ]
+    if retain_estimators:
+        assert list(model.estimators) == [success["analysis_id"]]
+        estimators = model.estimators[success["analysis_id"]]
+        assert len(estimators) == 2
+        complete = successful.dropna(subset=["score"])
+        for estimator in estimators:
+            assert isinstance(estimator, Pipeline)
+            assert estimator.named_steps["standardscaler"].n_samples_seen_ == 11
+            probabilities = estimator.predict_proba(complete)
+            assert probabilities.shape == (22, 2)
+            assert np.isfinite(probabilities).all()
+            np.testing.assert_allclose(probabilities.sum(axis=1), 1)
+    else:
+        assert model.estimators == {}
+
+
+def test_duplicate_formulas_retain_distinct_analyses(
+    logistic_data: pd.DataFrame,
+) -> None:
+    model = cns.LogisticModel(
+        logistic_data,
+        "event",
+        ["score", "score"],
+        inner_cv=2,
+        outer_cv=2,
+        retain_estimators=True,
+    )
+    model.fit()
+
+    assert model.diagnostics["analysis"].tolist() == ["score", "score"]
+    assert model.diagnostics["status"].tolist() == ["success", "success"]
+    analysis_ids = model.diagnostics["analysis_id"].tolist()
+    assert len(set(analysis_ids)) == 2
+    assert set(model.estimators) == set(analysis_ids)
+    assert (
+        model.estimators[analysis_ids[0]][0] is not model.estimators[analysis_ids[1]][0]
+    )
+    assert model.results is not None
+    assert len(model.results) == 2
+
+
+def test_refitting_clears_results_diagnostics_and_estimators(
+    logistic_data: pd.DataFrame,
+) -> None:
+    model = cns.LogisticModel(
+        logistic_data,
+        "event",
+        ["score"],
+        inner_cv=2,
+        outer_cv=2,
+        retain_estimators=True,
+    )
+    model.fit()
+    assert model.estimators
+    assert model.results is not None
+    assert model.diagnostics["status"].tolist() == ["success"]
+
+    model.variates = ["unknown_predictor"]
+    with pytest.warns(RuntimeWarning):
+        model.fit()
+
+    assert model.results is None
+    assert model.estimators == {}
+    assert model.diagnostics["analysis"].tolist() == ["unknown_predictor"]
+    assert model.diagnostics["status"].tolist() == ["failed"]
+
+    model.data = logistic_data.iloc[:0]
+    with pytest.raises(ValueError, match="empty"):
+        model.fit()
+
+    assert model.results is None
+    assert model.diagnostics.empty
+    assert model.estimators == {}
+
+
+def test_invalid_refit_clears_successful_retained_models(
+    logistic_data: pd.DataFrame,
+) -> None:
+    model = cns.LogisticModel(
+        logistic_data,
+        "event",
+        ["score"],
+        inner_cv=2,
+        outer_cv=2,
+        retain_estimators=True,
+    )
+    model.fit()
+    assert model.estimators
+
+    model.groups = [0]
+    with pytest.raises(ValueError, match="one identifier per input row"):
+        model.fit()
+
+    assert model.results is None
+    assert model.diagnostics.empty
+    assert model.estimators == {}
+
+
+def test_failed_outer_fold_does_not_retain_partial_estimators(
+    logistic_data: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_predict = GridSearchCV.predict_proba
+    predicted_folds = 0
+
+    def fail_second_prediction(self, X):
+        nonlocal predicted_folds
+        predicted_folds += 1
+        if predicted_folds == 2:
+            raise ValueError("Held-out prediction failed")
+        return original_predict(self, X)
+
+    monkeypatch.setattr(GridSearchCV, "predict_proba", fail_second_prediction)
+    model = cns.LogisticModel(
+        logistic_data,
+        "event",
+        ["score"],
+        inner_cv=2,
+        outer_cv=2,
+        retain_estimators=True,
+    )
+
+    with pytest.warns(RuntimeWarning) as caught:
+        model.fit()
+
+    assert predicted_folds == 2
+    assert any("Held-out prediction failed" in str(w.message) for w in caught)
+    assert model.results is None
+    assert model.estimators == {}
+    assert model.diagnostics["status"].tolist() == ["failed"]
+    assert model.diagnostics["failure_reason"].tolist() == [
+        "Held-out prediction failed"
+    ]
+    assert model.diagnostics["n_analyzed"].tolist() == [24]

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -73,23 +73,21 @@ def test_logistic_model_uses_scaled_out_of_fold_predictions(
     )
     seen_estimators: list[GridSearchCV] = []
 
-    def fake_cross_val_predict(
+    def fake_fit(
         estimator: GridSearchCV,
         X: pd.DataFrame,
         y: np.ndarray,
-        *,
-        cv: int,
-        method: str,
-        **kwargs: Any,
-    ) -> np.ndarray:
-        assert cv == 5
-        assert method == "predict_proba"
-        assert kwargs == {}
+    ) -> GridSearchCV:
+        np.testing.assert_array_equal(y, data.loc[X.index, "event"])
         seen_estimators.append(estimator)
-        probabilities = np.linspace(0.1, 0.9, len(y))
+        return estimator
+
+    def fake_predict_proba(estimator: GridSearchCV, X: pd.DataFrame) -> np.ndarray:
+        probabilities = np.linspace(0.1, 0.9, len(X))
         return np.column_stack((1 - probabilities, probabilities))
 
-    monkeypatch.setattr(_methods, "cross_val_predict", fake_cross_val_predict)
+    monkeypatch.setattr(GridSearchCV, "fit", fake_fit)
+    monkeypatch.setattr(GridSearchCV, "predict_proba", fake_predict_proba)
     monkeypatch.setattr(
         cns.LogisticModel,
         "_compute_auc_ci",
@@ -99,7 +97,7 @@ def test_logistic_model_uses_scaled_out_of_fold_predictions(
     model = cns.LogisticModel(data, event="event", variates=["score"], hue=hue)
     model.fit()
 
-    assert len(seen_estimators) == (1 if hue is None else 2)
+    assert len(seen_estimators) == (5 if hue is None else 10)
     for estimator in seen_estimators:
         assert isinstance(estimator, GridSearchCV)
         design, scaler, classifier = (step for _, step in estimator.estimator.steps)
@@ -112,7 +110,8 @@ def test_logistic_model_uses_scaled_out_of_fold_predictions(
             assert classifier.penalty == "l1"
         assert classifier.solver == "liblinear"
         assert classifier.random_state == 42
-        assert estimator.cv == 5
+        assert isinstance(estimator.cv, list)
+        assert len(estimator.cv) == 5
         assert estimator.scoring == "roc_auc"
         assert estimator.error_score == "raise"
         np.testing.assert_array_equal(
@@ -135,25 +134,13 @@ def test_logistic_model_aligns_outcome_after_patsy_drops_rows(
     )
     data.iloc[:2, data.columns.get_loc("score")] = np.nan
 
-    def fake_cross_val_predict(
-        estimator: GridSearchCV,
-        X: pd.DataFrame,
-        y: np.ndarray,
-        *,
-        cv: int,
-        method: str,
-    ) -> np.ndarray:
-        assert X.index.tolist() == list(range(2, 16))
+    def capture_auc(self, y, probabilities):
         np.testing.assert_array_equal(y, data["event"].to_numpy()[2:])
-        probabilities = np.linspace(0.1, 0.9, len(y))
-        return np.column_stack((1 - probabilities, probabilities))
+        assert probabilities.shape == (14,)
+        assert np.isfinite(probabilities).all()
+        return 0.5, 0.4, 0.6
 
-    monkeypatch.setattr(_methods, "cross_val_predict", fake_cross_val_predict)
-    monkeypatch.setattr(
-        cns.LogisticModel,
-        "_compute_auc_ci",
-        lambda self, y, predictions: (0.5, 0.4, 0.6),
-    )
+    monkeypatch.setattr(cns.LogisticModel, "_compute_auc_ci", capture_auc)
 
     model = cns.LogisticModel(data, event="event", variates=[formula])
     model.fit()


### PR DESCRIPTION
Model runs now expose failures and sample exclusions after warnings have scrolled away, and logistic analyses can keep repeated subjects together throughout nested cross-validation.

Closes #160
Closes #164

## Changes

- Add per-formula/per-hue diagnostics to both wrappers, including success/failure, eligible and dropped sample counts, event/class counts, and failure reasons. Every fit clears prior results, diagnostics, and estimators.
- Add opt-in estimator retention. Cox retains the fitted lifelines estimator; logistic retains the selected pipeline from each outer fold, with no additional full-data refit.
- Expose inner/outer CV splitters or fold counts, position-aligned group identifiers, and a configurable solver/bootstrap seed. Validate actual partitions, group separation, and exactly one outer prediction per analyzed row while preserving fold-local preprocessing.
- Update public typing, docstrings, and the forest-plot example. Preserve numerical result columns and deterministic five-by-five defaults.

## Validation

- `make test`: 1,410 tests passed with 100% coverage.
- `make lint`: passed.
- Regression tests verify both levels of group/preprocessing isolation, missing predictors and duplicate indexes, mixed-success runs, stale-state clearing, retained predictions, invalid splitters/groups, and exact default prediction equivalence to the previous implementation.

## Limits

Retention is opt-in because Cox estimators contain training data. Existing Cox failures on incomplete predictors remain failures with inspectable eligibility counts. Logistic outer folds must cover every row once; the existing bootstrap still resamples individual observations, even with grouped CV. No dependency, CI, or build changes.
