### PR TITLE
✨ Expose survival results and adjustments

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -178,6 +178,95 @@ same columns. Omitting `ax` selects the current axes.
    get_comparison_results
 ```
 
+## Survival Results
+
+After `survivalplot`, use `get_survival_results(ax)` to retrieve the estimates
+and tests used for its annotations. The plot still returns its Matplotlib axes.
+The accessor returns a DataFrame snapshot without refitting models or rerunning
+tests; it also works with `descriptive_only=True`.
+
+For example, compare stages in the synthetic showcase data, correcting two
+explicitly requested Cox contrasts as one family:
+
+```python
+survival = cns.datasets.get_showcase_data().survival_df
+cns.figure(width=260, height=240)
+ax = cns.survivalplot(
+    survival,
+    duration="time",
+    event="event",
+    hue="stage",
+    hue_order=["I", "II", "III"],
+    pairs=[("I", "II"), ("I", "III")],
+    p_adjust="holm",
+)
+results = cns.get_survival_results(ax)
+contrasts = results.loc[results["kind"] == "pairwise_cox"]
+print(contrasts[["group1", "group2", "estimate", "pvalue_raw", "pvalue_adjusted"]])
+```
+
+Pair tuples are `(reference, comparison)`: the hazard ratio estimates the
+comparison group's hazard relative to the reference. `p_adjust` accepts `None`
+(the default), `"bonferroni"`, `"holm"`, `"fdr_bh"`, or `"fdr_by"`. Correction
+covers the requested pairwise Cox contrasts in that call, excluding the overall
+and landmark tests. Duplicate contrasts, including reversed pairs, are rejected
+when pairwise inference is enabled. An unavailable contrast still counts toward
+the family size and contributes a placeholder p-value of 1 to correction; its
+returned p-values remain missing. Corrected annotations show the raw and adjusted
+p-values, method, and family size. Hazard-ratio confidence intervals remain
+unadjusted 95% intervals.
+
+The table has the same columns for every call:
+
+| Columns | Meaning |
+| --- | --- |
+| `kind` | `overall`, `pairwise_cox`, `median_survival`, `landmark_survival`, `landmark_test`, or `rmst`. |
+| `test` | `logrank`, `trend`, `cox_wald`, or `fixed_time_log_minus_log`; `None` for descriptive estimates. |
+| `groups` | Tuple of contributing groups, in `hue_order` for overall tests and `(reference, comparison)` order for Cox contrasts. |
+| `group1`, `group2` | The estimate's group, or reference and comparison groups; unused entries are `None`. |
+| `n`, `events` | Total contributing observations and observed events over full follow-up, not truncated at the landmark or RMST horizon. |
+| `n1`, `events1`, `n2`, `events2` | Counts for the named groups; unused entries, including for overall tests, are missing. |
+| `time` | Landmark or RMST horizon; missing for other rows. |
+| `estimate` | Hazard ratio, median survival time, landmark survival probability, or restricted mean survival time, as indicated by `kind`. |
+| `ci_lower`, `ci_upper`, `ci_level` | Hazard-ratio confidence interval and level (`0.95`); missing for other kinds. |
+| `statistic` | Chi-square for log-rank, landmark, or Cox likelihood-ratio trend tests; Wald z for pairwise Cox tests; missing for descriptive estimates. |
+| `pvalue_raw`, `pvalue_adjusted` | Raw and corrected p-values; equal when no correction applies and missing for descriptive estimates or unavailable tests. |
+| `p_adjust`, `family_size` | Pairwise correction method and number of requested Cox contrasts. |
+| `status`, `reason` | `available`, `unavailable`, or `not_reached`, with a reason when a result is unavailable. |
+| `annotation` | The exact annotation text for that result. |
+
+Only enabled annotations produce rows. For example, median rows require
+`show_median_survival=True`; `show_hazard_ratio=False` omits pairwise Cox rows,
+and `descriptive_only=True` omits all tests. A median that is not reached has
+`estimate=inf` and `status="not_reached"`. Numerical values retain their full
+precision independently of annotation formatting.
+
+The overall log-rank test treats groups as categories. The optional Cox trend
+test uses equally spaced scores in the explicit `hue_order`, recorded in
+`groups`, and reports a one-degree-of-freedom likelihood-ratio test.
+
+Durations are finite, nonnegative times to the event or censoring; event code 1
+means observed and 0 means censored. Landmark and RMST horizons must be finite,
+positive, and at most the smallest maximum follow-up among the plotted groups.
+The endpoint is inclusive: the right-continuous Kaplan-Meier estimate at a
+landmark includes events at that time. These summaries do not extrapolate beyond
+the common follow-up. The table's `attrs` record the `duration`, `event`, and
+`hue` column names, `time_label`, `event_observed=1`, `event_censored=0`, and
+`common_follow_up`.
+
+Every accessor call returns a copy. A new `survivalplot` call on the same axes
+replaces its results, including when no annotations are requested. Clearing the
+axes removes the stored results. Axes without survival results return an empty
+table with the same columns; omitting `ax` selects the current axes.
+
+```{eval-rst}
+.. apirootsummary::
+   :toctree: api
+   :nosignatures:
+
+   get_survival_results
+```
+
 ## Statistical Models
 
 ```{eval-rst}

--- a/examples/survivalplot.py
+++ b/examples/survivalplot.py
@@ -204,21 +204,33 @@ clinical_df = pd.DataFrame(survival_data)
 # %%
 # Survival plot with three groups
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Compare multiple treatment arms with an omnibus test and an explicitly
-# requested Cox contrast. Pair tuples are (reference, comparison).
-cns.figure(150, 180)
+# Compare multiple treatment arms with an omnibus test and two Cox contrasts.
+# Pair tuples are (reference, comparison). Holm correction covers both requested
+# contrasts; the omnibus test is separate and HR confidence intervals remain 95%.
+cns.figure(260, 240)
 ax = cns.survivalplot(
     data=clinical_df,
     duration="time",
     event="event",
     hue="group",
     hue_order=["Control", "Treatment A", "Treatment B"],
-    pairs=[("Control", "Treatment B")],
+    pairs=[("Control", "Treatment A"), ("Control", "Treatment B")],
+    p_adjust="holm",
     pvalue_loc="upper right",
 )
 ax.set_xlabel("Time (Months)")
 cns.take_legend_out()
 plt.title("Three-Arm Clinical Trial")
+
+# Retrieve the statistics used in the annotation without refitting any models.
+# ``estimate`` is the comparison-versus-reference hazard ratio for these rows.
+results = cns.get_survival_results(ax)
+contrasts = results.loc[results["kind"] == "pairwise_cox"]
+print(
+    contrasts[
+        ["group1", "group2", "estimate", "pvalue_raw", "pvalue_adjusted", "status"]
+    ].to_string(index=False)
+)
 
 
 # %%

--- a/src/cnsplots/__init__.py
+++ b/src/cnsplots/__init__.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
     from .plots import vennplot as vennplot
     from .plots import violinplot as violinplot
     from .plots import volcanoplot as volcanoplot
+    from .plots._survival import get_survival_results as get_survival_results
 
     methods = _methods
     save = savefig
@@ -108,6 +109,7 @@ _LAZY_IMPORTS = {
     "available_palettes": ("cnsplots._palettes", "available_palettes"),
     "figure": ("cnsplots._utils", "figure"),
     "get_comparison_results": ("cnsplots._utils", "get_comparison_results"),
+    "get_survival_results": ("cnsplots.plots._survival", "get_survival_results"),
     "multipanel": ("cnsplots._multipanels", "multipanel"),
     "save": ("cnsplots._utils", "savefig"),
     "savefig": ("cnsplots._utils", "savefig"),

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import matplotlib.pyplot as plt
 import num2tex
@@ -36,6 +36,34 @@ PValueLoc = Literal[
 ]
 HorizontalAlignment = Literal["left", "center", "right"]
 VerticalAlignment = Literal["top", "center", "bottom"]
+
+_P_ADJUST_METHODS = ("bonferroni", "holm", "fdr_bh", "fdr_by")
+_SURVIVAL_COLUMNS = (
+    "kind",
+    "test",
+    "groups",
+    "group1",
+    "group2",
+    "n",
+    "events",
+    "n1",
+    "events1",
+    "n2",
+    "events2",
+    "time",
+    "estimate",
+    "ci_lower",
+    "ci_upper",
+    "ci_level",
+    "statistic",
+    "pvalue_raw",
+    "pvalue_adjusted",
+    "p_adjust",
+    "family_size",
+    "status",
+    "reason",
+    "annotation",
+)
 
 _CIF_Y_LIMITS = (-0.05, 1.01)
 _DEFAULT_CENSOR_MARK_LENGTH = 0.02
@@ -231,6 +259,69 @@ def _censor_mark_extents(
     )
 
 
+def get_survival_results(ax: Axes | None = None) -> pd.DataFrame:
+    """Return the estimates and tests annotated by the latest survivalplot call.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes, optional
+        Axes returned by survivalplot. Defaults to the current axes.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A detached table in annotation order. ``kind`` identifies ``overall``,
+        ``pairwise_cox``, ``median_survival``, ``landmark_survival``,
+        ``landmark_test``, or ``rmst``. Only requested, enabled analyses appear.
+        ``test`` names the inferential method; ``groups`` preserves its group
+        order. For pairwise Cox rows, ``group1`` is the reference and ``group2``
+        the comparison: ``estimate`` is the hazard ratio of group2 versus group1.
+        Single-group estimates use ``group1``. ``n``/``events`` count contributing
+        observations/events over full follow-up, even for landmark and RMST rows;
+        ``n1``/``events1`` and ``n2``/``events2`` give group counts for non-overall
+        rows. ``time`` is the landmark or RMST horizon.
+        ``estimate`` holds the HR, median, survival probability, or RMST;
+        ``ci_lower``, ``ci_upper``, and ``ci_level`` describe unadjusted 95% Cox
+        intervals only. ``statistic`` is chi-square for log-rank, fixed-time, and
+        Cox likelihood-ratio trend tests, or Wald z for Cox pairs. ``trend`` uses
+        equally spaced scores in the order recorded in ``groups``.
+        ``pvalue_raw`` and ``pvalue_adjusted`` agree without correction;
+        ``p_adjust`` and ``family_size`` describe the requested Cox family only.
+        ``status`` is ``available``, ``unavailable``, or ``not_reached``;
+        ``reason`` explains missing inference or an infinite median. Inapplicable
+        numeric fields and unavailable inference are NaN. ``annotation`` contains
+        the row's displayed text. An empty table retains the same columns.
+
+    Notes
+    -----
+    No models or tests are rerun. Each call returns a copy; each survivalplot call
+    replaces the stored results. Clearing the axes or removing its annotation
+    makes the results unavailable. DataFrame ``attrs`` record ``duration``,
+    ``event``, ``hue``, ``time_label``, ``event_observed=1``, ``event_censored=0``,
+    and ``common_follow_up`` (the minimum group maximum duration).
+
+    Survival estimates include events at the landmark time. RMST integrates the
+    Kaplan-Meier curve from zero through the requested horizon, in input time
+    units. Unreached medians retain lifelines' positive infinity. Pairwise
+    corrections exclude the overall and landmark tests and never adjust CIs.
+
+    Examples
+    --------
+    >>> ax = cns.survivalplot(df, "time", "event", "group", p_adjust="holm")
+    >>> results = cns.get_survival_results(ax)
+    >>> results.to_csv("survival_results.csv", index=False)
+    """
+    if ax is None:
+        ax = plt.gca()
+    stored = getattr(ax, "_cnsplots_survival_results", None)
+    if stored is None:
+        return pd.DataFrame(columns=pd.Index(_SURVIVAL_COLUMNS))
+    results, artists = stored
+    if any(artist not in ax.texts for artist in artists):
+        return pd.DataFrame(columns=pd.Index(_SURVIVAL_COLUMNS))
+    return results.copy(deep=True)
+
+
 def survivalplot(
     data: pd.DataFrame,
     duration: str,
@@ -249,6 +340,7 @@ def survivalplot(
     rmst_time: float | None = None,
     overall_test: Literal["logrank", "trend"] = "logrank",
     pairs: list[tuple[str, str]] | None = None,
+    p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     show_hazard_ratio: bool = True,
     descriptive_only: bool = False,
     pvalue_loc: PValueLoc = "lower left",
@@ -266,7 +358,8 @@ def survivalplot(
     data : pd.DataFrame
         The input DataFrame containing survival data.
     duration : str
-        Column name for the time-to-event or time-to-censoring variable.
+        Column name for finite, nonnegative time to event or right censoring.
+        All times and analysis horizons use the same units; no rows are dropped.
     event : str
         Column name for the event indicator (1 = event occurred, 0 = censored).
     hue : str
@@ -293,11 +386,13 @@ def survivalplot(
         ``not reached``.
     landmark_time : float, optional
         Time at which to mark and report each group's Kaplan-Meier survival
-        probability. For exactly two groups, also reports the two-sided fixed-time
-        log-minus-log comparison p-value.
+        probability, including events at that time. Must be finite, positive, and
+        at most the minimum group maximum follow-up. For exactly two groups,
+        also reports the two-sided fixed-time log-minus-log comparison p-value.
     rmst_time : float, optional
         Truncation time through which to compute and report each group's restricted
-        mean survival time (RMST).
+        mean survival time (RMST), integrating from zero in input time units. Must
+        be finite, positive, and at most the minimum group maximum follow-up.
     overall_test : {'logrank', 'trend'}, default: 'logrank'
         Test used for the overall p-value. ``'logrank'`` performs a categorical
         omnibus log-rank test. ``'trend'`` performs a one-degree-of-freedom Cox
@@ -309,7 +404,15 @@ def survivalplot(
         95% confidence interval, and an unadjusted two-sided Cox Wald p-value.
         When omitted, the sole contrast is reported automatically for two groups;
         no contrast is inferred for three or more groups. Pass an empty list to
-        suppress pairwise inference.
+        suppress pairwise inference. Duplicate contrasts, including reversed
+        duplicates, are rejected.
+    p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'} or None, default: None
+        Adjust two-sided Cox Wald p-values across all requested pairwise contrasts
+        in this call. Annotations show raw and adjusted values, the method and
+        family size. Failed contrasts remain unavailable and count in the family
+        using p=1 only during correction. Overall and landmark tests remain raw,
+        and Cox confidence intervals remain unadjusted 95% intervals. Ignored
+        when ``show_hazard_ratio=False`` or ``descriptive_only=True``.
     show_hazard_ratio : bool, default: True
         Whether to show pairwise hazard ratios, confidence intervals, and Cox
         p-values. If False, pairwise Cox inference is skipped and only the overall
@@ -333,12 +436,14 @@ def survivalplot(
     Returns
     -------
     matplotlib.axes.Axes
-        The matplotlib Axes object containing the plot.
+        The matplotlib Axes object containing the plot. Use
+        ``get_survival_results(ax)`` to retrieve its estimates and test results.
 
     See Also
     --------
     cumulativeincidenceplot : Create a cumulative incidence plot for competing risks.
     forestplot : Create a forest plot from a Cox model.
+    get_survival_results : Retrieve the estimates and tests used for annotations.
 
     Examples
     --------
@@ -426,11 +531,17 @@ def survivalplot(
 
     resolved_pairs: list[tuple[str, str]] = []
     if show_hazard_ratio and not descriptive_only:
+        if p_adjust is not None and p_adjust not in _P_ADJUST_METHODS:
+            raise ValueError(
+                "[survivalplot] Parameter 'p_adjust' must be one of "
+                f"{_P_ADJUST_METHODS} or None."
+            )
         resolved_pairs = (
             [(hue_order[0], hue_order[1])]
             if pairs is None and len(hue_order) == 2
             else ([] if pairs is None else pairs)
         )
+    seen_pairs: set[frozenset[str]] = set()
     for pair in resolved_pairs:
         if not isinstance(pair, tuple) or len(pair) != 2:
             raise ValueError(
@@ -447,6 +558,13 @@ def survivalplot(
                 "[survivalplot] Pairwise contrast contains group(s) not present in "
                 f"'{hue}': {missing_groups}."
             )
+        pair_key = frozenset(pair)
+        if pair_key in seen_pairs:
+            raise ValueError(
+                "[survivalplot] Duplicate pairwise contrasts (including reversed "
+                "pairs) are not allowed."
+            )
+        seen_pairs.add(pair_key)
 
     if ax is None:
         ax = plt.gca()
@@ -484,8 +602,39 @@ def survivalplot(
                 max(current_xlim[1], specified_xticks.max()),
             )
 
+    result_rows: list[dict[str, Any]] = []
+
+    def record_result(
+        kind: str, groups: Sequence[str], **values: Any
+    ) -> dict[str, Any]:
+        subset = data[data[hue].isin(groups)]
+        row: dict[str, Any] = dict.fromkeys(_SURVIVAL_COLUMNS, np.nan)
+        row.update(
+            kind=kind,
+            test=None,
+            groups=tuple(groups),
+            group1=None,
+            group2=None,
+            n=len(subset),
+            events=int(subset[event].sum()),
+            p_adjust=None,
+            status="available",
+            reason=None,
+            annotation="",
+        )
+        if kind != "overall":
+            for index, group in enumerate(groups, start=1):
+                group_data = subset[subset[hue] == group]
+                row[f"group{index}"] = group
+                row[f"n{index}"] = len(group_data)
+                row[f"events{index}"] = int(group_data[event].sum())
+        row.update(values)
+        result_rows.append(row)
+        return row
+
     annotation_lines = []
     if not descriptive_only and overall_test == "logrank":
+        row = record_result("overall", hue_order, test="logrank")
         try:
             _validate_logrank_variance(data, duration, event, hue)
             with warnings.catch_warnings():
@@ -493,15 +642,24 @@ def survivalplot(
                 logrank_result = multivariate_logrank_test(
                     data[duration], data[hue], data[event]
                 )
-            annotation_lines.append(
-                "Log-rank P = " + _format_inference_pvalue(logrank_result.p_value)
+            row["annotation"] = "Log-rank P = " + _format_inference_pvalue(
+                logrank_result.p_value
+            )
+            row.update(
+                statistic=float(logrank_result.test_statistic),
+                pvalue_raw=float(logrank_result.p_value),
+                pvalue_adjusted=float(logrank_result.p_value),
             )
             logger.info("P-value was determined by two-sided omnibus log-rank test.")
         except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
-            annotation_lines.append(
-                _unavailable_inference("survivalplot", "Log-rank", e)
+            row.update(
+                status="unavailable",
+                reason=str(e),
+                annotation=_unavailable_inference("survivalplot", "Log-rank", e),
             )
+        annotation_lines.append(row["annotation"])
     elif not descriptive_only:
+        row = record_result("overall", hue_order, test="trend")
         trend_data = pd.DataFrame(
             {
                 "_duration": data[duration].to_numpy(),
@@ -512,19 +670,36 @@ def survivalplot(
         try:
             cph = _fit_cox_inference(trend_data, "_group_score")
             trend_result = cph.log_likelihood_ratio_test()
-            annotation_lines.append(
-                "Cox trend P = " + _format_inference_pvalue(trend_result.p_value)
+            row["annotation"] = "Cox trend P = " + _format_inference_pvalue(
+                trend_result.p_value
+            )
+            row.update(
+                statistic=float(trend_result.test_statistic),
+                pvalue_raw=float(trend_result.p_value),
+                pvalue_adjusted=float(trend_result.p_value),
             )
             logger.info(
                 "P-value was determined by a one-degree-of-freedom Cox proportional "
                 "hazards trend test using hue_order scores."
             )
         except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
-            annotation_lines.append(
-                _unavailable_inference("survivalplot", "Cox trend", e)
+            row.update(
+                status="unavailable",
+                reason=str(e),
+                annotation=_unavailable_inference("survivalplot", "Cox trend", e),
             )
+        annotation_lines.append(row["annotation"])
 
+    pair_rows = []
     for reference, comparison in resolved_pairs:
+        row = record_result(
+            "pairwise_cox",
+            (reference, comparison),
+            test="cox_wald",
+            p_adjust=p_adjust,
+            family_size=len(resolved_pairs),
+        )
+        pair_rows.append(row)
         pair_data = data[data[hue].isin([reference, comparison])]
         cox_data = pd.DataFrame(
             {
@@ -539,23 +714,68 @@ def survivalplot(
             hazard_ratio = summary["exp(coef)"]
             ci1 = summary["exp(coef) lower 95%"]
             ci2 = summary["exp(coef) upper 95%"]
-            pair_p = _format_inference_pvalue(summary["p"])
-        except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
-            annotation_lines.append(
-                _unavailable_inference(
-                    "survivalplot", f"Cox HR ({comparison} vs {reference})", e
-                )
+            _format_inference_pvalue(summary["p"])
+            row.update(
+                estimate=float(hazard_ratio),
+                ci_lower=float(ci1),
+                ci_upper=float(ci2),
+                ci_level=0.95,
+                statistic=float(summary["z"]),
+                pvalue_raw=float(summary["p"]),
+                pvalue_adjusted=float(summary["p"]),
             )
+        except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
+            row.update(
+                status="unavailable",
+                reason=str(e),
+                annotation=_unavailable_inference(
+                    "survivalplot", f"Cox HR ({comparison} vs {reference})", e
+                ),
+            )
+
+    if p_adjust is not None and pair_rows:
+        from statsmodels.stats.multitest import multipletests
+
+        # Keep the requested family intact when a contrast cannot be estimated.
+        correction_input = [
+            row["pvalue_raw"] if row["status"] == "available" else 1.0
+            for row in pair_rows
+        ]
+        adjusted = multipletests(correction_input, method=p_adjust)[1]
+        for row, pvalue in zip(pair_rows, adjusted, strict=True):
+            if row["status"] == "available":
+                row["pvalue_adjusted"] = float(pvalue)
+        annotation_lines.append(
+            f"Pairwise Cox ({p_adjust}-adjusted; {len(pair_rows)} contrasts)"
+        )
+
+    for row in pair_rows:
+        if row["status"] == "unavailable":
+            annotation_lines.append(row["annotation"])
             continue
+        pair_lines = []
         if len(hue_order) > 2:
-            annotation_lines.append(f"{comparison} vs {reference}")
-        annotation_lines.extend(
+            pair_lines.append(f"{row['group2']} vs {row['group1']}")
+        ci_label = "95% CI" if p_adjust is None else "95% CI (unadjusted)"
+        pair_lines.extend(
             [
-                f"HR = {hazard_ratio:.2f}",
-                f"95% CI {ci1:.2f}-{ci2:.2f}",
-                "Cox P = " + pair_p,
+                f"HR = {row['estimate']:.2f}",
+                f"{ci_label} {row['ci_lower']:.2f}-{row['ci_upper']:.2f}",
             ]
         )
+        raw_p = _format_inference_pvalue(row["pvalue_raw"])
+        if p_adjust is None:
+            pair_lines.append("Cox P = " + raw_p)
+        else:
+            pair_lines.extend(
+                [
+                    "Cox raw P = " + raw_p,
+                    f"Cox {p_adjust}-adjusted P = "
+                    + _format_inference_pvalue(row["pvalue_adjusted"]),
+                ]
+            )
+        row["annotation"] = "\n".join(pair_lines)
+        annotation_lines.extend(pair_lines)
         logger.info(
             "Pairwise hazard ratios and unadjusted two-sided P-values were determined "
             "by Cox proportional hazards models."
@@ -565,8 +785,9 @@ def survivalplot(
         annotation_lines.append("Median survival")
         for group, fitter, color in zip(hue_order, fitters, curve_colors, strict=True):
             median = float(fitter.median_survival_time_)
+            row = record_result("median_survival", (group,), estimate=median)
             if np.isfinite(median):
-                annotation_lines.append(f"{group} = {median:g}")
+                row["annotation"] = f"{group} = {median:g}"
                 ax.hlines(
                     0.5,
                     0,
@@ -584,7 +805,12 @@ def survivalplot(
                     linewidth=0.8,
                 )
             else:
-                annotation_lines.append(f"{group} = not reached")
+                row.update(
+                    status="not_reached",
+                    reason="the Kaplan-Meier curve does not reach 0.5",
+                    annotation=f"{group} = not reached",
+                )
+            annotation_lines.append(row["annotation"])
 
     analysis_guide_times = set()
     if landmark_time is not None:
@@ -597,7 +823,14 @@ def survivalplot(
         for group, estimate, color in zip(
             hue_order, landmark_estimates, curve_colors, strict=True
         ):
-            annotation_lines.append(f"{group} = {estimate:.2f}")
+            row = record_result(
+                "landmark_survival",
+                (group,),
+                time=landmark_time,
+                estimate=estimate,
+                annotation=f"{group} = {estimate:.2f}",
+            )
+            annotation_lines.append(row["annotation"])
             ax.scatter(
                 landmark_time,
                 estimate,
@@ -606,6 +839,12 @@ def survivalplot(
                 zorder=3,
             )
         if not descriptive_only and len(fitters) == 2:
+            row = record_result(
+                "landmark_test",
+                hue_order,
+                time=landmark_time,
+                test="fixed_time_log_minus_log",
+            )
             try:
                 if not all(0 < estimate < 1 for estimate in landmark_estimates):
                     raise ValueError(
@@ -616,29 +855,47 @@ def survivalplot(
                     landmark_result = survival_difference_at_fixed_point_in_time_test(
                         landmark_time, fitters[0], fitters[1]
                     )
-                annotation_lines.append(
-                    "Landmark P = " + _format_inference_pvalue(landmark_result.p_value)
+                row["annotation"] = "Landmark P = " + _format_inference_pvalue(
+                    landmark_result.p_value
+                )
+                row.update(
+                    statistic=float(landmark_result.test_statistic),
+                    pvalue_raw=float(landmark_result.p_value),
+                    pvalue_adjusted=float(landmark_result.p_value),
                 )
                 logger.info(
                     "Landmark P-value was determined by a two-sided fixed-time "
                     "log-minus-log test."
                 )
             except (ValueError, RuntimeError, ArithmeticError, RuntimeWarning) as e:
-                annotation_lines.append(
-                    _unavailable_inference("survivalplot", "Landmark test", e)
+                row.update(
+                    status="unavailable",
+                    reason=str(e),
+                    annotation=_unavailable_inference(
+                        "survivalplot", "Landmark test", e
+                    ),
                 )
+            annotation_lines.append(row["annotation"])
 
     if rmst_time is not None:
         rmst_time = float(rmst_time)
         analysis_guide_times.add(rmst_time)
         annotation_lines.append(f"RMST to {rmst_time:g}")
         for group, fitter in zip(hue_order, fitters, strict=True):
-            rmst = restricted_mean_survival_time(fitter, t=rmst_time)
-            annotation_lines.append(f"{group} = {rmst:.2f}")
+            rmst = cast(float, restricted_mean_survival_time(fitter, t=rmst_time))
+            row = record_result(
+                "rmst",
+                (group,),
+                time=rmst_time,
+                estimate=rmst,
+                annotation=f"{group} = {rmst:.2f}",
+            )
+            annotation_lines.append(row["annotation"])
 
     for analysis_time in sorted(analysis_guide_times):
         ax.axvline(analysis_time, color="0.5", linestyle="--", linewidth=0.8)
 
+    text_start = len(ax.texts)
     if annotation_lines:
         _add_pvalue_annotation(ax, "\n".join(annotation_lines), pvalue_loc)
 
@@ -665,6 +922,17 @@ def survivalplot(
             fig=ax.figure,
         )
 
+    results = pd.DataFrame(result_rows, columns=pd.Index(_SURVIVAL_COLUMNS))
+    results.attrs.update(
+        duration=duration,
+        event=event,
+        hue=hue,
+        time_label=time_label,
+        event_observed=1,
+        event_censored=0,
+        common_follow_up=common_follow_up,
+    )
+    setattr(ax, "_cnsplots_survival_results", (results, tuple(ax.texts)[text_start:]))
     return ax
 
 

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -215,7 +215,7 @@ assert not {
     src_path = Path(__file__).parents[1] / "src"
     no_site_script = (
         f"import sys; sys.path.insert(0, {str(src_path)!r}); "
-        "import cnsplots; assert len(cnsplots.__all__) == 68"
+        "import cnsplots; assert len(cnsplots.__all__) == 69"
     )
     subprocess.run([sys.executable, "-S", "-c", no_site_script], check=True)
 

--- a/tests/test_survival_results.py
+++ b/tests/test_survival_results.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import lifelines as ll
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from lifelines.statistics import (
+    multivariate_logrank_test,
+    survival_difference_at_fixed_point_in_time_test,
+)
+from lifelines.utils import restricted_mean_survival_time
+from statsmodels.stats.multitest import multipletests
+
+import cnsplots as cns
+
+
+_COLUMNS = {
+    "kind",
+    "groups",
+    "group1",
+    "group2",
+    "test",
+    "n",
+    "events",
+    "n1",
+    "events1",
+    "n2",
+    "events2",
+    "time",
+    "estimate",
+    "ci_lower",
+    "ci_upper",
+    "ci_level",
+    "statistic",
+    "pvalue_raw",
+    "pvalue_adjusted",
+    "p_adjust",
+    "family_size",
+    "status",
+    "reason",
+    "annotation",
+}
+
+
+@pytest.mark.parametrize("p_adjust", [None, "bonferroni", "holm", "fdr_bh", "fdr_by"])
+def test_survival_results_match_cox_and_adjustment(
+    survival_three_group_df: pd.DataFrame, p_adjust: str | None
+) -> None:
+    data = survival_three_group_df
+    order = ["High", "Mid", "Low"]
+    pairs = [("Low", "High"), ("High", "Mid"), ("Low", "Mid")]
+    _, target = plt.subplots()
+    ax = cns.survivalplot(
+        data,
+        "time",
+        "event",
+        "group",
+        hue_order=order,
+        pairs=pairs,
+        p_adjust=cast(Any, p_adjust),
+        time_label="Months",
+        ax=target,
+    )
+    assert ax is target
+    results = cns.get_survival_results(ax)
+    assert set(results.columns) == _COLUMNS
+    assert results.attrs == {
+        "duration": "time",
+        "event": "event",
+        "hue": "group",
+        "time_label": "Months",
+        "event_observed": 1,
+        "event_censored": 0,
+        "common_follow_up": 8,
+    }
+    assert results.kind.tolist() == ["overall"] + ["pairwise_cox"] * 3
+    overall = results.iloc[0]
+    expected_overall = multivariate_logrank_test(data.time, data.group, data.event)
+    assert overall.groups == tuple(order)
+    assert overall.test == "logrank"
+    assert overall.n == 18
+    assert overall.events == 12
+    assert overall[["n1", "events1", "n2", "events2"]].isna().all()
+    assert overall.statistic == pytest.approx(expected_overall.test_statistic)
+    assert overall.pvalue_raw == pytest.approx(expected_overall.p_value)
+    assert overall.pvalue_adjusted == overall.pvalue_raw
+    assert overall.p_adjust is None
+
+    contrasts = results.loc[results.kind == "pairwise_cox"]
+    assert list(zip(contrasts.group1, contrasts.group2)) == pairs
+    raw = []
+    for (_, row), (reference, comparison) in zip(
+        contrasts.iterrows(), pairs, strict=True
+    ):
+        subset = data.loc[data.group.isin([reference, comparison])]
+        model_data = subset[["time", "event"]].assign(
+            comparison=(subset.group == comparison).astype(int)
+        )
+        expected = ll.CoxPHFitter().fit(model_data, "time", "event").summary.iloc[0]
+        raw.append(expected["p"])
+        assert row.groups == (reference, comparison)
+        assert row.test == "cox_wald"
+        assert (row.n, row.events) == (12, 8)
+        assert (row.n1, row.events1, row.n2, row.events2) == (6, 4, 6, 4)
+        assert row.estimate == pytest.approx(expected["exp(coef)"])
+        assert row.ci_lower == pytest.approx(expected["exp(coef) lower 95%"])
+        assert row.ci_upper == pytest.approx(expected["exp(coef) upper 95%"])
+        assert row.ci_level == 0.95
+        assert row.statistic == pytest.approx(expected["z"])
+        assert row.pvalue_raw == pytest.approx(expected["p"])
+        assert row.p_adjust == p_adjust
+        assert row.family_size == 3
+        assert row.status == "available"
+        assert pd.isna(row.time)
+    adjusted = raw if p_adjust is None else multipletests(raw, method=p_adjust)[1]
+    np.testing.assert_allclose(contrasts.pvalue_adjusted, adjusted)
+    annotation = ax.texts[-1].get_text()
+    assert all(text and text in annotation for text in results.annotation)
+    if p_adjust is not None:
+        assert p_adjust in annotation
+        assert "raw" in annotation.lower()
+        assert "adjusted" in annotation.lower()
+        assert "unadjusted" in annotation.lower()
+        assert "3" in annotation
+
+
+def test_survival_results_match_ordered_trend(
+    survival_three_group_df: pd.DataFrame,
+) -> None:
+    order = ["High", "Low", "Mid"]
+    data = survival_three_group_df
+    ax = cns.survivalplot(
+        data, "time", "event", "group", hue_order=order, overall_test="trend"
+    )
+    model_data = data[["time", "event"]].assign(
+        order=data.group.map({group: index for index, group in enumerate(order)})
+    )
+    expected = (
+        ll.CoxPHFitter().fit(model_data, "time", "event").log_likelihood_ratio_test()
+    )
+    result = cns.get_survival_results(ax).iloc[0]
+    assert result.kind == "overall"
+    assert result.test == "trend"
+    assert result.groups == tuple(order)
+    assert result.statistic == pytest.approx(expected.test_statistic)
+    assert result.pvalue_raw == pytest.approx(expected.p_value)
+
+
+def test_survival_results_match_descriptive_and_landmark_estimates(
+    survival_df: pd.DataFrame,
+) -> None:
+    ax = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        show_median_survival=True,
+        landmark_time=6,
+        rmst_time=11,
+    )
+    results = cns.get_survival_results(ax)
+    assert results.kind.value_counts().to_dict() == {
+        "overall": 1,
+        "pairwise_cox": 1,
+        "median_survival": 2,
+        "landmark_survival": 2,
+        "landmark_test": 1,
+        "rmst": 2,
+    }
+    fitters = []
+    for group in ("Control", "Treatment"):
+        subset = survival_df.loc[survival_df.group == group]
+        fitter = ll.KaplanMeierFitter().fit(subset.time, subset.event)
+        fitters.append(fitter)
+        expected = {
+            "median_survival": (fitter.median_survival_time_, np.nan),
+            "landmark_survival": (fitter.predict(6), 6),
+            "rmst": (restricted_mean_survival_time(fitter, t=11), 11),
+        }
+        for kind, (estimate, time) in expected.items():
+            row = results.loc[(results.kind == kind) & (results.group1 == group)].iloc[
+                0
+            ]
+            assert row.estimate == pytest.approx(estimate)
+            assert row.time == time or (pd.isna(row.time) and pd.isna(time))
+            assert row.groups == (group,)
+            assert row.group2 is None
+            assert (row.n, row.events) == (6, 4)
+            assert (row.n1, row.events1) == (6, 4)
+            assert row[["n2", "events2"]].isna().all()
+            assert row.status == "available"
+            assert row.test is None
+            assert row[["pvalue_raw", "pvalue_adjusted", "ci_level"]].isna().all()
+    landmark = results.loc[results.kind == "landmark_test"].iloc[0]
+    expected_test = survival_difference_at_fixed_point_in_time_test(6, *fitters)
+    assert landmark.test == "fixed_time_log_minus_log"
+    assert landmark.time == 6
+    assert landmark.statistic == pytest.approx(expected_test.test_statistic)
+    assert landmark.pvalue_raw == pytest.approx(expected_test.p_value)
+    assert landmark.pvalue_adjusted == landmark.pvalue_raw
+    assert landmark.p_adjust is None
+    assert (landmark.n1, landmark.events1, landmark.n2, landmark.events2) == (
+        6,
+        4,
+        6,
+        4,
+    )
+    assert all(text and text in ax.texts[-1].get_text() for text in results.annotation)
+
+
+@pytest.mark.parametrize("p_adjust", ["bonferroni", "holm", "fdr_bh", "fdr_by"])
+def test_unavailable_pairs_remain_in_correction_family(
+    survival_three_group_df: pd.DataFrame, p_adjust: str
+) -> None:
+    data = survival_three_group_df.copy()
+    data.loc[data.group == "Mid", "event"] = 0
+    with pytest.warns(UserWarning, match="Cox HR.*unavailable"):
+        ax = cns.survivalplot(
+            data,
+            "time",
+            "event",
+            "group",
+            pairs=[("Low", "Mid"), ("Low", "High")],
+            p_adjust=cast(Any, p_adjust),
+        )
+    pairs = cns.get_survival_results(ax).query("kind == 'pairwise_cox'")
+    assert pairs.group2.tolist() == ["Mid", "High"]
+    assert pairs.status.tolist() == ["unavailable", "available"]
+    assert pairs.family_size.tolist() == [2, 2]
+    unavailable, available = pairs.iloc[0], pairs.iloc[1]
+    assert unavailable.reason
+    assert unavailable.events2 == 0
+    assert (
+        unavailable[
+            [
+                "estimate",
+                "ci_lower",
+                "ci_upper",
+                "statistic",
+                "pvalue_raw",
+                "pvalue_adjusted",
+            ]
+        ]
+        .isna()
+        .all()
+    )
+    expected = multipletests([1, available.pvalue_raw], method=p_adjust)[1][1]
+    assert available.pvalue_adjusted == pytest.approx(expected)
+    assert unavailable.annotation in ax.texts[-1].get_text()
+
+
+def test_survival_results_preserve_unavailable_landmark_and_unreached_median(
+    survival_df: pd.DataFrame,
+) -> None:
+    data = survival_df.copy()
+    data.loc[data.group == "Treatment", "event"] = 0
+    with pytest.warns(UserWarning, match="Landmark test unavailable"):
+        ax = cns.survivalplot(
+            data,
+            "time",
+            "event",
+            "group",
+            show_hazard_ratio=False,
+            show_median_survival=True,
+            landmark_time=1,
+        )
+    results = cns.get_survival_results(ax)
+    median = results.loc[
+        (results.kind == "median_survival") & (results.group1 == "Treatment")
+    ].iloc[0]
+    assert median.estimate == np.inf
+    assert median.status == "not_reached"
+    assert median.reason
+    assert "not reached" in median.annotation
+    landmark = results.loc[results.kind == "landmark_test"].iloc[0]
+    assert landmark.status == "unavailable"
+    assert "strictly between 0 and 1" in landmark.reason
+    assert landmark[["statistic", "pvalue_raw", "pvalue_adjusted"]].isna().all()
+    assert results.loc[results.kind == "landmark_survival", "estimate"].tolist() == [
+        1,
+        1,
+    ]
+
+
+@pytest.mark.parametrize("overall_test", ["logrank", "trend"])
+def test_survival_results_preserve_unavailable_overall(
+    survival_df: pd.DataFrame, overall_test: str
+) -> None:
+    with pytest.warns(UserWarning, match="unavailable.*no events"):
+        ax = cns.survivalplot(
+            survival_df.assign(event=0),
+            "time",
+            "event",
+            "group",
+            hue_order=["Control", "Treatment"],
+            overall_test=cast(Any, overall_test),
+            show_hazard_ratio=False,
+        )
+    result = cns.get_survival_results(ax).iloc[0]
+    assert result.status == "unavailable"
+    assert result.events == 0
+    assert result.reason
+    assert result[["statistic", "pvalue_raw", "pvalue_adjusted"]].isna().all()
+
+
+def test_survival_results_retain_fully_unavailable_corrected_family(
+    survival_df: pd.DataFrame,
+) -> None:
+    with pytest.warns(UserWarning, match="unavailable.*no events"):
+        ax = cns.survivalplot(
+            survival_df.assign(event=0),
+            "time",
+            "event",
+            "group",
+            p_adjust="holm",
+        )
+    results = cns.get_survival_results(ax)
+    assert results.status.tolist() == ["unavailable", "unavailable"]
+    assert results[["statistic", "pvalue_raw", "pvalue_adjusted"]].isna().all().all()
+    pair = results.iloc[1]
+    assert pair.family_size == 1
+    assert pair.p_adjust == "holm"
+    assert "holm-adjusted; 1 contrasts" in ax.texts[-1].get_text()
+
+
+@pytest.mark.parametrize("mode", ["descriptive_only", "show_hazard_ratio"])
+def test_survival_results_skip_disabled_pairwise_options(
+    survival_df: pd.DataFrame, mode: str
+) -> None:
+    kwargs: dict[str, Any] = {mode: mode == "descriptive_only"}
+    ax = cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        pairs=cast(Any, ["invalid pair"]),
+        p_adjust=cast(Any, "invalid method"),
+        **kwargs,
+    )
+    results = cns.get_survival_results(ax)
+    expected = [] if mode == "descriptive_only" else ["overall"]
+    assert results.kind.tolist() == expected
+
+
+@pytest.mark.parametrize(
+    "pairs",
+    [
+        [("Low", "High"), ("Low", "High")],
+        [("Low", "High"), ("High", "Low")],
+    ],
+)
+def test_survivalplot_rejects_duplicate_contrasts(
+    survival_three_group_df: pd.DataFrame, pairs: list[tuple[str, str]]
+) -> None:
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        cns.survivalplot(survival_three_group_df, "time", "event", "group", pairs=pairs)
+
+
+@pytest.mark.parametrize("p_adjust", ["sidak", "Holm", True, ["holm"]])
+def test_survivalplot_rejects_unsupported_adjustment(
+    survival_df: pd.DataFrame, p_adjust: Any
+) -> None:
+    with pytest.raises(ValueError, match="p_adjust"):
+        cns.survivalplot(survival_df, "time", "event", "group", p_adjust=p_adjust)
+
+
+def test_survival_results_are_defensive_snapshots_without_refitting(
+    survival_df: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ax = cns.survivalplot(survival_df, "time", "event", "group")
+    expected = cns.get_survival_results(ax)
+    assert expected.kind.tolist() == ["overall", "pairwise_cox"]
+
+    def unexpected_fit(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Reading results must not recompute inference")
+
+    monkeypatch.setattr(ll.CoxPHFitter, "fit", unexpected_fit)
+    monkeypatch.setattr(ll.KaplanMeierFitter, "fit", unexpected_fit)
+    survival_df.loc[:, "time"] = 100
+    result = cns.get_survival_results(ax)
+    result.loc[:, "pvalue_raw"] = -1
+    result.attrs["duration"] = "changed"
+    pd.testing.assert_frame_equal(cns.get_survival_results(ax), expected)
+    assert cns.get_survival_results(ax).attrs == expected.attrs
+
+
+def test_survival_results_follow_axes_and_replace_on_reuse(
+    survival_df: pd.DataFrame,
+) -> None:
+    _, (ax, other) = plt.subplots(1, 2)
+    empty = cns.get_survival_results(ax)
+    assert empty.empty
+    assert set(empty.columns) == _COLUMNS
+    cns.survivalplot(survival_df, "time", "event", "group", ax=ax)
+    plt.sca(other)
+    assert cns.get_survival_results().empty
+    plt.sca(ax)
+    pd.testing.assert_frame_equal(
+        cns.get_survival_results(), cns.get_survival_results(ax)
+    )
+    cns.survivalplot(
+        survival_df,
+        "time",
+        "event",
+        "group",
+        descriptive_only=True,
+        show_median_survival=True,
+        landmark_time=6,
+        rmst_time=8,
+        ax=ax,
+    )
+    results = cns.get_survival_results(ax)
+    assert results.kind.tolist() == [
+        "median_survival",
+        "median_survival",
+        "landmark_survival",
+        "landmark_survival",
+        "rmst",
+        "rmst",
+    ]
+    assert results.pvalue_raw.isna().all()
+    ax.clear()
+    pd.testing.assert_frame_equal(cns.get_survival_results(ax), empty)
+    cns.survivalplot(
+        survival_df, "time", "event", "group", descriptive_only=True, ax=ax
+    )
+    assert cns.get_survival_results(ax).empty
+    assert set(cns.get_survival_results(ax).columns) == _COLUMNS
+
+
+def test_survival_results_expire_when_annotation_is_removed(
+    survival_df: pd.DataFrame,
+) -> None:
+    ax = cns.survivalplot(survival_df, "time", "event", "group")
+    assert not cns.get_survival_results(ax).empty
+    ax.texts[-1].remove()
+    assert cns.get_survival_results(ax).empty
+    assert set(cns.get_survival_results(ax).columns) == _COLUMNS

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -105,6 +105,20 @@ if TYPE_CHECKING:
         assert_type(cns.boxplot(data, x="group", y="value"), Axes)
         assert_type(cns.get_comparison_results(ax), pd.DataFrame)
         assert_type(cns.get_comparison_results(), pd.DataFrame)
+        assert_type(
+            cns.survivalplot(
+                data,
+                duration="time",
+                event="event",
+                hue="group",
+                pairs=[("A", "B"), ("A", "C")],
+                p_adjust="holm",
+                ax=ax,
+            ),
+            Axes,
+        )
+        assert_type(cns.get_survival_results(ax), pd.DataFrame)
+        assert_type(cns.get_survival_results(), pd.DataFrame)
         assert_type(cns.histplot(data, x="x", ax=ax), Axes)
         assert_type(cns.lineplot(data, x="x", y="y", ax=ax), Axes)
         assert_type(cns.regplot(data, x="x", y="y", color=(0.1, 0.2, 0.3)), Axes)


### PR DESCRIPTION
Expose the estimates and tests used by survival annotations so callers can reuse the numerical results, and support explicit multiple-comparison correction for requested Cox contrasts. `survivalplot` continues to return an Axes, with unadjusted p-values by default.

- Add `get_survival_results(ax)` snapshots with contrast direction, estimates, test statistics, sample/event counts, horizons, confidence intervals, raw/adjusted p-values, and unavailable-result reasons.
- Support Bonferroni, Holm, Benjamini–Hochberg, and Benjamini–Yekutieli correction over the requested Cox family. Label raw and adjusted annotations explicitly while keeping overall and landmark tests separate.
- Document event/time semantics and update the example and public typing contracts.

Validation: `make test` passed all 1,436 tests with 100% coverage; `make lint` passed. Regression tests compare results with lifelines and statsmodels, including unavailable inference, median not reached, landmark boundaries, RMST horizons, and snapshot reuse. Executed and visually checked the updated three-group example.

Compatibility and limits: duplicate or reversed duplicate contrasts now raise `ValueError`. Failed contrasts remain in the correction family using p=1 only during correction; their reported values remain unavailable. Confidence intervals remain unadjusted 95% intervals. The accessor returns only enabled analyses from the latest plot call.

Closes #162
Closes #165
