### PR TITLE
✨ Add prediction curves and results

### DIFF
--- a/docs/_ext/gallery_order.py
+++ b/docs/_ext/gallery_order.py
@@ -73,6 +73,8 @@ GALLERY_CATEGORIES = [
             "volcanoplot",
             "confusionplot",
             "rocplot",
+            "precisionrecallplot",
+            "calibrationplot",
             "vennplot",
             "upsetplot",
         ],

--- a/docs/_static/css/override.css
+++ b/docs/_static/css/override.css
@@ -685,6 +685,10 @@ article[role="main"] .highlight span.linenos {
   }
 }
 
+.sphx-glr-thumbnail-title {
+  text-align: center;
+}
+
 .sphx-glr-single-img {
   margin: auto;
   display: block;

--- a/docs/api.md
+++ b/docs/api.md
@@ -96,6 +96,8 @@ diagram object, respectively.
    volcanoplot
    gseaplot
    rocplot
+   precisionrecallplot
+   calibrationplot
    qqplot
    forestplot
 ```
@@ -265,6 +267,125 @@ table with the same columns; omitting `ax` selects the current axes.
    :nosignatures:
 
    get_survival_results
+```
+
+## Prediction Evaluation Results
+
+`rocplot`, `precisionrecallplot`, and `calibrationplot` return the target
+Matplotlib axes. Their result accessors return typed dictionaries of detached
+DataFrames containing the numbers used to draw the plot, without recomputing
+metrics. Rows identify prediction columns using `model`; comparisons identify
+`model1` and `model2`. Models retain the supplied column order.
+
+```python
+import pandas as pd
+import cnsplots as cns
+
+data = pd.DataFrame(
+    {
+        "truth": [0, 0, 1, 1],
+        "model_a": [0.1, 0.4, 0.35, 0.8],
+        "model_b": [0.2, 0.3, 0.5, 0.7],
+    }
+)
+panels = cns.multipanel(max_width=800)
+roc_ax = panels.panel("A", width=200, height=180)
+cns.rocplot(data, "truth", ["model_a", "model_b"], pairs="all", ax=roc_ax)
+pr_ax = panels.panel("B", width=200, height=180)
+cns.precisionrecallplot(data, "truth", ["model_a", "model_b"], ax=pr_ax)
+cal_ax = panels.panel("C", width=200, height=180)
+cns.calibrationplot(data, "truth", ["model_a", "model_b"], n_bins=4, ax=cal_ax)
+
+roc = cns.get_roc_results(roc_ax)
+pr = cns.get_precision_recall_results(pr_ax)
+calibration = cns.get_calibration_results(cal_ax)
+print(roc["comparisons"])
+print(pr["metrics"])
+print(calibration["bins"])
+```
+
+### ROC coordinates and inference
+
+`get_roc_results(ax)` returns `ROCResults` with four tables:
+
+| Table | Contents |
+| --- | --- |
+| `curves` | `model`, `fpr`, `tpr`, and `threshold` in sklearn curve order; the initial threshold is infinity. |
+| `metrics` | Full-precision `auc`, `method`, `pos_label`, and sample counts per model. |
+| `bands` | `fpr`, `lower`, `upper`, `ci_level`, and `method` per model; empty unless `ci_show=True`. |
+| `comparisons` | Compared models and AUCs, `pvalue_raw`, `pvalue_adjusted`, `method`, `p_adjust`, `family_size`, and sample counts. Empty unless pairs are requested. |
+
+ROC truth remains encoded as 0/1, with 1 positive. Scores may be any finite real
+numbers; larger scores indicate the positive class. The default sklearn ROC
+coordinates omit redundant intermediate points. AUC is trapezoidal ROC area.
+Bands retain the existing deterministic, stratified 1,000-sample pointwise 95%
+bootstrap on 101 false-positive-rate grid points; they are neither simultaneous
+bands nor AUC confidence intervals. Comparisons remain paired, two-sided DeLong
+tests. `p_adjust` corrects the requested pairs as one family and adjusted p-values
+equal raw p-values when no correction is requested. DeLong comparisons require
+at least two observations of each class. Existing labels and axes returns are
+unchanged.
+
+### Precision and recall
+
+`precisionrecallplot` draws recall on the x-axis and precision on the y-axis,
+both as fractions from 0 to 1. Its reference line is positive-class prevalence.
+Legend labels explicitly report **AP**, sklearn average precision: a sum of
+precision values weighted by increases in recall, not trapezoidal PR area.
+The initial implementation has no PR confidence bands or comparison tests.
+
+`get_precision_recall_results(ax)` returns `PrecisionRecallResults` with
+`curves` (`model`, `recall`, `precision`, `threshold`) and `metrics`
+(`model`, `average_precision`, `prevalence`, `method`, `pos_label`, and counts).
+Coordinates preserve sklearn's order of increasing thresholds and decreasing
+recall. The final precision=1, recall=0 endpoint has a missing threshold.
+
+### Probability calibration
+
+Pass held-out or out-of-fold positive-class probabilities to `calibrationplot`;
+it never fits, refits, or recalibrates a model. The x-axis is mean predicted
+probability, the y-axis is observed positive-class frequency, and the diagonal
+is ideal calibration. Both axes use fractions from 0 to 1.
+
+`n_bins` defaults to 5. `strategy="uniform"` uses equal-width bins on `[0, 1]`;
+`strategy="quantile"` uses each model's empirical quantiles. Quantile bin edges
+can repeat with tied predictions, so counts need not be equal. Interior-edge
+values belong to the bin on their left; the first bin includes its lower edge.
+Endpoint probabilities 0 and 1 are accepted.
+
+`get_calibration_results(ax)` returns `CalibrationResults`. Its `bins` table
+contains `model`, zero-based `bin`, `bin_lower`, `bin_upper`, `count`,
+`mean_predicted_probability`, and `observed_frequency`. Every requested bin is
+included; empty bins have count 0 and missing means and are omitted from curves.
+The `metrics` table contains `brier_score`, `method`, `pos_label`, counts,
+`strategy`, and `n_bins` per model. The binary Brier score is the mean squared
+probability error, measuring overall probabilistic prediction quality rather
+than calibration alone. `brier_show=False` hides its legend value while keeping
+the score available in results.
+
+### Input and snapshot policies
+
+Both new plots accept `pos_label` (default 1), including string labels. Scores
+must refer to that class; changing `pos_label` does not invert the supplied
+scores. Both classes must be observed. Missing truth/scores and nonfinite,
+nonnumeric, complex, or Boolean scores are rejected without dropping rows.
+Precision–recall accepts unbounded decision scores; calibration requires
+probabilities in `[0, 1]`. The input DataFrame is left unchanged. The metrics
+tables record `n`, `n_positive`, and `n_negative` for the shared observations.
+
+Each accessor returns copies of the stored tables. A later call to the same
+plotter on the same axes replaces its snapshot. Axes without a corresponding
+plot, or whose stored plot artists have been removed, return empty tables with
+the same columns. Omitting `ax` selects the current axes.
+
+```{eval-rst}
+.. apirootsummary::
+   :toctree: api
+   :nosignatures:
+
+   get_roc_results
+   get_precision_recall_results
+   get_calibration_results
 ```
 
 ## Statistical Models

--- a/examples/calibrationplot.py
+++ b/examples/calibrationplot.py
@@ -1,0 +1,74 @@
+"""
+Probability Calibration
+-----------------------
+
+Compare mean predicted probabilities with observed event frequencies using
+uniform or quantile bins. In an analysis, supply held-out or out-of-fold
+probabilities for the positive class; cnsplots never fits or recalibrates a
+model. This example uses synthetic observations and requires no downloads.
+
+The Brier score measures overall probabilistic prediction quality, including
+calibration and discrimination. Lower scores are better; the reliability curve
+shows calibration directly. All probabilities and frequencies are on [0, 1].
+"""
+
+# %%
+# Generate synthetic predictions
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import numpy as np
+import pandas as pd
+
+import cnsplots as cns
+
+rng = np.random.default_rng(42)
+probability = rng.uniform(0.02, 0.98, 500)
+data = pd.DataFrame(
+    {
+        "outcome": np.where(rng.binomial(1, probability), "case", "control"),
+        "Reference": probability,
+        "Overconfident": probability**2 / (probability**2 + (1 - probability) ** 2),
+    }
+)
+
+# %%
+# Compare binning strategies
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Uniform bins have equal widths. Quantile bins target similar sample counts
+# using separate boundaries for each model. Ties may still leave bins empty.
+# Missing/nonfinite probabilities, probabilities outside [0, 1], missing labels,
+# and outcomes with fewer or more than two classes are rejected.
+mp = cns.multipanel(max_width=450)
+uniform_ax = mp.panel("A", width=150, height=150)
+cns.calibrationplot(
+    data,
+    "outcome",
+    ["Reference", "Overconfident"],
+    pos_label="case",
+    n_bins=8,
+    ax=uniform_ax,
+)
+uniform_ax.set_title("Uniform bins")
+
+quantile_ax = mp.panel("B", width=150, height=150)
+cns.calibrationplot(
+    data,
+    "outcome",
+    ["Reference", "Overconfident"],
+    pos_label="case",
+    n_bins=8,
+    strategy="quantile",
+    brier_show=False,
+    ax=quantile_ax,
+)
+quantile_ax.set_title("Quantile bins")
+
+# %%
+# Inspect counts and probability quality
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Results follow model-column order, then ascending bin order. Empty bins have
+# count zero and NaN means and are omitted from plotted lines. Returned tables
+# are copies; they can be edited or exported without changing the plotted data.
+# Brier scores remain available even when their legend annotations are hidden.
+results = cns.get_calibration_results(quantile_ax)
+print(results["bins"].to_string(index=False))
+print(results["metrics"].to_string(index=False))

--- a/examples/precisionrecallplot.py
+++ b/examples/precisionrecallplot.py
@@ -1,0 +1,61 @@
+"""
+Precision-Recall Curves
+------------------------
+
+Evaluate binary prediction scores with precision-recall curves. The legend
+reports average precision (AP), which weights precision by increases in recall,
+and a horizontal reference marks the positive-class prevalence. AP differs from
+trapezoidal area under a precision-recall curve.
+"""
+
+# %%
+# Generate imbalanced binary predictions
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# This synthetic example needs no downloaded datasets. Larger scores indicate
+# stronger evidence for a positive outcome; decision scores need not lie in [0, 1].
+import numpy as np
+import pandas as pd
+
+import cnsplots as cns
+
+rng = np.random.default_rng(42)
+truth = np.r_[np.zeros(160, dtype=int), np.ones(40, dtype=int)]
+data = pd.DataFrame(
+    {
+        "outcome": truth,
+        "Model A": truth + rng.normal(0, 0.6, len(truth)),
+        "Model B": truth + rng.normal(0, 1.0, len(truth)),
+    }
+)
+
+# %%
+# Compare models and retrieve exact values
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Recall and precision are unitless fractions. Models appear in the supplied
+# column order. AP and prevalence are descriptive metrics: no confidence bands
+# or statistical comparison tests are calculated.
+cns.figure(180, 150)
+ax = cns.precisionrecallplot(data, "outcome", ["Model A", "Model B"])
+ax.set_title("Imbalanced classification")
+results = cns.get_precision_recall_results(ax)
+print(results["metrics"])
+
+# The last curve row per model is sklearn's (recall=0, precision=1) endpoint.
+# Its threshold is NaN because the endpoint has no associated score cutoff.
+print(results["curves"].groupby("model", sort=False).tail(1))
+
+# %%
+# Explicit positive labels in a multipanel figure
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Both classes must be observed. Missing labels/scores and nonfinite values are
+# rejected, so all reported counts and prevalence refer to the complete input.
+# Plotting leaves the caller's DataFrame unchanged.
+labeled = data.assign(status=np.where(truth == 1, "case", "control"))
+mp = cns.multipanel(max_width=380)
+mp.panel("A", 130, 130)
+cns.precisionrecallplot(labeled, "status", "Model A", pos_label="case")
+mp.get_axes("A").set_title("Model A")
+mp.panel("B", 130, 130)
+target = mp.get_axes("B")
+cns.precisionrecallplot(labeled, "status", "Model B", pos_label="case", ax=target)
+target.set_title("Model B")

--- a/examples/rocplot.py
+++ b/examples/rocplot.py
@@ -7,6 +7,9 @@ Create ROC (Receiver Operating Characteristic) curves for classifier evaluation.
 ROC plots visualize the trade-off between true positive rate and false
 positive rate at various classification thresholds. cnsplots automatically
 calculates AUC values and displays them in the legend.
+The result accessor also exposes the exact coordinates, AUCs, confidence bands,
+and comparison p-values as tables. This example uses bundled and synthetic data
+and can run offline.
 """
 
 # %%
@@ -72,6 +75,29 @@ ax = cns.rocplot(
 )
 ax.set_title("Top 2 Models with Uncertainty")
 cns.take_legend_out()
+
+
+# %%
+# Retrieve the exact plotted results
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The accessor reuses the values computed by rocplot. It returns detached tables,
+# so filtering or exporting them does not change the plot or stored results.
+roc_results = cns.get_roc_results(ax)
+roc_results["metrics"]
+
+# %%
+# The paired DeLong comparison includes raw and adjusted p-values. They agree
+# here because no multiple-testing correction was requested. Use p_adjust="holm"
+# in rocplot to correct the requested family of comparisons.
+roc_results["comparisons"]
+
+# %%
+# Coordinates retain sklearn's thresholds, including the infinite first
+# threshold. Bands contain the exact pointwise 95% bootstrap intervals drawn.
+roc_results["curves"].head()
+roc_results["bands"].head()
+# To export, for example:
+# roc_results["metrics"].to_csv("roc_metrics.csv", index=False)
 
 
 # %%

--- a/src/cnsplots/__init__.py
+++ b/src/cnsplots/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from ._utils import take_legend_out as take_legend_out
     from .plots import barplot as barplot
     from .plots import boxplot as boxplot
+    from .plots import calibrationplot as calibrationplot
     from .plots import confusionplot as confusionplot
     from .plots import cumulativeincidenceplot as cumulativeincidenceplot
     from .plots import distplot as distplot
@@ -57,6 +58,7 @@ if TYPE_CHECKING:
     from .plots import phyloplot as phyloplot
     from .plots import pieplot as pieplot
     from .plots import placeholderplot as placeholderplot
+    from .plots import precisionrecallplot as precisionrecallplot
     from .plots import qqplot as qqplot
     from .plots import regplot as regplot
     from .plots import ridgeplot as ridgeplot
@@ -71,6 +73,16 @@ if TYPE_CHECKING:
     from .plots import vennplot as vennplot
     from .plots import violinplot as violinplot
     from .plots import volcanoplot as volcanoplot
+    from .plots._calibration import CalibrationResults as CalibrationResults
+    from .plots._calibration import get_calibration_results as get_calibration_results
+    from .plots._precision_recall import (
+        PrecisionRecallResults as PrecisionRecallResults,
+    )
+    from .plots._precision_recall import (
+        get_precision_recall_results as get_precision_recall_results,
+    )
+    from .plots._specialized import ROCResults as ROCResults
+    from .plots._specialized import get_roc_results as get_roc_results
     from .plots._survival import get_survival_results as get_survival_results
 
     methods = _methods
@@ -109,6 +121,21 @@ _LAZY_IMPORTS = {
     "available_palettes": ("cnsplots._palettes", "available_palettes"),
     "figure": ("cnsplots._utils", "figure"),
     "get_comparison_results": ("cnsplots._utils", "get_comparison_results"),
+    "get_calibration_results": (
+        "cnsplots.plots._calibration",
+        "get_calibration_results",
+    ),
+    "get_precision_recall_results": (
+        "cnsplots.plots._precision_recall",
+        "get_precision_recall_results",
+    ),
+    "get_roc_results": ("cnsplots.plots._specialized", "get_roc_results"),
+    "CalibrationResults": ("cnsplots.plots._calibration", "CalibrationResults"),
+    "PrecisionRecallResults": (
+        "cnsplots.plots._precision_recall",
+        "PrecisionRecallResults",
+    ),
+    "ROCResults": ("cnsplots.plots._specialized", "ROCResults"),
     "get_survival_results": ("cnsplots.plots._survival", "get_survival_results"),
     "multipanel": ("cnsplots._multipanels", "multipanel"),
     "save": ("cnsplots._utils", "savefig"),
@@ -123,6 +150,7 @@ _LAZY_IMPORTS = {
     "get_palette_colors": ("cnsplots._utils", "get_palette_colors"),
     "barplot": ("cnsplots.plots._categorical", "barplot"),
     "boxplot": ("cnsplots.plots._distribution", "boxplot"),
+    "calibrationplot": ("cnsplots.plots._calibration", "calibrationplot"),
     "confusionplot": ("cnsplots.plots._heatmap", "confusionplot"),
     "cumulativeincidenceplot": (
         "cnsplots.plots._survival",
@@ -142,6 +170,7 @@ _LAZY_IMPORTS = {
     "phyloplot": ("cnsplots.plots._specialized", "phyloplot"),
     "placeholderplot": ("cnsplots.plots._specialized", "placeholderplot"),
     "pieplot": ("cnsplots.plots._categorical", "pieplot"),
+    "precisionrecallplot": ("cnsplots.plots._precision_recall", "precisionrecallplot"),
     "qqplot": ("cnsplots.plots._distribution", "qqplot"),
     "regplot": ("cnsplots.plots._regression", "regplot"),
     "ridgeplot": ("cnsplots.plots._distribution", "ridgeplot"),

--- a/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
+++ b/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
@@ -63,7 +63,14 @@ before plotting.
 - `volcanoplot`: effect size versus transformed adjusted significance.
 - `gseaplot`: gene-set enrichment results.
 - `rocplot`: receiver operating characteristic curves with optional pointwise
-  bootstrap confidence bands and paired DeLong AUC comparisons.
+  bootstrap confidence bands and paired DeLong AUC comparisons. Retrieve exact
+  coordinates, AUCs, bands, and tests with `get_roc_results(ax)`.
+- `precisionrecallplot`: precision versus recall with average precision (AP)
+  labels and a prevalence reference. `get_precision_recall_results(ax)` returns
+  coordinates and metrics; no confidence bands or comparison tests are run.
+- `calibrationplot`: reliability curves from held-out probabilities, uniform or
+  quantile bins, and optional Brier labels. `get_calibration_results(ax)` exposes
+  bin counts and metrics. Brier measures overall probabilistic prediction quality.
 - `phyloplot`: phylogenetic visualization from `AnnData`.
 - `prerank`: preranked enrichment analysis.
 

--- a/src/cnsplots/plots/__init__.py
+++ b/src/cnsplots/plots/__init__.py
@@ -4,6 +4,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from ._calibration import calibrationplot as calibrationplot
     from ._categorical import barplot as barplot
     from ._categorical import donutplot as donutplot
     from ._categorical import dumbbellplot as dumbbellplot
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
     from ._heatmap import confusionplot as confusionplot
     from ._heatmap import dotplot as dotplot
     from ._heatmap import heatmapplot as heatmapplot
+    from ._precision_recall import precisionrecallplot as precisionrecallplot
     from ._regression import lineplot as lineplot
     from ._regression import regplot as regplot
     from ._regression import scatterplot as scatterplot
@@ -40,6 +42,7 @@ if TYPE_CHECKING:
 _LAZY_IMPORTS = {
     "barplot": ("cnsplots.plots._categorical", "barplot"),
     "boxplot": ("cnsplots.plots._distribution", "boxplot"),
+    "calibrationplot": ("cnsplots.plots._calibration", "calibrationplot"),
     "confusionplot": ("cnsplots.plots._heatmap", "confusionplot"),
     "cumulativeincidenceplot": (
         "cnsplots.plots._survival",
@@ -59,6 +62,7 @@ _LAZY_IMPORTS = {
     "phyloplot": ("cnsplots.plots._specialized", "phyloplot"),
     "placeholderplot": ("cnsplots.plots._specialized", "placeholderplot"),
     "pieplot": ("cnsplots.plots._categorical", "pieplot"),
+    "precisionrecallplot": ("cnsplots.plots._precision_recall", "precisionrecallplot"),
     "qqplot": ("cnsplots.plots._distribution", "qqplot"),
     "regplot": ("cnsplots.plots._regression", "regplot"),
     "ridgeplot": ("cnsplots.plots._distribution", "ridgeplot"),

--- a/src/cnsplots/plots/_calibration.py
+++ b/src/cnsplots/plots/_calibration.py
@@ -1,0 +1,310 @@
+"""Calibration curves for supplied binary prediction probabilities."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.axes import Axes
+
+from cnsplots._validation import (
+    validate_columns_exist,
+    validate_dataframe,
+    validate_dataframe_not_empty,
+    validate_no_nulls,
+)
+
+_BIN_COLUMNS = [
+    "model",
+    "bin",
+    "bin_lower",
+    "bin_upper",
+    "count",
+    "mean_predicted_probability",
+    "observed_frequency",
+]
+_METRIC_COLUMNS = [
+    "model",
+    "brier_score",
+    "method",
+    "pos_label",
+    "n",
+    "n_positive",
+    "n_negative",
+    "strategy",
+    "n_bins",
+]
+
+
+class CalibrationResults(TypedDict):
+    """Tables describing calibration bins and probabilistic prediction quality."""
+
+    bins: pd.DataFrame
+    metrics: pd.DataFrame
+
+
+def get_calibration_results(ax: Axes | None = None) -> CalibrationResults:
+    """Return detached tables from the latest calibrationplot call on an axes.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes, optional
+        Axes returned by calibrationplot. Defaults to the current axes.
+
+    Returns
+    -------
+    CalibrationResults
+        A dictionary containing two DataFrames. ``bins`` contains ``model``,
+        zero-based ``bin``, ``bin_lower``, ``bin_upper``, ``count``,
+        ``mean_predicted_probability``, and ``observed_frequency``. Rows follow
+        prediction-column order, then ascending bin order. Empty bins have zero
+        count and NaN means; repeated quantile boundaries are retained. The
+        first bin includes both boundaries; later bins exclude their lower
+        boundary and include their upper boundary. Ties belong to the first
+        matching bin, as in sklearn.calibration.calibration_curve.
+
+        ``metrics`` has one row per model, in prediction-column order:
+        ``model``, ``brier_score``, ``method`` (``"brier_score"``), ``pos_label``,
+        ``n``, ``n_positive``, ``n_negative``, ``strategy``, and ``n_bins``.
+        Brier score is mean squared probability error, in [0, 1]; lower values
+        indicate better overall probabilistic prediction quality. It measures
+        more than calibration alone and is independent of the chosen bins.
+
+    Notes
+    -----
+    Results are computed once when plotting. Each call returns fresh table
+    copies. Replotting replaces the stored results for that axes; clearing the
+    axes or removing a model curve makes the results unavailable. Axes with no
+    available results return empty tables with the same columns.
+
+    Examples
+    --------
+    >>> ax = cns.calibrationplot(df, "outcome", "probability")
+    >>> results = cns.get_calibration_results(ax)
+    >>> results["bins"].to_csv("calibration_bins.csv", index=False)
+    """
+    if ax is None:
+        ax = plt.gca()
+    stored = getattr(ax, "_cnsplots_calibration_results", None)
+    if stored is None or any(curve not in ax.lines for curve in stored[1]):
+        return {
+            "bins": pd.DataFrame(columns=pd.Index(_BIN_COLUMNS)),
+            "metrics": pd.DataFrame(columns=pd.Index(_METRIC_COLUMNS)),
+        }
+    results = stored[0]
+    return {
+        "bins": results["bins"].copy(deep=True),
+        "metrics": results["metrics"].copy(deep=True),
+    }
+
+
+def calibrationplot(
+    data: pd.DataFrame,
+    true_label_col: str,
+    pred_prob_cols: str | list[str],
+    *,
+    pos_label: str | int | float | bool = 1,
+    n_bins: int = 5,
+    strategy: Literal["uniform", "quantile"] = "uniform",
+    brier_show: bool = True,
+    ax: Axes | None = None,
+) -> Axes:
+    """Plot observed event frequencies against mean predicted probabilities.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        One observation per row. Supply held-out or out-of-fold predictions;
+        no estimator is fitted, refitted, or recalibrated by this function.
+        The input is not modified. Missing labels or probabilities are rejected.
+    true_label_col : str
+        Column containing exactly two distinct, nonmissing class labels.
+        One-class data is rejected explicitly. Numeric labels must be finite.
+    pred_prob_cols : str or list of str
+        One or more distinct numeric probability columns, each giving the
+        probability of ``pos_label``. Values must be finite and in [0, 1];
+        boolean, complex, and nonnumeric columns are rejected. Curves and legend
+        entries preserve the supplied column order.
+    pos_label : str, int, float, or bool, default: 1
+        Observed class treated as the positive event. Specify this explicitly
+        for string labels or labels other than 0/1. The other class is negative.
+    n_bins : int, default: 5
+        Positive number of bins. More bins show finer detail but may have few
+        observations; inspect counts using get_calibration_results.
+    strategy : {"uniform", "quantile"}, default: "uniform"
+        Uniform bins divide [0, 1] into equal widths. Quantile bins use each
+        model's empirical probability quantiles to target similar counts.
+        Ties can produce repeated boundaries and empty bins. Empty bins remain
+        in the result table with zero counts and NaN means, but are omitted
+        from the curve; occupied bins are connected in ascending order.
+    brier_show : bool, default: True
+        Append the Brier score to each model's legend label. The score measures
+        overall probabilistic prediction quality, not calibration alone.
+        Disabling the annotation does not remove it from the results table.
+    ax : matplotlib.axes.Axes, optional
+        Target axes, including a multipanel panel. Defaults to the current axes.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The target axes, with one line and circular markers per model, followed
+        by a dashed identity line. Both axes use dimensionless probabilities
+        from 0 to 1: x is mean predicted probability and y observed positive
+        event frequency. A legend identifies the models. Artists are available
+        through ``ax.lines``; numerical tables through get_calibration_results.
+
+    See Also
+    --------
+    get_calibration_results : Retrieve bin counts and per-model Brier scores.
+    rocplot : Evaluate binary discrimination across decision thresholds.
+
+    Examples
+    --------
+    >>> ax = cns.calibrationplot(df, "outcome", ["model_a", "model_b"], n_bins=10)
+    >>> ax = cns.calibrationplot(
+    ...     df, "diagnosis", "probability", pos_label="positive", strategy="quantile"
+    ... )
+    """
+    validate_dataframe(data, "data", "calibrationplot")
+    if isinstance(pred_prob_cols, str):
+        pred_prob_cols = [pred_prob_cols]
+    if not isinstance(pred_prob_cols, list) or not all(
+        isinstance(column, str) for column in pred_prob_cols
+    ):
+        raise TypeError(
+            "[calibrationplot] 'pred_prob_cols' must be a string or list of strings."
+        )
+    if not pred_prob_cols:
+        raise ValueError(
+            "[calibrationplot] At least one prediction column is required."
+        )
+    if len(set(pred_prob_cols)) != len(pred_prob_cols):
+        raise ValueError("[calibrationplot] Prediction columns must be unique.")
+    columns = [true_label_col, *pred_prob_cols]
+    validate_columns_exist(data, columns, "calibrationplot")
+    validate_dataframe_not_empty(data, "calibrationplot")
+    validate_no_nulls(data, columns, "calibrationplot")
+    if (
+        isinstance(n_bins, (bool, np.bool_))
+        or not isinstance(n_bins, (int, np.integer))
+        or n_bins < 1
+    ):
+        raise ValueError("[calibrationplot] 'n_bins' must be a positive integer.")
+    if strategy not in ("uniform", "quantile"):
+        raise ValueError(
+            "[calibrationplot] 'strategy' must be 'uniform' or 'quantile'."
+        )
+
+    labels = data[true_label_col]
+    classes = labels.unique()
+    if any(
+        np.iscomplexobj(value)
+        or (isinstance(value, (int, float, np.number)) and not np.isfinite(value))
+        for value in classes
+    ):
+        raise ValueError(
+            "[calibrationplot] Class labels must be finite and noncomplex."
+        )
+    if len(classes) != 2:
+        raise ValueError(
+            "[calibrationplot] Labels must contain exactly two classes; "
+            "one-class data is not supported."
+        )
+    if pos_label not in classes:
+        raise ValueError(
+            "[calibrationplot] 'pos_label' must be an observed class label."
+        )
+    y_true = (labels == pos_label).to_numpy(dtype=int)
+
+    bin_tables = []
+    metric_rows = []
+    for model in pred_prob_cols:
+        dtype = data[model].dtype
+        if (
+            not pd.api.types.is_numeric_dtype(dtype)
+            or pd.api.types.is_bool_dtype(dtype)
+            or pd.api.types.is_complex_dtype(dtype)
+        ):
+            raise ValueError(
+                f"[calibrationplot] Column '{model}' must contain real numeric scores."
+            )
+        scores = data[model].to_numpy(dtype=float)
+        if not np.isfinite(scores).all():
+            raise ValueError(
+                f"[calibrationplot] Column '{model}' must contain only finite scores."
+            )
+        if ((scores < 0) | (scores > 1)).any():
+            raise ValueError(
+                f"[calibrationplot] Column '{model}' probabilities must be in [0, 1]."
+            )
+        edges = np.linspace(0, 1, n_bins + 1)
+        if strategy == "quantile":
+            edges = np.percentile(scores, edges * 100)
+        bin_ids = np.searchsorted(edges[1:-1], scores)
+        counts = np.bincount(bin_ids, minlength=n_bins)
+        score_sums = np.bincount(bin_ids, weights=scores, minlength=n_bins)
+        event_sums = np.bincount(bin_ids, weights=y_true, minlength=n_bins)
+        mean_scores = np.full(n_bins, np.nan)
+        frequencies = np.full(n_bins, np.nan)
+        np.divide(score_sums, counts, out=mean_scores, where=counts > 0)
+        np.divide(event_sums, counts, out=frequencies, where=counts > 0)
+        bin_tables.append(
+            pd.DataFrame(
+                {
+                    "model": model,
+                    "bin": np.arange(n_bins),
+                    "bin_lower": edges[:-1],
+                    "bin_upper": edges[1:],
+                    "count": counts,
+                    "mean_predicted_probability": mean_scores,
+                    "observed_frequency": frequencies,
+                }
+            )
+        )
+        metric_rows.append(
+            {
+                "model": model,
+                "brier_score": float(np.mean((scores - y_true) ** 2)),
+                "method": "brier_score",
+                "pos_label": pos_label,
+                "n": len(y_true),
+                "n_positive": int(y_true.sum()),
+                "n_negative": int(len(y_true) - y_true.sum()),
+                "strategy": strategy,
+                "n_bins": int(n_bins),
+            }
+        )
+
+    if ax is None:
+        ax = plt.gca()
+    curves = []
+    for table, row in zip(bin_tables, metric_rows, strict=True):
+        occupied = table[table["count"] > 0]
+        label = str(row["model"])
+        if brier_show:
+            label += f" (Brier={row['brier_score']:.3f})"
+        (curve,) = ax.plot(
+            occupied["mean_predicted_probability"],
+            occupied["observed_frequency"],
+            marker="o",
+            markersize=3,
+            linewidth=1.2,
+            label=label,
+        )
+        curves.append(curve)
+    ax.plot([0, 1], [0, 1], color="black", linestyle="--", linewidth=0.8)
+    ax.set_xlim(-0.02, 1.02)
+    ax.set_ylim(-0.02, 1.02)
+    ax.set_xticks(np.linspace(0, 1, 6))
+    ax.set_yticks(np.linspace(0, 1, 6))
+    ax.set_xlabel("Mean Predicted Probability")
+    ax.set_ylabel("Observed Event Frequency")
+    ax.legend(loc="lower right")
+    results: CalibrationResults = {
+        "bins": pd.concat(bin_tables, ignore_index=True),
+        "metrics": pd.DataFrame(metric_rows),
+    }
+    setattr(ax, "_cnsplots_calibration_results", (results, curves))
+    return ax

--- a/src/cnsplots/plots/_precision_recall.py
+++ b/src/cnsplots/plots/_precision_recall.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from typing import TypedDict, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.axes import Axes
+from pandas.api.types import is_bool_dtype, is_complex_dtype, is_numeric_dtype
+from sklearn.metrics import average_precision_score, precision_recall_curve
+
+from cnsplots._validation import (
+    validate_columns_exist,
+    validate_dataframe,
+    validate_dataframe_not_empty,
+    validate_no_nulls,
+)
+
+
+class PrecisionRecallResults(TypedDict):
+    """Detached curve coordinates and average-precision summaries."""
+
+    curves: pd.DataFrame
+    metrics: pd.DataFrame
+
+
+_CURVE_COLUMNS = ("model", "recall", "precision", "threshold")
+_METRIC_COLUMNS = (
+    "model",
+    "average_precision",
+    "prevalence",
+    "method",
+    "pos_label",
+    "n",
+    "n_positive",
+    "n_negative",
+)
+
+
+def get_precision_recall_results(ax: Axes | None = None) -> PrecisionRecallResults:
+    """Return tables from the latest precisionrecallplot call on an axes.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes, optional
+        Axes returned by :func:`precisionrecallplot`. Defaults to the current axes.
+
+    Returns
+    -------
+    PrecisionRecallResults
+        A mapping of two detached DataFrames. ``curves`` contains ``model``,
+        ``recall``, ``precision``, and ``threshold`` in prediction-column order.
+        Thresholds increase and recall decreases within each model, following
+        scikit-learn. The final endpoint has recall 0, precision 1, and a NaN
+        threshold because it does not represent a score cutoff. Thresholds use
+        object dtype to preserve exact integer scores alongside that endpoint.
+
+        ``metrics`` contains one row per model in prediction-column order:
+        ``model``, ``average_precision``, ``prevalence``, ``method``
+        (``"average_precision"``), ``pos_label``, ``n``, ``n_positive``, and
+        ``n_negative``. Precision, recall, AP, and prevalence are unitless
+        fractions; thresholds have the same units as the input scores. Counts
+        include every input row because missing values are rejected.
+
+        Empty tables with these same columns are returned before plotting or
+        after the axes are cleared or a model's curve is removed.
+
+    Notes
+    -----
+    No statistics are recomputed. Each call returns copies, and each successful
+    :func:`precisionrecallplot` call replaces the results stored on its axes.
+
+    Examples
+    --------
+    >>> ax = cns.precisionrecallplot(df, "outcome", ["model_a", "model_b"])
+    >>> results = cns.get_precision_recall_results(ax)
+    >>> results["metrics"].to_csv("average_precision.csv", index=False)
+    """
+    if ax is None:
+        ax = plt.gca()
+    stored = getattr(ax, "_cnsplots_precision_recall_results", None)
+    if stored is None or any(artist not in ax.lines for artist in stored[1]):
+        return {
+            "curves": pd.DataFrame(columns=pd.Index(_CURVE_COLUMNS)),
+            "metrics": pd.DataFrame(columns=pd.Index(_METRIC_COLUMNS)),
+        }
+    results = cast(PrecisionRecallResults, stored[0])
+    return {
+        "curves": results["curves"].copy(deep=True),
+        "metrics": results["metrics"].copy(deep=True),
+    }
+
+
+def precisionrecallplot(
+    data: pd.DataFrame,
+    true_label_col: str,
+    pred_prob_cols: str | list[str],
+    *,
+    pos_label: str | int | float | bool = 1,
+    ax: Axes | None = None,
+) -> Axes:
+    """Plot binary precision-recall curves and report average precision (AP).
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        Input data, containing one observation per row. It is not modified.
+        Missing labels or scores and nonfinite numeric values are rejected;
+        no rows are silently dropped.
+    true_label_col : str
+        Column containing exactly two distinct class labels, both observed.
+        Numeric, boolean, and string labels are supported.
+    pred_prob_cols : str or list of str
+        One or more unique columns of finite, real numeric prediction scores.
+        Larger scores must indicate stronger evidence for ``pos_label``.
+        Scores may be probabilities or decision scores outside [0, 1]. Boolean,
+        complex, and nonnumeric score columns are rejected. Models, legend
+        entries, and result tables preserve the supplied column order.
+    pos_label : str, int, float, or bool, default: 1
+        The observed label treated as positive. Set this explicitly for string
+        labels or when the positive class is not 1.
+    ax : matplotlib.axes.Axes, optional
+        Axes on which to draw. Defaults to the current axes, including a current
+        :class:`cnsplots.multipanel` panel.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The target axes, containing one step line per model and a dashed
+        horizontal prevalence reference. Recall is on the x-axis and precision
+        on the y-axis, both as fractions from 0 to 1. The legend identifies each
+        model's AP and the positive-class prevalence. Exact coordinates, AP,
+        and sample counts are available through :func:`get_precision_recall_results`.
+
+    Raises
+    ------
+    TypeError
+        If data is not a DataFrame, prediction column names have the wrong type,
+        or scores are not real numeric values.
+    ValueError
+        If data is empty, requested columns are absent or duplicated, no models
+        are selected, labels do not contain two classes including ``pos_label``,
+        or labels or scores contain missing or nonfinite values.
+
+    Notes
+    -----
+    Coordinates use :func:`sklearn.metrics.precision_recall_curve`, including
+    its final (recall=0, precision=1) endpoint. AP is computed using
+    :func:`sklearn.metrics.average_precision_score`: the sum of precision
+    weighted by each increase in recall. AP is not trapezoidal PR area.
+    The prevalence reference is the positive count divided by the total count.
+    Confidence bands and statistical model-comparison tests are not performed.
+
+    See Also
+    --------
+    rocplot : Plot receiver operating characteristic curves.
+    calibrationplot : Compare predicted probabilities with observed outcomes.
+    get_precision_recall_results : Retrieve exact curve and AP tables.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import cnsplots as cns
+    >>> data = pd.DataFrame({"truth": [0, 0, 1, 1], "score": [0.1, 0.4, 0.35, 0.8]})
+    >>> ax = cns.precisionrecallplot(data, "truth", "score")
+    >>> results = cns.get_precision_recall_results(ax)
+
+    >>> # Set the positive class for text labels
+    >>> data["outcome"] = ["control", "control", "case", "case"]
+    >>> ax = cns.precisionrecallplot(data, "outcome", "score", pos_label="case")
+    """
+    validate_dataframe(data, "data", "precisionrecallplot")
+    validate_dataframe_not_empty(data, "precisionrecallplot")
+    if isinstance(pred_prob_cols, str):
+        pred_prob_cols = [pred_prob_cols]
+    if not isinstance(pred_prob_cols, list) or not all(
+        isinstance(column, str) for column in pred_prob_cols
+    ):
+        raise TypeError(
+            "[precisionrecallplot] 'pred_prob_cols' must be a string or list of strings."
+        )
+    if not pred_prob_cols:
+        raise ValueError("[precisionrecallplot] Select at least one prediction column.")
+    if len(set(pred_prob_cols)) != len(pred_prob_cols):
+        raise ValueError("[precisionrecallplot] Prediction columns must be unique.")
+    validate_columns_exist(
+        data, [true_label_col] + pred_prob_cols, "precisionrecallplot"
+    )
+    validate_no_nulls(data, true_label_col, "precisionrecallplot")
+    labels = data[true_label_col]
+    classes = labels.unique()
+    if any(
+        isinstance(value, (int, float, complex, np.number)) and not np.isfinite(value)
+        for value in classes
+    ):
+        raise ValueError("[precisionrecallplot] Class labels must be finite.")
+    if len(classes) != 2:
+        raise ValueError(
+            "[precisionrecallplot] Labels must contain exactly two classes."
+        )
+    if pos_label not in classes:
+        raise ValueError("[precisionrecallplot] 'pos_label' must be an observed class.")
+
+    scores = {}
+    for column in pred_prob_cols:
+        dtype = data[column].dtype
+        if (
+            not is_numeric_dtype(dtype)
+            or is_complex_dtype(dtype)
+            or is_bool_dtype(dtype)
+        ):
+            raise TypeError(
+                f"[precisionrecallplot] Scores in {column!r} must be real numeric values."
+            )
+        if data[column].isna().any() or not np.isfinite(data[column]).all():
+            raise ValueError(
+                f"[precisionrecallplot] Scores in {column!r} must be finite "
+                "with no missing values."
+            )
+        scores[column] = data[column].to_numpy()
+
+    if ax is None:
+        ax = plt.gca()
+    positive = (labels == pos_label).to_numpy(dtype=bool)
+    n_positive = int(positive.sum())
+    prevalence = n_positive / len(data)
+    curves = []
+    metrics = []
+    artists = []
+    for column in pred_prob_cols:
+        precision, recall, thresholds = precision_recall_curve(positive, scores[column])
+        ap = float(average_precision_score(positive, scores[column]))
+        curves.append(
+            pd.DataFrame(
+                {
+                    "model": column,
+                    "recall": recall,
+                    "precision": precision,
+                    "threshold": np.append(thresholds.astype(object), np.nan),
+                }
+            )
+        )
+        metrics.append(
+            {
+                "model": column,
+                "average_precision": ap,
+                "prevalence": prevalence,
+                "method": "average_precision",
+                "pos_label": pos_label,
+                "n": len(data),
+                "n_positive": n_positive,
+                "n_negative": len(data) - n_positive,
+            }
+        )
+        (curve,) = ax.step(
+            recall, precision, where="post", label=f"{column} (AP={ap:.2f})", lw=1
+        )
+        artists.append(curve)
+
+    ax.axhline(
+        prevalence,
+        color="black",
+        linestyle="--",
+        linewidth=0.8,
+        label=f"Prevalence={prevalence:.2f}",
+    )
+    ax.set_xlim((-0.02, 1.02))
+    ax.set_ylim((-0.02, 1.02))
+    ax.set_xticks([0, 0.2, 0.4, 0.6, 0.8, 1])
+    ax.set_yticks([0, 0.2, 0.4, 0.6, 0.8, 1])
+    ax.set_xlabel("Recall")
+    ax.set_ylabel("Precision")
+    ax.legend(loc="lower left")
+    results: PrecisionRecallResults = {
+        "curves": pd.concat(curves, ignore_index=True),
+        "metrics": pd.DataFrame(metrics),
+    }
+    setattr(ax, "_cnsplots_precision_recall_results", (results, artists))
+    return ax

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from itertools import combinations
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 import matplotlib.pyplot as plt
 import num2tex
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from anndata import AnnData
+from matplotlib.artist import Artist
 from matplotlib.axes import Axes
 from matplotlib.patches import Circle, FancyBboxPatch, Polygon
 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -37,6 +38,44 @@ _FOREST_GROUP = "_forest_group"
 _FOREST_HUE = "_forest_hue"
 _FOREST_ALL = "__forest_all__"
 _P_ADJUST_METHODS = ("bonferroni", "holm", "fdr_bh", "fdr_by")
+_ROC_COLUMNS = {
+    "curves": ["model", "fpr", "tpr", "threshold"],
+    "metrics": ["model", "auc", "method", "pos_label", "n", "n_positive", "n_negative"],
+    "bands": ["model", "fpr", "lower", "upper", "ci_level", "method"],
+    "comparisons": [
+        "model1",
+        "model2",
+        "auc1",
+        "auc2",
+        "pvalue_raw",
+        "pvalue_adjusted",
+        "method",
+        "p_adjust",
+        "family_size",
+        "pos_label",
+        "n",
+        "n_positive",
+        "n_negative",
+    ],
+}
+
+
+class ROCResults(TypedDict):
+    """Detached ROC tables returned by :func:`get_roc_results`."""
+
+    curves: pd.DataFrame
+    metrics: pd.DataFrame
+    bands: pd.DataFrame
+    comparisons: pd.DataFrame
+
+
+def _empty_roc_results() -> ROCResults:
+    return {
+        "curves": pd.DataFrame(columns=pd.Index(_ROC_COLUMNS["curves"])),
+        "metrics": pd.DataFrame(columns=pd.Index(_ROC_COLUMNS["metrics"])),
+        "bands": pd.DataFrame(columns=pd.Index(_ROC_COLUMNS["bands"])),
+        "comparisons": pd.DataFrame(columns=pd.Index(_ROC_COLUMNS["comparisons"])),
+    }
 
 
 def placeholderplot(description: str, *, ax: Axes | None = None) -> Axes:
@@ -891,6 +930,73 @@ def _validate_roc_scores(data: pd.DataFrame, columns: list[str]) -> None:
             )
 
 
+def get_roc_results(ax: Axes | None = None) -> ROCResults:
+    """Return the exact numerical outputs of the latest rocplot call.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes, optional
+        Axes returned by rocplot. Defaults to the current axes.
+
+    Returns
+    -------
+    ROCResults
+        A mapping of four detached pandas DataFrames, in plotted model and
+        requested comparison order:
+
+        * ``curves``: ``model``, ``fpr``, ``tpr``, ``threshold``. Coordinates and
+          thresholds come directly from sklearn's ``roc_curve`` with its default
+          intermediate-point dropping. The first threshold is positive infinity.
+        * ``metrics``: ``model``, ``auc``, ``method``, ``pos_label``, ``n``,
+          ``n_positive``, ``n_negative``. ``auc`` is the unrounded value used in
+          the legend; ``method='trapezoidal'`` integrates TPR over FPR.
+        * ``bands``: ``model``, ``fpr``, ``lower``, ``upper``, ``ci_level``,
+          ``method``. Only populated when ``ci_show=True``. These pointwise 95%
+          intervals use 1,000 stratified bootstrap samples, seed 42, and a grid
+          of 101 equally spaced FPR values; ``method='stratified_bootstrap'``.
+          They are intervals for the curve, not for AUC.
+        * ``comparisons``: ``model1``, ``model2``, ``auc1``, ``auc2``,
+          ``pvalue_raw``, ``pvalue_adjusted``, ``method``, ``p_adjust``,
+          ``family_size``, ``pos_label``, ``n``, ``n_positive``, ``n_negative``.
+          Only requested paired, two-sided tests appear (``method='delong'``).
+          Raw and adjusted p-values agree when ``p_adjust`` is None;
+          ``family_size`` counts all requested pairs. The adjusted value is the
+          unrounded value used in each annotation.
+
+        Models are identified by prediction column names. Positive labels are
+        always 1 and negative labels 0. Counts include every input row, with the
+        same paired observations used for all models. Unrequested analyses and
+        axes without valid stored results return empty tables with these columns.
+
+    Notes
+    -----
+    No statistics are recomputed. Each call returns independent copies, and each
+    rocplot call replaces the stored results for its axes. Clearing the axes or
+    removing a stored ROC curve, band, or comparison annotation invalidates the
+    snapshot. Editing labels or moving the legend does not affect the tables.
+
+    Examples
+    --------
+    >>> ax = cns.rocplot(df, "truth", ["model_a", "model_b"], pairs="all")
+    >>> results = cns.get_roc_results(ax)
+    >>> results["metrics"].to_csv("roc_metrics.csv", index=False)
+    """
+    if ax is None:
+        ax = plt.gca()
+    stored = getattr(ax, "_cnsplots_roc_results", None)
+    if stored is None:
+        return _empty_roc_results()
+    results, artists = stored
+    if any(artist not in ax.get_children() for artist in artists):
+        return _empty_roc_results()
+    return {
+        "curves": results["curves"].copy(deep=True),
+        "metrics": results["metrics"].copy(deep=True),
+        "bands": results["bands"].copy(deep=True),
+        "comparisons": results["comparisons"].copy(deep=True),
+    }
+
+
 def rocplot(
     data: pd.DataFrame,
     true_label_col: str,
@@ -925,12 +1031,15 @@ def rocplot(
     Returns
     -------
     matplotlib.axes.Axes
-        The matplotlib Axes object containing the plot.
+        The matplotlib Axes object containing the plot. Use
+        ``get_roc_results(ax)`` to retrieve its coordinates, AUCs, confidence
+        bands, and comparison results without recomputing them.
 
     See Also
     --------
     confusionplot : Create a confusion matrix heatmap.
     forestplot : Create a forest plot from a logistic model.
+    get_roc_results : Retrieve the exact values computed for the plot.
 
     Examples
     --------
@@ -979,21 +1088,60 @@ def rocplot(
 
     if ax is None:
         ax = plt.gca()
+    results = _empty_roc_results()
+    result_artists: list[Artist] = []
+    curve_tables = []
+    metric_rows = []
+    band_tables = []
+    auc_by_model = {}
+    sample_metadata = {
+        "pos_label": 1,
+        "n": len(data),
+        "n_positive": int((data[true_label_col] == 1).sum()),
+        "n_negative": int((data[true_label_col] == 0).sum()),
+    }
     for col in pred_prob_cols:
-        fpr, tpr, _ = roc_curve(data[true_label_col], data[col])
+        fpr, tpr, thresholds = roc_curve(data[true_label_col], data[col])
         roc_auc = auc(fpr, tpr)
+        auc_by_model[col] = roc_auc
+        curve_tables.append(
+            pd.DataFrame(
+                {"model": col, "fpr": fpr, "tpr": tpr, "threshold": thresholds}
+            )
+        )
+        metric_rows.append(
+            {
+                "model": col,
+                "auc": roc_auc,
+                "method": "trapezoidal",
+                **sample_metadata,
+            }
+        )
         (curve,) = ax.plot(
             fpr,
             tpr,
             label=f"{col} (AUC={roc_auc:.2f})",
             linewidth=1,
         )
+        result_artists.append(curve)
         if ci_show:
             ci_fpr, ci_lower, ci_upper = helper_roc._bootstrap_roc_confidence_band(
                 data[true_label_col].to_numpy(),
                 data[col].to_numpy(),
             )
-            ax.fill_between(
+            band_tables.append(
+                pd.DataFrame(
+                    {
+                        "model": col,
+                        "fpr": ci_fpr,
+                        "lower": ci_lower,
+                        "upper": ci_upper,
+                        "ci_level": 0.95,
+                        "method": "stratified_bootstrap",
+                    }
+                )
+            )
+            band = ax.fill_between(
                 ci_fpr,
                 ci_lower,
                 ci_upper,
@@ -1002,6 +1150,7 @@ def rocplot(
                 linewidth=0,
                 zorder=curve.get_zorder() - 1,
             )
+            result_artists.append(band)
 
     ax.plot([0, 1], [0, 1], color="black", linestyle="--", linewidth=0.8, dashes=(8, 5))
     ax.set_xlim((-0.02, 1.02))
@@ -1033,6 +1182,26 @@ def rocplot(
         if p_adjust is not None:
             displayed_pvalues = multipletests(raw_pvalues, method=p_adjust)[1].tolist()
             annotation_header += f" ({p_adjust}-adjusted)"
+        results["comparisons"] = pd.DataFrame(
+            [
+                {
+                    "model1": first,
+                    "model2": second,
+                    "auc1": auc_by_model[first],
+                    "auc2": auc_by_model[second],
+                    "pvalue_raw": raw,
+                    "pvalue_adjusted": adjusted,
+                    "method": "delong",
+                    "p_adjust": p_adjust,
+                    "family_size": len(resolved_pairs),
+                    **sample_metadata,
+                }
+                for (first, second), raw, adjusted in zip(
+                    resolved_pairs, raw_pvalues, displayed_pvalues, strict=True
+                )
+            ],
+            columns=pd.Index(_ROC_COLUMNS["comparisons"]),
+        )
         annotation_lines = [annotation_header]
         annotation_lines.extend(
             f"{first} vs {second}: P = "
@@ -1041,7 +1210,7 @@ def rocplot(
                 resolved_pairs, displayed_pvalues, strict=True
             )
         )
-        ax.text(
+        annotation = ax.text(
             0.02,
             0.02,
             "\n".join(annotation_lines),
@@ -1051,5 +1220,15 @@ def rocplot(
             fontsize=_legend_fontsize(),
             linespacing=1.25,
         )
+        result_artists.append(annotation)
+
+    if curve_tables:
+        results["curves"] = pd.concat(curve_tables, ignore_index=True)
+    results["metrics"] = pd.DataFrame(
+        metric_rows, columns=pd.Index(_ROC_COLUMNS["metrics"])
+    )
+    if band_tables:
+        results["bands"] = pd.concat(band_tables, ignore_index=True)
+    setattr(ax, "_cnsplots_roc_results", (results, result_artists))
 
     return ax

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,285 @@
+"""Numerical and artist contracts for binary probability calibration."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.calibration import calibration_curve
+from sklearn.metrics import brier_score_loss
+
+import cnsplots as cns
+from cnsplots.plots._calibration import calibrationplot, get_calibration_results
+
+
+@pytest.mark.parametrize("strategy", ["uniform", "quantile"])
+@pytest.mark.parametrize(
+    "scores",
+    [
+        [0, 0.15, 0.25, 0.4, 0.4, 0.75, 0.85, 1],
+        [0, 0, 0.5, 0.5, 0.5, 0.5, 1, 1],
+        [0.5] * 8,
+    ],
+)
+def test_calibration_matches_sklearn_with_ties_and_endpoints(
+    strategy: str, scores: list[float]
+) -> None:
+    data = pd.DataFrame(
+        {"truth": [0, 0, 1, 0, 1, 1, 0, 1], "first": scores, "second": scores[::-1]}
+    )
+    original = data.copy(deep=True)
+    ax = calibrationplot(
+        data, "truth", ["second", "first"], n_bins=8, strategy=cast(Any, strategy)
+    )
+    results = get_calibration_results(ax)
+
+    pd.testing.assert_frame_equal(data, original)
+    assert results["bins"]["model"].tolist() == ["second"] * 8 + ["first"] * 8
+    assert results["metrics"]["model"].tolist() == ["second", "first"]
+    assert results["metrics"]["strategy"].tolist() == [strategy, strategy]
+    assert results["metrics"]["n_bins"].tolist() == [8, 8]
+    assert results["metrics"]["method"].tolist() == ["brier_score"] * 2
+    assert results["metrics"]["pos_label"].tolist() == [1, 1]
+    for index, model in enumerate(["second", "first"]):
+        bins = results["bins"].query("model == @model")
+        occupied = bins[bins["count"] > 0]
+        expected_frequency, expected_probability = calibration_curve(
+            data["truth"], data[model], n_bins=8, strategy=strategy
+        )
+        np.testing.assert_allclose(
+            occupied["mean_predicted_probability"], expected_probability
+        )
+        np.testing.assert_allclose(occupied["observed_frequency"], expected_frequency)
+        np.testing.assert_allclose(
+            np.asarray(ax.lines[index].get_xdata(), dtype=float), expected_probability
+        )
+        np.testing.assert_allclose(
+            np.asarray(ax.lines[index].get_ydata(), dtype=float), expected_frequency
+        )
+        assert bins["count"].sum() == len(data)
+        assert bins["bin"].tolist() == list(range(8))
+        assert (
+            bins.loc[
+                bins["count"] == 0,
+                ["mean_predicted_probability", "observed_frequency"],
+            ]
+            .isna()
+            .all()
+            .all()
+        )
+        metrics = results["metrics"].iloc[index]
+        expected_brier = brier_score_loss(data["truth"], data[model])
+        assert metrics["brier_score"] == pytest.approx(expected_brier)
+        assert metrics[["n", "n_positive", "n_negative"]].tolist() == [8, 4, 4]
+        assert ax.lines[index].get_label() == f"{model} (Brier={expected_brier:.3f})"
+
+
+def test_calibration_uniform_boundaries_include_upper_endpoint() -> None:
+    data = pd.DataFrame(
+        {"truth": [0, 1, 0, 1, 0, 1], "probability": np.linspace(0, 1, 6)}
+    )
+    ax = calibrationplot(data, "truth", "probability")
+    bins = get_calibration_results(ax)["bins"]
+
+    assert bins["count"].tolist() == [2, 1, 1, 1, 1]
+    np.testing.assert_allclose(bins["bin_lower"], np.linspace(0, 1, 6)[:-1])
+    np.testing.assert_allclose(bins["bin_upper"], np.linspace(0, 1, 6)[1:])
+    np.testing.assert_allclose(bins["observed_frequency"], [0.5, 0, 1, 0, 1])
+
+
+def test_calibration_quantile_repeated_boundaries_remain_empty() -> None:
+    data = pd.DataFrame({"truth": [0, 1, 0, 1], "probability": [0.4] * 4})
+    ax = calibrationplot(data, "truth", "probability", strategy="quantile")
+    bins = get_calibration_results(ax)["bins"]
+
+    assert bins["count"].tolist() == [4, 0, 0, 0, 0]
+    assert bins["bin_lower"].tolist() == [0.4] * 5
+    assert bins["bin_upper"].tolist() == [0.4] * 5
+    np.testing.assert_allclose(np.asarray(ax.lines[0].get_xdata(), dtype=float), [0.4])
+    np.testing.assert_allclose(np.asarray(ax.lines[0].get_ydata(), dtype=float), [0.5])
+
+
+@pytest.mark.parametrize("pos_label", ["case", "control", 2, 3, False, True])
+def test_calibration_respects_explicit_positive_label(pos_label: Any) -> None:
+    labels = ["control", "case"] if isinstance(pos_label, str) else [2, 3]
+    if isinstance(pos_label, bool):
+        labels = [False, True]
+    data = pd.DataFrame({"truth": labels * 2, "probability": [0, 0.4, 0.8, 1]})
+    ax = calibrationplot(
+        data, "truth", "probability", pos_label=pos_label, n_bins=1, brier_show=False
+    )
+    results = get_calibration_results(ax)
+
+    assert results["metrics"].iloc[0]["pos_label"] == pos_label
+    assert results["metrics"].iloc[0]["brier_score"] == pytest.approx(
+        brier_score_loss(data["truth"] == pos_label, data["probability"])
+    )
+    np.testing.assert_allclose(np.asarray(ax.lines[0].get_xdata(), dtype=float), [0.55])
+    np.testing.assert_allclose(np.asarray(ax.lines[0].get_ydata(), dtype=float), [0.5])
+    assert ax.lines[0].get_label() == "probability"
+
+
+def test_calibration_axes_identity_legend_and_multipanel(roc_df: pd.DataFrame) -> None:
+    mp = cns.multipanel(max_width=450)
+    target = mp.panel("A", width=140, height=140)
+    other = mp.panel("B", width=140, height=140)
+    ax = calibrationplot(roc_df, "truth", ["model_b", "model_a"], ax=target)
+
+    assert ax is target
+    assert plt.gca() is other
+    assert len(other.lines) == 0
+    assert len(ax.lines) == 3
+    np.testing.assert_array_equal(ax.lines[-1].get_xdata(), [0, 1])
+    np.testing.assert_array_equal(ax.lines[-1].get_ydata(), [0, 1])
+    assert ax.lines[-1].get_linestyle() == "--"
+    assert ax.lines[0].get_marker() == "o"
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.texts] == [
+        ax.lines[0].get_label(),
+        ax.lines[1].get_label(),
+    ]
+    assert ax.get_xlabel() == "Mean Predicted Probability"
+    assert ax.get_ylabel() == "Observed Event Frequency"
+    assert ax.get_xlim() == pytest.approx((-0.02, 1.02))
+    assert ax.get_ylim() == pytest.approx((-0.02, 1.02))
+    assert calibrationplot(roc_df, "truth", "model_a") is other
+    assert get_calibration_results()["metrics"]["model"].tolist() == ["model_a"]
+    assert get_calibration_results(target)["metrics"]["model"].tolist() == [
+        "model_b",
+        "model_a",
+    ]
+
+
+def test_calibration_results_are_detached_latest_and_clearable(
+    roc_df: pd.DataFrame,
+) -> None:
+    _, ax = plt.subplots()
+    empty = get_calibration_results(ax)
+    assert empty["bins"].empty
+    assert empty["metrics"].empty
+    calibrationplot(roc_df, "truth", "model_a", ax=ax)
+    first = get_calibration_results(ax)
+    assert first["bins"].columns.tolist() == empty["bins"].columns.tolist()
+    assert first["metrics"].columns.tolist() == empty["metrics"].columns.tolist()
+    first["bins"].loc[0, "count"] = 999
+    first["metrics"].loc[0, "brier_score"] = 999
+    assert get_calibration_results(ax)["bins"].loc[0, "count"] != 999
+    assert get_calibration_results(ax)["metrics"].loc[0, "brier_score"] != 999
+
+    calibrationplot(roc_df, "truth", "model_b", ax=ax)
+    assert get_calibration_results(ax)["metrics"]["model"].tolist() == ["model_b"]
+    ax.lines[-2].remove()
+    assert get_calibration_results(ax)["bins"].empty
+    calibrationplot(roc_df, "truth", "model_b", ax=ax)
+    ax.clear()
+    pd.testing.assert_frame_equal(get_calibration_results(ax)["bins"], empty["bins"])
+    pd.testing.assert_frame_equal(
+        get_calibration_results(ax)["metrics"], empty["metrics"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("scores", "message"),
+    [
+        ([0.1, None], "Null values"),
+        ([0.1, np.nan], "Null values"),
+        ([0.1, np.inf], "finite scores"),
+        ([0.1, -np.inf], "finite scores"),
+        ([0.1, -0.01], r"in \[0, 1\]"),
+        ([0.1, 1.01], r"in \[0, 1\]"),
+        (["0.1", "0.9"], "real numeric scores"),
+        ([0.1j, 0.9], "real numeric scores"),
+        ([False, True], "real numeric scores"),
+    ],
+)
+def test_calibration_rejects_invalid_scores_before_drawing(
+    scores: list[Any], message: str
+) -> None:
+    data = pd.DataFrame({"truth": [0, 1], "valid": [0.1, 0.9], "invalid": scores})
+    _, ax = plt.subplots()
+    with pytest.raises(ValueError, match=message):
+        calibrationplot(data, "truth", ["valid", "invalid"], ax=ax)
+    assert len(ax.lines) == 0
+    assert get_calibration_results(ax)["metrics"].empty
+
+
+@pytest.mark.parametrize(
+    ("labels", "message"),
+    [
+        ([0, None], "Null values"),
+        ([0, 0], "exactly two classes"),
+        ([1, 1], "exactly two classes"),
+        (["case", "case"], "exactly two classes"),
+        ([0, 1, 2], "exactly two classes"),
+        ([0, np.inf], "finite and noncomplex"),
+        ([0j, 1j], "finite and noncomplex"),
+        (["control", "case"], "'pos_label' must be an observed"),
+    ],
+)
+def test_calibration_rejects_invalid_labels(labels: list[Any], message: str) -> None:
+    data = pd.DataFrame({"truth": labels, "probability": [0.5] * len(labels)})
+    with pytest.raises(ValueError, match=message):
+        calibrationplot(data, "truth", "probability")
+
+
+@pytest.mark.parametrize("n_bins", [0, -1, 1.5, True, np.bool_(True), "5"])
+def test_calibration_rejects_invalid_bin_count(
+    roc_df: pd.DataFrame, n_bins: Any
+) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        calibrationplot(roc_df, "truth", "model_a", n_bins=n_bins)
+
+
+def test_calibration_validates_columns_and_structure(roc_df: pd.DataFrame) -> None:
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        calibrationplot(cast(Any, {}), "truth", "model_a")
+    with pytest.raises(ValueError, match="At least one prediction column"):
+        calibrationplot(roc_df, "truth", [])
+    with pytest.raises(ValueError, match="Prediction columns must be unique"):
+        calibrationplot(roc_df, "truth", ["model_a", "model_a"])
+    with pytest.raises(ValueError, match="not found in data"):
+        calibrationplot(roc_df, "truth", "missing")
+    duplicate = pd.concat([roc_df, roc_df[["model_a"]]], axis=1)
+    with pytest.raises(ValueError, match="Duplicate column"):
+        calibrationplot(duplicate, "truth", "model_a")
+    with pytest.raises(ValueError, match="Data is empty"):
+        calibrationplot(roc_df.iloc[:0], "truth", "model_a")
+    with pytest.raises(ValueError, match="'strategy' must be"):
+        calibrationplot(roc_df, "truth", "model_a", strategy=cast(Any, "invalid"))
+    with pytest.raises(ValueError, match="'pos_label' must be an observed"):
+        calibrationplot(roc_df, "truth", "model_a", pos_label=2)
+
+
+def test_calibration_accepts_nullable_numeric_columns_and_numpy_bin_count() -> None:
+    data = pd.DataFrame(
+        {"truth": pd.Series([0, 1], dtype="Int64"), "probability": [0.1, 0.9]}
+    ).astype({"probability": "Float64"})
+    ax = calibrationplot(data, "truth", "probability", n_bins=cast(Any, np.int64(2)))
+    assert get_calibration_results(ax)["bins"]["count"].tolist() == [1, 1]
+
+
+@pytest.mark.parametrize("dtype", ["object", "category"])
+@pytest.mark.parametrize("invalid_label", [np.inf, 1j])
+def test_calibration_rejects_invalid_label_scalars(
+    dtype: str, invalid_label: Any
+) -> None:
+    data = pd.DataFrame(
+        {
+            "truth": pd.Series([0, invalid_label], dtype=dtype),
+            "probability": [0.1, 0.9],
+        }
+    )
+    with pytest.raises(ValueError, match="finite and noncomplex"):
+        calibrationplot(data, "truth", "probability")
+
+
+@pytest.mark.parametrize("columns", [None, 1, ["model_a", 1], ("model_a",)])
+def test_calibration_rejects_invalid_column_selection_types(
+    roc_df: pd.DataFrame, columns: Any
+) -> None:
+    with pytest.raises(TypeError, match="string or list of strings"):
+        calibrationplot(roc_df, "truth", columns)

--- a/tests/test_precision_recall.py
+++ b/tests/test_precision_recall.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.metrics import average_precision_score, precision_recall_curve
+
+import cnsplots as cns
+from cnsplots.plots._precision_recall import (
+    get_precision_recall_results,
+    precisionrecallplot,
+)
+
+
+CURVE_COLUMNS = ["model", "recall", "precision", "threshold"]
+METRIC_COLUMNS = [
+    "model",
+    "average_precision",
+    "prevalence",
+    "method",
+    "pos_label",
+    "n",
+    "n_positive",
+    "n_negative",
+]
+
+
+@pytest.mark.parametrize(
+    ("labels", "scores"),
+    [
+        ([0, 0, 1, 1], [0.1, 0.4, 0.35, 0.8]),
+        ([0, 0, 1, 1], [0.1, 0.4, 0.4, 0.8]),
+        ([0, 0, 0, 0, 0, 1], [0.2, 0.8, 0.4, 0.1, 0.1, 0.6]),
+        ([0, 0, 1, 1], [0.9, 0.7, 0.2, 0.1]),
+        ([0, 0, 1, 1], [0.5, 0.5, 0.5, 0.5]),
+        ([0, 0, 1, 1], [-3, 0, -1, 4]),
+    ],
+)
+def test_precision_recall_matches_sklearn(
+    labels: list[int], scores: list[float]
+) -> None:
+    data = pd.DataFrame({"truth": labels, "model": scores})
+    original = data.copy(deep=True)
+    ax = precisionrecallplot(data, "truth", "model")
+    expected_precision, expected_recall, thresholds = precision_recall_curve(
+        labels, scores
+    )
+    expected_ap = average_precision_score(labels, scores)
+    results = get_precision_recall_results(ax)
+    assert list(results["curves"].columns) == CURVE_COLUMNS
+    assert list(results["metrics"].columns) == METRIC_COLUMNS
+    curves = results["curves"]
+    assert curves.model.tolist() == ["model"] * len(expected_recall)
+    np.testing.assert_array_equal(curves.recall, expected_recall)
+    np.testing.assert_array_equal(curves.precision, expected_precision)
+    np.testing.assert_array_equal(curves.threshold.iloc[:-1], thresholds)
+    endpoint = curves.iloc[-1]
+    assert endpoint.recall == 0
+    assert endpoint.precision == 1
+    assert np.isnan(endpoint.threshold)
+    np.testing.assert_array_equal(ax.lines[0].get_xdata(), expected_recall)
+    np.testing.assert_array_equal(ax.lines[0].get_ydata(), expected_precision)
+    assert ax.lines[0].get_drawstyle() == "steps-post"
+    assert ax.lines[0].get_label() == f"model (AP={expected_ap:.2f})"
+    assert results["metrics"].iloc[0].to_dict() == {
+        "model": "model",
+        "average_precision": pytest.approx(expected_ap),
+        "prevalence": np.mean(labels),
+        "method": "average_precision",
+        "pos_label": 1,
+        "n": len(labels),
+        "n_positive": sum(labels),
+        "n_negative": len(labels) - sum(labels),
+    }
+    np.testing.assert_array_equal(ax.lines[-1].get_ydata(), [np.mean(labels)] * 2)
+    assert ax.lines[-1].get_linestyle() == "--"
+    assert ax.lines[-1].get_label() == f"Prevalence={np.mean(labels):.2f}"
+    assert ax.get_xlabel() == "Recall"
+    assert ax.get_ylabel() == "Precision"
+    assert ax.get_xlim() == (-0.02, 1.02)
+    assert ax.get_ylim() == (-0.02, 1.02)
+    assert not ax.collections
+    assert not ax.texts
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_average_precision_is_not_trapezoidal_area() -> None:
+    data = pd.DataFrame({"truth": [0, 0, 1, 1], "score": [0.1, 0.4, 0.35, 0.8]})
+    ax = precisionrecallplot(data, "truth", "score")
+    metric = get_precision_recall_results(ax)["metrics"].iloc[0]
+    assert metric.average_precision == pytest.approx(5 / 6)
+    assert metric.average_precision != pytest.approx(19 / 24)
+    assert "AUC" not in str(ax.lines[0].get_label())
+
+
+@pytest.mark.parametrize("dtype", ["int64", "Int64", "uint64"])
+def test_large_integer_scores_preserve_ranking_and_thresholds(dtype: str) -> None:
+    data = pd.DataFrame(
+        {
+            "truth": [0, 1],
+            "score": pd.Series([2**53, 2**53 + 1], dtype=dtype),
+        }
+    )
+    # Give sklearn the numeric array: its pandas nullable adapter casts to float.
+    scores = data.score.to_numpy()
+    expected_precision, expected_recall, thresholds = precision_recall_curve(
+        data.truth, scores
+    )
+    ax = precisionrecallplot(data, "truth", "score")
+    results = get_precision_recall_results(ax)
+    np.testing.assert_array_equal(results["curves"].precision, expected_precision)
+    np.testing.assert_array_equal(results["curves"].recall, expected_recall)
+    assert results["curves"].threshold.iloc[:-1].tolist() == thresholds.tolist()
+    assert np.isnan(results["curves"].threshold.iloc[-1])
+    assert results["metrics"].average_precision.iloc[0] == (
+        average_precision_score(data.truth, scores)
+    )
+    assert results["metrics"].average_precision.iloc[0] == 1
+
+
+@pytest.mark.parametrize(
+    ("labels", "pos_label"),
+    [
+        (["case", "control", "case", "control"], "control"),
+        ([2, -1, 2, -1], -1),
+        ([True, False, True, False], False),
+        ([0.2, 0.9, 0.2, 0.9], 0.9),
+    ],
+)
+def test_positive_class_semantics(labels: list[Any], pos_label: Any) -> None:
+    data = pd.DataFrame({"truth": labels, "score": [0.1, 0.9, 0.2, 0.8]})
+    ax = precisionrecallplot(data, "truth", "score", pos_label=pos_label)
+    metrics = get_precision_recall_results(ax)["metrics"].iloc[0]
+    assert metrics.average_precision == 1
+    assert metrics.pos_label == pos_label
+    assert metrics.n_positive == 2
+
+
+def test_multiple_models_preserve_order_and_use_explicit_axes(
+    roc_df: pd.DataFrame,
+) -> None:
+    _, (target, current) = plt.subplots(1, 2)
+    plt.sca(current)
+    ax = precisionrecallplot(roc_df, "truth", ["model_b", "model_a"], ax=target)
+    assert ax is target
+    assert plt.gca() is current
+    assert len(current.lines) == 0
+    results = get_precision_recall_results(ax)
+    assert results["metrics"].model.tolist() == ["model_b", "model_a"]
+    assert results["curves"].model.unique().tolist() == ["model_b", "model_a"]
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.texts] == [
+        "model_b (AP=1.00)",
+        "model_a (AP=1.00)",
+        "Prevalence=0.50",
+    ]
+
+
+def test_precision_recall_works_in_multipanel(roc_df: pd.DataFrame) -> None:
+    mp = cns.multipanel(max_width=300)
+    mp.panel("A", 100, 100)
+    first = precisionrecallplot(roc_df, "truth", "model_a")
+    assert first is mp.get_axes("A")
+    mp.panel("B", 100, 100)
+    second = precisionrecallplot(roc_df, "truth", "model_b")
+    assert second is mp.get_axes("B")
+    assert get_precision_recall_results()["metrics"].model.tolist() == ["model_b"]
+    assert get_precision_recall_results(first)["metrics"].model.tolist() == ["model_a"]
+
+
+def test_nullable_labels_and_scores_are_supported() -> None:
+    data = pd.DataFrame(
+        {
+            "truth": pd.Series([0, 0, 1, 1], dtype="Int64"),
+            "score": pd.Series([0.1, 0.4, 0.35, 0.8], dtype="Float64"),
+        }
+    )
+    ax = precisionrecallplot(data, "truth", "score")
+    assert get_precision_recall_results(ax)["metrics"].average_precision.iloc[0] == (
+        pytest.approx(5 / 6)
+    )
+
+
+def test_results_are_copies_and_replaced_by_latest_plot(roc_df: pd.DataFrame) -> None:
+    ax = precisionrecallplot(roc_df, "truth", "model_a")
+    first = get_precision_recall_results(ax)
+    first["curves"].loc[:, "precision"] = -1
+    first["metrics"].loc[:, "average_precision"] = -1
+    stored = get_precision_recall_results(ax)
+    assert (stored["curves"].precision >= 0).all()
+    assert stored["metrics"].average_precision.iloc[0] == 1
+    precisionrecallplot(roc_df, "truth", "model_b", ax=ax)
+    assert get_precision_recall_results(ax)["metrics"].model.tolist() == ["model_b"]
+    # Removing a previous call's curve does not invalidate the newest results.
+    ax.lines[0].remove()
+    assert not get_precision_recall_results(ax)["metrics"].empty
+
+
+@pytest.mark.parametrize("state", ["unplotted", "cleared", "removed"])
+def test_unavailable_results_have_fixed_empty_schemas(
+    roc_df: pd.DataFrame, state: str
+) -> None:
+    _, ax = plt.subplots()
+    if state != "unplotted":
+        precisionrecallplot(roc_df, "truth", "model_a", ax=ax)
+        if state == "cleared":
+            ax.clear()
+        else:
+            ax.lines[0].remove()
+    results = get_precision_recall_results(ax)
+    assert results["curves"].empty
+    assert results["metrics"].empty
+    assert list(results["curves"].columns) == CURVE_COLUMNS
+    assert list(results["metrics"].columns) == METRIC_COLUMNS
+
+
+@pytest.mark.parametrize(
+    ("columns", "error", "message"),
+    [
+        ([], ValueError, "at least one prediction"),
+        (["model_a", "model_a"], ValueError, "must be unique"),
+        (["missing"], ValueError, "not found"),
+        (None, TypeError, "string or list of strings"),
+        ([1], TypeError, "string or list of strings"),
+        (("model_a",), TypeError, "string or list of strings"),
+    ],
+)
+def test_invalid_prediction_columns(
+    roc_df: pd.DataFrame, columns: Any, error: type[Exception], message: str
+) -> None:
+    with pytest.raises(error, match=message):
+        precisionrecallplot(roc_df, "truth", columns)
+
+
+@pytest.mark.parametrize(
+    ("labels", "pos_label", "message"),
+    [
+        ([1, 1, 1, 1], 1, "exactly two classes"),
+        ([0, 1, 2, 0], 1, "exactly two classes"),
+        ([0, 1, None, 0], 1, "null values"),
+        ([0, 1, np.nan, 0], 1, "null values"),
+        ([0, np.inf, 0, np.inf], 0, "must be finite"),
+        (["case", np.inf, "case", np.inf], "case", "must be finite"),
+        ([0, 1, 0, 1], 2, "observed class"),
+        (["case", "control", "case", "control"], 1, "observed class"),
+    ],
+)
+def test_invalid_labels(labels: list[Any], pos_label: Any, message: str) -> None:
+    data = pd.DataFrame({"truth": labels, "score": [0.1, 0.9, 0.2, 0.8]})
+    with pytest.raises(ValueError, match=message):
+        precisionrecallplot(data, "truth", "score", pos_label=pos_label)
+
+
+@pytest.mark.parametrize(
+    ("scores", "error", "message"),
+    [
+        ([0.1, np.nan, 0.7, 0.8], ValueError, "must be finite"),
+        ([0.1, np.inf, 0.7, 0.8], ValueError, "must be finite"),
+        ([0.1, -np.inf, 0.7, 0.8], ValueError, "must be finite"),
+        (pd.Series([0.1, pd.NA, 0.7, 0.8], dtype="Float64"), ValueError, "finite"),
+        (["0.1", "0.3", "0.7", "0.8"], TypeError, "real numeric"),
+        ([1j, 2j, 3j, 4j], TypeError, "real numeric"),
+        ([True, False, True, True], TypeError, "real numeric"),
+    ],
+)
+def test_invalid_scores_are_rejected_before_drawing(
+    scores: Any, error: type[Exception], message: str
+) -> None:
+    data = pd.DataFrame(
+        {"truth": [0, 0, 1, 1], "valid": [0.1, 0.3, 0.7, 0.8], "invalid": scores}
+    )
+    _, ax = plt.subplots()
+    with pytest.raises(error, match=message):
+        precisionrecallplot(data, "truth", ["valid", "invalid"], ax=ax)
+    assert not ax.lines
+    assert get_precision_recall_results(ax)["curves"].empty
+
+
+def test_invalid_dataframe_and_ambiguous_columns(roc_df: pd.DataFrame) -> None:
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        precisionrecallplot(cast(Any, [0, 1]), "truth", "score")
+    with pytest.raises(ValueError, match="empty"):
+        precisionrecallplot(roc_df.iloc[:0], "truth", "model_a")
+    with pytest.raises(ValueError, match="not found"):
+        precisionrecallplot(roc_df, "missing", "model_a")
+    duplicated = pd.concat([roc_df, roc_df[["model_a"]]], axis=1)
+    with pytest.raises(ValueError, match="Duplicate column"):
+        precisionrecallplot(duplicated, "truth", "model_a")

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -10,7 +10,7 @@ import types
 from collections.abc import Mapping, Sequence
 from importlib.metadata import version
 from pathlib import Path
-from typing import Any, cast, get_type_hints
+from typing import Any, cast, get_type_hints, is_typeddict
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,6 +29,7 @@ _PUBLIC_PLOT_NAMES = frozenset(
     {
         "barplot",
         "boxplot",
+        "calibrationplot",
         "confusionplot",
         "cumulativeincidenceplot",
         "distplot",
@@ -45,6 +46,7 @@ _PUBLIC_PLOT_NAMES = frozenset(
         "phyloplot",
         "pieplot",
         "placeholderplot",
+        "precisionrecallplot",
         "qqplot",
         "regplot",
         "ridgeplot",
@@ -215,7 +217,7 @@ assert not {
     src_path = Path(__file__).parents[1] / "src"
     no_site_script = (
         f"import sys; sys.path.insert(0, {str(src_path)!r}); "
-        "import cnsplots; assert len(cnsplots.__all__) == 69"
+        "import cnsplots; assert len(cnsplots.__all__) == 77"
     )
     subprocess.run([sys.executable, "-S", "-c", no_site_script], check=True)
 
@@ -276,6 +278,9 @@ def test_public_callable_annotations_resolve() -> None:
 
     for name in cns.__all__:
         value = getattr(cns, name)
+        if is_typeddict(value):
+            assert set(get_type_hints(value).values()) == {pd.DataFrame}
+            continue
         if not (inspect.isfunction(value) or inspect.isclass(value)):
             continue
 

--- a/tests/test_roc_results.py
+++ b/tests/test_roc_results.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import matplotlib.pyplot as plt
+import num2tex
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.metrics import auc, roc_curve
+from statsmodels.stats.multitest import multipletests
+
+import cnsplots as cns
+from cnsplots.helpers import _roc
+from cnsplots.plots import _specialized
+
+
+_TABLES: tuple[Literal["curves", "metrics", "bands", "comparisons"], ...] = (
+    "curves",
+    "metrics",
+    "bands",
+    "comparisons",
+)
+_COLUMNS = {
+    "curves": ["model", "fpr", "tpr", "threshold"],
+    "metrics": ["model", "auc", "method", "pos_label", "n", "n_positive", "n_negative"],
+    "bands": ["model", "fpr", "lower", "upper", "ci_level", "method"],
+    "comparisons": [
+        "model1",
+        "model2",
+        "auc1",
+        "auc2",
+        "pvalue_raw",
+        "pvalue_adjusted",
+        "method",
+        "p_adjust",
+        "family_size",
+        "pos_label",
+        "n",
+        "n_positive",
+        "n_negative",
+    ],
+}
+
+
+@pytest.fixture
+def tied_roc_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "truth": [0, 0, 0, 0, 1, 1, 1, 1, 1],
+            "first": [0.1, 0.3, 0.3, 0.8, 0.3, 0.4, 0.5, 0.8, 0.9],
+            "second": [0.2, 0.3, 0.6, 0.7, 0.3, 0.4, 0.7, 0.8, 0.9],
+            "third": [0.1, 0.4, 0.5, 0.7, 0.2, 0.3, 0.5, 0.8, 0.9],
+        }
+    )
+
+
+def test_roc_results_match_sklearn_and_plotted_values(
+    tied_roc_df: pd.DataFrame,
+) -> None:
+    models = ["second", "first", "third"]
+    _, ax = plt.subplots()
+    assert cns.rocplot(tied_roc_df, "truth", models, ax=ax) is ax
+    result = cns.get_roc_results(ax)
+    assert set(result) == set(_COLUMNS)
+    assert result["curves"].model.unique().tolist() == models
+    assert result["metrics"].model.tolist() == models
+    for key in _TABLES:
+        assert result[key].columns.tolist() == _COLUMNS[key]
+    for model, line in zip(models, ax.lines[:3], strict=True):
+        fpr, tpr, thresholds = roc_curve(tied_roc_df.truth, tied_roc_df[model])
+        expected_auc = auc(fpr, tpr)
+        curve = result["curves"].query("model == @model")
+        np.testing.assert_array_equal(curve.fpr, fpr)
+        np.testing.assert_array_equal(curve.tpr, tpr)
+        np.testing.assert_array_equal(curve.threshold, thresholds)
+        assert np.isposinf(curve.threshold.iloc[0])
+        np.testing.assert_array_equal(curve[["fpr", "tpr"]], line.get_xydata())
+        metric = result["metrics"].query("model == @model").iloc[0]
+        assert metric.auc == expected_auc
+        assert metric.method == "trapezoidal"
+        assert metric.pos_label == 1
+        assert metric.n == 9
+        assert metric.n_positive == 5
+        assert metric.n_negative == 4
+        assert line.get_label() == f"{model} (AUC={metric.auc:.2f})"
+    assert result["bands"].empty
+    assert result["comparisons"].empty
+
+
+@pytest.mark.parametrize("p_adjust", [None, "bonferroni", "holm", "fdr_bh", "fdr_by"])
+def test_roc_comparison_results_match_delong_and_adjustments(
+    tied_roc_df: pd.DataFrame, p_adjust: Any
+) -> None:
+    models = ["third", "first", "second"]
+    expected_pairs = [("third", "first"), ("third", "second"), ("first", "second")]
+    raw = [
+        _roc._delong_roc_test(
+            tied_roc_df.truth.to_numpy(),
+            tied_roc_df[first].to_numpy(),
+            tied_roc_df[second].to_numpy(),
+        )
+        for first, second in expected_pairs
+    ]
+    adjusted = raw if p_adjust is None else multipletests(raw, method=p_adjust)[1]
+    ax = cns.rocplot(tied_roc_df, "truth", models, pairs="all", p_adjust=p_adjust)
+    result = cns.get_roc_results(ax)
+    comparisons = result["comparisons"]
+    assert list(zip(comparisons.model1, comparisons.model2)) == expected_pairs
+    np.testing.assert_array_equal(comparisons.pvalue_raw, raw)
+    np.testing.assert_array_equal(comparisons.pvalue_adjusted, adjusted)
+    assert comparisons.method.tolist() == ["delong"] * 3
+    assert comparisons.p_adjust.tolist() == [p_adjust] * 3
+    assert comparisons.family_size.tolist() == [3] * 3
+    assert comparisons.pos_label.tolist() == [1] * 3
+    assert comparisons.n.tolist() == [9] * 3
+    assert comparisons.n_positive.tolist() == [5] * 3
+    assert comparisons.n_negative.tolist() == [4] * 3
+    metrics = result["metrics"].set_index("model")
+    for _, row in comparisons.iterrows():
+        assert row.auc1 == metrics.loc[row.model1, "auc"]
+        assert row.auc2 == metrics.loc[row.model2, "auc"]
+        displayed = rf"${num2tex.num2tex(row.pvalue_adjusted, precision=2):.2g}$"
+        assert (
+            f"{row.model1} vs {row.model2}: P = {displayed}" in ax.texts[-1].get_text()
+        )
+
+
+@pytest.mark.parametrize("pairs", [None, []])
+def test_unrequested_roc_comparisons_are_empty_without_testing(
+    tied_roc_df: pd.DataFrame, pairs: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def unexpected_test(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("No DeLong comparisons were requested")
+
+    monkeypatch.setattr(_roc, "_delong_roc_test", unexpected_test)
+    ax = cns.rocplot(tied_roc_df, "truth", ["first", "second"], pairs=pairs)
+    result = cns.get_roc_results(ax)
+    assert result["comparisons"].empty
+    assert result["comparisons"].columns.tolist() == _COLUMNS["comparisons"]
+    assert len(ax.texts) == 0
+
+
+def test_roc_results_preserve_requested_degenerate_comparisons() -> None:
+    truth = np.array([0, 0, 0, 1, 1, 1])
+    data = pd.DataFrame(
+        {"truth": truth, "perfect": truth, "identical": truth, "reversed": 1 - truth}
+    )
+    ax = cns.rocplot(
+        data,
+        "truth",
+        ["perfect", "identical", "reversed"],
+        pairs=[("perfect", "reversed"), ("identical", "perfect")],
+    )
+    result = cns.get_roc_results(ax)
+    assert result["metrics"].auc.tolist() == [1.0, 1.0, 0.0]
+    comparisons = result["comparisons"]
+    assert comparisons.model1.tolist() == ["perfect", "identical"]
+    assert comparisons.model2.tolist() == ["reversed", "perfect"]
+    assert comparisons.pvalue_raw.tolist() == [0.0, 1.0]
+    assert comparisons.pvalue_adjusted.tolist() == [0.0, 1.0]
+
+
+def test_roc_results_capture_exact_bands_and_are_defensive_snapshots(
+    tied_roc_df: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    computed_bands = []
+    bootstrap = _roc._bootstrap_roc_confidence_band
+
+    def capture_band(*args: Any) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        band = bootstrap(*args)
+        computed_bands.append(band)
+        return band
+
+    monkeypatch.setattr(_roc, "_bootstrap_roc_confidence_band", capture_band)
+    ax = cns.rocplot(
+        tied_roc_df, "truth", ["first", "second"], ci_show=True, pairs="all"
+    )
+    expected = cns.get_roc_results(ax)
+    assert len(computed_bands) == 2
+    for model, (fpr, lower, upper), artist in zip(
+        ["first", "second"], computed_bands, ax.collections, strict=True
+    ):
+        band = expected["bands"].query("model == @model")
+        np.testing.assert_array_equal(band.fpr, fpr)
+        np.testing.assert_array_equal(band.lower, lower)
+        np.testing.assert_array_equal(band.upper, upper)
+        assert band.ci_level.tolist() == [0.95] * 101
+        assert band.method.tolist() == ["stratified_bootstrap"] * 101
+        vertices = np.asarray(artist.get_paths()[0].vertices)
+        np.testing.assert_array_equal(vertices[1:102], np.column_stack([fpr, lower]))
+        np.testing.assert_array_equal(
+            vertices[103:204][::-1], np.column_stack([fpr, upper])
+        )
+
+    def unexpected_compute(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Reading ROC results must not recompute statistics")
+
+    monkeypatch.setattr(_roc, "_bootstrap_roc_confidence_band", unexpected_compute)
+    monkeypatch.setattr(_roc, "_delong_roc_test", unexpected_compute)
+    monkeypatch.setattr(_specialized, "roc_curve", unexpected_compute)
+    monkeypatch.setattr(_specialized, "auc", unexpected_compute)
+    tied_roc_df.loc[:, "first"] = 0.0
+    result = cns.get_roc_results(ax)
+    for key in _TABLES:
+        table = result[key]
+        table.iloc[0, 0] = "changed"
+        table.attrs["source"] = "changed"
+    result["metrics"] = pd.DataFrame()
+    ax.lines[0].set_label("Updated legend")
+    legend = ax.get_legend()
+    assert legend is not None
+    legend.remove()
+    actual = cns.get_roc_results(ax)
+    for key in _TABLES:
+        pd.testing.assert_frame_equal(actual[key], expected[key])
+        assert actual[key].attrs == expected[key].attrs
+
+
+def test_roc_results_follow_current_axes_and_replace_on_reuse(
+    roc_df: pd.DataFrame,
+) -> None:
+    _, (ax, other) = plt.subplots(1, 2)
+    empty = cns.get_roc_results(ax)
+    for key in _TABLES:
+        assert empty[key].empty
+        assert empty[key].columns.tolist() == _COLUMNS[key]
+    cns.rocplot(roc_df, "truth", ["model_a", "model_b"], pairs="all", ax=ax)
+    old_curve = ax.lines[0]
+    plt.sca(other)
+    assert all(cns.get_roc_results()[key].empty for key in _TABLES)
+    plt.sca(ax)
+    for key in _TABLES:
+        pd.testing.assert_frame_equal(
+            cns.get_roc_results()[key], cns.get_roc_results(ax)[key]
+        )
+    cns.rocplot(roc_df, "truth", "model_b", ax=ax)
+    old_curve.remove()
+    result = cns.get_roc_results(ax)
+    assert result["metrics"].model.tolist() == ["model_b"]
+    assert result["comparisons"].empty
+    ax.clear()
+    for key in _TABLES:
+        pd.testing.assert_frame_equal(cns.get_roc_results(ax)[key], empty[key])
+
+
+@pytest.mark.parametrize("artist_kind", ["curve", "band", "annotation"])
+def test_roc_results_expire_when_plot_artist_removed(
+    roc_df: pd.DataFrame, artist_kind: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        _roc,
+        "_bootstrap_roc_confidence_band",
+        lambda *args: (
+            np.array([0.0, 1.0]),
+            np.array([0.0, 0.5]),
+            np.array([0.5, 1.0]),
+        ),
+    )
+    ax = cns.rocplot(roc_df, "truth", ["model_a", "model_b"], ci_show=True, pairs="all")
+    artist = {
+        "curve": ax.lines[0],
+        "band": ax.collections[0],
+        "annotation": ax.texts[0],
+    }[artist_kind]
+    artist.remove()
+    for key in _TABLES:
+        table = cns.get_roc_results(ax)[key]
+        assert table.empty
+        assert table.columns.tolist() == _COLUMNS[key]

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -119,6 +119,30 @@ if TYPE_CHECKING:
         )
         assert_type(cns.get_survival_results(ax), pd.DataFrame)
         assert_type(cns.get_survival_results(), pd.DataFrame)
+        assert_type(cns.rocplot(data, "truth", ["model_a", "model_b"], ax=ax), Axes)
+        assert_type(cns.get_roc_results(ax), cns.ROCResults)
+        assert_type(cns.get_roc_results()["comparisons"], pd.DataFrame)
+        assert_type(
+            cns.precisionrecallplot(data, "truth", "score", pos_label="yes", ax=ax),
+            Axes,
+        )
+        assert_type(cns.get_precision_recall_results(ax), cns.PrecisionRecallResults)
+        assert_type(cns.get_precision_recall_results()["metrics"], pd.DataFrame)
+        assert_type(
+            cns.calibrationplot(
+                data,
+                "truth",
+                "probability",
+                n_bins=10,
+                strategy="quantile",
+                brier_show=False,
+                pos_label="yes",
+                ax=ax,
+            ),
+            Axes,
+        )
+        assert_type(cns.get_calibration_results(ax), cns.CalibrationResults)
+        assert_type(cns.get_calibration_results()["bins"], pd.DataFrame)
         assert_type(cns.histplot(data, x="x", ax=ax), Axes)
         assert_type(cns.lineplot(data, x="x", y="y", ax=ax), Axes)
         assert_type(cns.regplot(data, x="x", y="y", color=(0.1, 0.2, 0.3)), Axes)


### PR DESCRIPTION
Expose the numbers used by ROC plots and add complementary precision–recall and probability calibration views for supplied binary predictions.

- Add `get_roc_results` for exact coordinates, AUCs, optional pointwise bootstrap bands, and raw/adjusted paired DeLong comparisons, preserving existing ROC returns and displayed values.
- Add `precisionrecallplot` with explicit average precision (AP), a prevalence reference, positive-label semantics, and copied curve/metric tables. Preserve large integer decision-score rankings and thresholds.
- Add `calibrationplot` with uniform/quantile bins, accessible counts including empty bins, optional Brier labels, and copied bin/metric tables. Brier measures overall probabilistic prediction quality.
- Export typed result interfaces lazily and document input, axes, snapshot, and metric policies with offline gallery examples. Center all gallery card titles, including wrapped captions.

Validation: `make test` passed (1,542 tests, 100% coverage); `make lint` passed. An offline Sphinx build with warnings treated as errors passed while executing ROC, precision–recall, calibration, and showcase examples. Numerical and artist regressions cover sklearn/statsmodels agreement, ties, degenerate ROC comparisons, endpoints, missing/nonfinite data, explicit axes, multipanel use, and unchanged caller inputs. Rendered galleries and a combined three-panel figure were inspected.

Limitations and follow-ups: the new plots reject one-class data explicitly. PR confidence bands and comparison tests remain out of scope. `make test-visual` skipped all 32 existing image-hash tests on macOS; new pinned visual baselines still require the repository's Linux x86_64/Python 3.12/Matplotlib 3.10/FreeType 2.6.1 environment. No dependencies or CI/build configuration changed.

Closes #163
Closes #187
Closes #188

