### PR TITLE
✨ Add enrichment filtering and bars

### DIFF
--- a/docs/_ext/gallery_order.py
+++ b/docs/_ext/gallery_order.py
@@ -70,6 +70,7 @@ GALLERY_CATEGORIES = [
             "survivalplot",
             "forestplot",
             "gseaplot",
+            "enrichmentbarplot",
             "volcanoplot",
             "confusionplot",
             "rocplot",

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,12 +95,38 @@ diagram object, respectively.
 
    volcanoplot
    gseaplot
+   enrichmentbarplot
    rocplot
    precisionrecallplot
    calibrationplot
    qqplot
    forestplot
 ```
+
+`enrichmentbarplot` draws horizontal bars with lengths equal to
+`-log10(FDR q-val)` by default. Supply already adjusted p-values or FDR values;
+the plot does not perform enrichment tests or multiple-testing correction.
+Use `significance_column` for another significance column. Raw p-values are
+accepted only as supplied, and the axis names that column without implying
+adjustment. Larger, dimensionless values indicate greater significance.
+
+The default selection is FDR **less than or equal to** `0.05`, followed by the
+20 lowest values. Set `cutoff=None` for prefiltered data and `top_term=None`
+to display every retained row. Selection always ranks by significance; ties
+keep input order. `order="significance"` displays the smallest values at the
+top, while `order="input"` displays the selected rows in their original order.
+Duplicate term labels remain separate bars. Optional `count="Count"` labels
+show nonnegative integer overlapping-gene counts; missing counts omit the
+label. Gene ratios are not converted into counts.
+
+Missing term labels and missing, nonfinite, or out-of-range significance
+values raise an error. Exact zero significance values use the smallest
+positive normal float for plotting (about 307.65 on the transformed axis);
+positive values remain unchanged. This is a finite display convention, not
+an estimate of an unreported p-value. Empty selections return labeled axes
+without bars. The function leaves all input rows and values unchanged and
+returns the target `Axes`; bars and count annotations are available through
+its `containers` and `texts`. Pass `ax` to compose it in `multipanel`.
 
 ### Specialized Plots
 
@@ -399,6 +425,32 @@ the same columns. Omitting `ax` selects the current axes.
    LogisticModel
    prerank
 ```
+
+`prerank` preserves its existing defaults: **FDR q-val < 0.25** and
+**abs(NES) > 1.5**. Equality at either boundary is excluded. The keyword-only
+`fdr_cutoff` and `min_abs_nes` make these selection rules explicit; `None`
+disables either filter independently. To obtain every enrichment summary row
+in one computation and select terms later:
+
+```python
+all_results = cns.prerank(
+    ranked_genes,
+    gene_sets,
+    name_gene="gene",
+    name_rank="rank",
+    fdr_cutoff=None,
+    min_abs_nes=None,
+)
+selected = all_results.loc[all_results["FDR q-val"] <= 0.05].copy()
+cns.enrichmentbarplot(selected, y="Clean_Term", cutoff=None, top_term=None)
+```
+
+Every returned table retains the original backend columns and index, adds
+`Clean_Term`, and sorts by descending absolute NES, with ties in backend
+order. Existing `gseaplot` calls continue to work with selected results;
+its own inclusive significance cutoff and top-term limit still apply.
+The full summary table does not contain the running-score arrays needed for
+a GSEA running-enrichment plot.
 
 ## Figure & Layout Utilities
 

--- a/examples/enrichmentbarplot.py
+++ b/examples/enrichmentbarplot.py
@@ -1,0 +1,87 @@
+"""
+Enrichment Significance Bars
+----------------------------
+
+Display computed pathway or GO enrichment results as horizontal -log10(FDR)
+bars, with optional overlapping-gene count labels. The data below are synthetic
+and require no downloads or enrichment analysis. Significance values are
+already adjusted; the plot never computes or adjusts p-values.
+"""
+
+# %%
+# Supply a complete results table
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import pandas as pd
+
+import cnsplots as cns
+
+results = pd.DataFrame(
+    {
+        "Term": [
+            "DNA repair",
+            "Cell cycle",
+            "Immune response",
+            "RNA processing",
+            "Metabolism",
+            "Cell adhesion",
+        ],
+        "FDR q-val": [0.001, 0.0001, 0.01, 0.01, 0.05, 0.2],
+        "Count": [12, 18, 9, None, 7, 4],
+    }
+)
+original = results.copy(deep=True)
+
+# %%
+# Select significant terms and annotate counts
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# The cutoff is inclusive: FDR = 0.05 is retained. Top-term selection always
+# takes the smallest FDR values; ties keep their input order. Larger bars mean
+# smaller FDR. Missing counts omit labels without dropping their pathway.
+cns.figure(width=250, height=150)
+ax = cns.enrichmentbarplot(results, y="Term", count="Count", cutoff=0.05, top_term=5)
+ax.set_title("Pathway enrichment")
+
+# %%
+# Compose views from explicitly selected results
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Set cutoff=None to skip significance filtering and top_term=None to show all
+# supplied rows. order="input" controls display order after significance-based
+# selection. Duplicate term labels would remain separate bars.
+selected = results.loc[results["FDR q-val"] <= 0.01].copy()
+mp = cns.multipanel(max_width=650)
+ranked_ax = mp.panel("A", width=200, height=140)
+cns.enrichmentbarplot(
+    selected,
+    y="Term",
+    count="Count",
+    cutoff=None,
+    top_term=None,
+    ax=ranked_ax,
+)
+ranked_ax.set_title("Ranked by significance")
+input_ax = mp.panel("B", width=200, height=140)
+cns.enrichmentbarplot(
+    selected,
+    y="Term",
+    cutoff=None,
+    top_term=None,
+    order="input",
+    ax=input_ax,
+)
+input_ax.set_title("Input order")
+pd.testing.assert_frame_equal(results, original)
+
+# %%
+# Obtain every summary row from prerank
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# For your own ranked genes, request all computed results with
+# ``cns.prerank(ranked_genes, gene_sets, "gene", "rank", fdr_cutoff=None,
+# min_abs_nes=None)`` and then choose rows for this plot or ``cns.gseaplot``.
+# The prerank defaults remain strict FDR < 0.25 and abs(NES) > 1.5.
+#
+# Missing/nonfinite FDR values or values outside [0, 1] are rejected. Exact
+# zeros use the smallest positive normal float for plotting, giving a finite
+# length of about 307.65; this display convention does not estimate their true
+# significance. Positive FDR values are unchanged. Empty selections return
+# labeled axes without bars. A supplied raw p-value column is used as-is and
+# named on the axis; it is never relabeled as adjusted significance.

--- a/src/cnsplots/__init__.py
+++ b/src/cnsplots/__init__.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from .plots import donutplot as donutplot
     from .plots import dotplot as dotplot
     from .plots import dumbbellplot as dumbbellplot
+    from .plots import enrichmentbarplot as enrichmentbarplot
     from .plots import forestplot as forestplot
     from .plots import gseaplot as gseaplot
     from .plots import heatmapplot as heatmapplot
@@ -160,6 +161,7 @@ _LAZY_IMPORTS = {
     "donutplot": ("cnsplots.plots._categorical", "donutplot"),
     "dotplot": ("cnsplots.plots._heatmap", "dotplot"),
     "dumbbellplot": ("cnsplots.plots._categorical", "dumbbellplot"),
+    "enrichmentbarplot": ("cnsplots.plots._genomics", "enrichmentbarplot"),
     "forestplot": ("cnsplots.plots._specialized", "forestplot"),
     "gseaplot": ("cnsplots.plots._genomics", "gseaplot"),
     "heatmapplot": ("cnsplots.plots._heatmap", "heatmapplot"),

--- a/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
+++ b/src/cnsplots/_agent_skill/cnsplots/references/plot-catalog.md
@@ -62,6 +62,8 @@ before plotting.
 
 - `volcanoplot`: effect size versus transformed adjusted significance.
 - `gseaplot`: gene-set enrichment results.
+- `enrichmentbarplot`: horizontal -log10 significance bars from computed enrichment
+  tables, with optional overlapping-gene count labels and explicit term selection.
 - `rocplot`: receiver operating characteristic curves with optional pointwise
   bootstrap confidence bands and paired DeLong AUC comparisons. Retrieve exact
   coordinates, AUCs, bands, and tests with `get_roc_results(ax)`.

--- a/src/cnsplots/_methods.py
+++ b/src/cnsplots/_methods.py
@@ -907,6 +907,9 @@ def prerank(
     name_gene: str | None = None,
     name_rank: str | None = None,
     permutation_num: int = 1000,
+    *,
+    fdr_cutoff: float | None = 0.25,
+    min_abs_nes: float | None = 1.5,
 ) -> pd.DataFrame:
     """
     Perform pre-ranked Gene Set Enrichment Analysis (GSEA).
@@ -929,11 +932,18 @@ def prerank(
         or a composite metric like log2FC * -log10(p)).
     permutation_num : int, default: 1000
         Number of permutations for significance testing.
+    fdr_cutoff : float or None, default: 0.25
+        Keep results with ``FDR q-val < fdr_cutoff`` (strictly below the cutoff).
+        Set to None to disable FDR filtering.
+    min_abs_nes : float or None, default: 1.5
+        Keep results with ``abs(NES) > min_abs_nes`` (strictly above the minimum).
+        Set to None to disable enrichment-score filtering. Set both filters to
+        None to return every result row from gseapy.
 
     Returns
     -------
     pd.DataFrame
-        Filtered and formatted GSEA results containing:
+        Formatted GSEA results with the requested filters applied, containing:
 
         - Term: Gene set name
         - Clean_Term: Cleaned gene set name with improved formatting
@@ -941,8 +951,10 @@ def prerank(
         - FDR q-val: False Discovery Rate q-value
         - Other columns from gseapy results
 
-        Results are filtered for FDR q-val < 0.25 and abs(NES) > 1.5, and sorted
-        by absolute NES value (descending).
+        By default, results are filtered for FDR q-val < 0.25 and abs(NES) > 1.5.
+        All result columns and the original index are retained. Results are
+        sorted by absolute NES value (descending), with ties retaining their
+        order in the gseapy result table.
 
     See Also
     --------
@@ -987,6 +999,19 @@ def prerank(
     >>>
     >>> # Visualize results
     >>> cns.gseaplot(gsea_results, y="Clean_Term", top_term=20)
+
+    >>> # Retain every tested pathway, then select terms explicitly
+    >>> all_results = cns.prerank(
+    ...     de_results,
+    ...     "KEGG_2021_Human",
+    ...     "gene_symbol",
+    ...     "rank",
+    ...     fdr_cutoff=None,
+    ...     min_abs_nes=None,
+    ... )
+    >>> selected = all_results[all_results["Term"].isin(terms_of_interest)]
+    >>> # Plot filtering is independent: cutoff=1 includes all valid FDR values
+    >>> cns.gseaplot(selected, y="Clean_Term", cutoff=1.0, top_term=len(selected))
     """
     validate_dataframe(data, "data", "prerank")
     validate_dataframe_not_empty(data, "prerank")
@@ -1041,6 +1066,9 @@ def prerank(
     assert gsea_res.res2d is not None
     gsea_df = gsea_res.res2d.copy()
     gsea_df["Clean_Term"] = gsea_df["Term"].apply(clean_term)
-    gsea_df = gsea_df[(gsea_df["FDR q-val"] < 0.25) & (gsea_df["NES"].abs() > 1.5)]
-    gsea_df = gsea_df.sort_values(by="NES", key=abs, ascending=False)
+    if fdr_cutoff is not None:
+        gsea_df = gsea_df[gsea_df["FDR q-val"] < fdr_cutoff]
+    if min_abs_nes is not None:
+        gsea_df = gsea_df[gsea_df["NES"].abs() > min_abs_nes]
+    gsea_df = gsea_df.sort_values(by="NES", key=abs, ascending=False, kind="stable")
     return gsea_df

--- a/src/cnsplots/plots/__init__.py
+++ b/src/cnsplots/plots/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from ._distribution import qqplot as qqplot
     from ._distribution import ridgeplot as ridgeplot
     from ._distribution import violinplot as violinplot
+    from ._genomics import enrichmentbarplot as enrichmentbarplot
     from ._genomics import gseaplot as gseaplot
     from ._genomics import volcanoplot as volcanoplot
     from ._heatmap import confusionplot as confusionplot
@@ -52,6 +53,7 @@ _LAZY_IMPORTS = {
     "donutplot": ("cnsplots.plots._categorical", "donutplot"),
     "dotplot": ("cnsplots.plots._heatmap", "dotplot"),
     "dumbbellplot": ("cnsplots.plots._categorical", "dumbbellplot"),
+    "enrichmentbarplot": ("cnsplots.plots._genomics", "enrichmentbarplot"),
     "forestplot": ("cnsplots.plots._specialized", "forestplot"),
     "gseaplot": ("cnsplots.plots._genomics", "gseaplot"),
     "heatmapplot": ("cnsplots.plots._heatmap", "heatmapplot"),

--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import matplotlib.patheffects as pe
 import matplotlib.pyplot as plt
@@ -342,4 +342,179 @@ def gseaplot(
     )
     setup_ax(ax, colorbar_label="")
     ax.set_xlabel("Normalized Enrichment Score (NES)")
+    return ax
+
+
+def enrichmentbarplot(
+    data: pd.DataFrame,
+    y: str,
+    significance_column: str = "FDR q-val",
+    *,
+    count: str | None = None,
+    cutoff: float | None = 0.05,
+    top_term: int | None = 20,
+    order: Literal["significance", "input"] = "significance",
+    ax: Axes | None = None,
+) -> Axes:
+    """
+    Plot horizontal enrichment bars from a computed results table.
+
+    Bar lengths are dimensionless -log10 significance values. No enrichment
+    test, multiple-testing correction, or network lookup is performed, and
+    the caller's DataFrame is not modified.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Computed enrichment results, with one row per term. Duplicate term
+        labels remain separate bars. Empty tables return labeled, empty axes.
+    y : str
+        Column containing term names. Missing term names are rejected.
+    significance_column : str, default: 'FDR q-val'
+        Column of adjusted p-values or FDR values, used for both selection and
+        bar lengths. Raw p-values can be supplied explicitly but are not
+        adjusted by this function. The column name appears in the x-axis label.
+        Values must be numeric, finite, nonmissing, and between 0 and 1.
+    count : str, optional
+        Column of overlapping-gene counts to annotate as ``n=<count>`` at each
+        bar's endpoint. Counts must be finite, nonnegative integers; missing
+        values omit the annotation. Gene ratios are not accepted as counts.
+    cutoff : float or None, default: 0.05
+        Retain significance values less than or equal to this threshold in
+        [0, 1]. Use None for prefiltered results or to disable filtering.
+    top_term : int or None, default: 20
+        Select at most this many rows with the lowest significance values,
+        preserving input order for ties. Use None to retain all passing rows
+        or 0 to display no rows.
+    order : {'significance', 'input'}, default: 'significance'
+        Display the selected rows from top to bottom by ascending significance
+        or in their original input order. This does not change top-term
+        selection. Duplicate DataFrame index values do not affect ordering.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw on. If None, uses the current axes, including the current
+        ``multipanel`` panel.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        Target axes. Bars are available through ``ax.patches`` and their
+        ``BarContainer`` in ``ax.containers``; count annotations are in
+        ``ax.texts``. Empty post-filter results produce no bars or annotations.
+
+    Notes
+    -----
+    Exact zeros are replaced only for the logarithm with
+    ``numpy.finfo(float).tiny`` (about 2.225e-308), giving a finite bar length
+    of about 307.65. Positive values, including subnormal values, are unchanged.
+    Filtering and ranking always use the original values. Invalid significance
+    values or counts anywhere in the input are rejected before filtering.
+
+    Examples
+    --------
+    >>> import cnsplots as cns
+    >>> import pandas as pd
+    >>> results = pd.DataFrame(
+    ...     {"Term": ["Repair", "Signaling"], "FDR": [0.001, 0.02], "Count": [8, 12]}
+    ... )
+    >>> ax = cns.enrichmentbarplot(
+    ...     results, y="Term", significance_column="FDR", count="Count", top_term=10
+    ... )
+    """
+    validate_dataframe(data, "data", "enrichmentbarplot")
+    numeric_columns = [significance_column] + ([] if count is None else [count])
+    validate_columns_exist(data, [y, *numeric_columns], "enrichmentbarplot")
+    if data[y].isna().any():
+        raise ValueError(
+            f"[enrichmentbarplot] Column '{y}' must not contain missing terms"
+        )
+    if top_term is not None:
+        if isinstance(top_term, bool) or not isinstance(top_term, (int, np.integer)):
+            raise TypeError(
+                "[enrichmentbarplot] Parameter 'top_term' must be an integer or None"
+            )
+        if top_term < 0:
+            raise ValueError(
+                "[enrichmentbarplot] Parameter 'top_term' must be non-negative"
+            )
+    if cutoff is not None:
+        if isinstance(cutoff, bool) or not isinstance(
+            cutoff, (int, float, np.integer, np.floating)
+        ):
+            raise TypeError(
+                "[enrichmentbarplot] Parameter 'cutoff' must be a number or None"
+            )
+        if not 0 <= cutoff <= 1:
+            raise ValueError(
+                "[enrichmentbarplot] Parameter 'cutoff' must be between 0 and 1"
+            )
+    if order not in ("significance", "input"):
+        raise ValueError(
+            "[enrichmentbarplot] Parameter 'order' must be 'significance' or 'input'"
+        )
+    for column in numeric_columns:
+        values = data[column].dropna()
+        if any(
+            isinstance(value, (bool, np.bool_))
+            or not isinstance(value, (int, float, np.integer, np.floating))
+            for value in values
+        ):
+            raise ValueError(
+                f"[enrichmentbarplot] Column '{column}' must be real numeric values"
+            )
+    significance = data[significance_column].to_numpy(dtype=float, na_value=np.nan)
+    if (
+        not np.isfinite(significance).all()
+        or ((significance < 0) | (significance > 1)).any()
+    ):
+        raise ValueError(
+            f"[enrichmentbarplot] Column '{significance_column}' must contain finite, "
+            "nonmissing significance values between 0 and 1"
+        )
+    counts = None
+    if count is not None:
+        counts = data[count].to_numpy(dtype=float, na_value=np.nan)
+        present_counts = counts[~np.isnan(counts)]
+        if (
+            not np.isfinite(present_counts).all()
+            or (present_counts < 0).any()
+            or (present_counts % 1 != 0).any()
+        ):
+            raise ValueError(
+                f"[enrichmentbarplot] Column '{count}' must contain finite, nonnegative integer counts"
+            )
+
+    selected = np.argsort(significance, kind="stable")
+    if cutoff is not None:
+        selected = selected[significance[selected] <= cutoff]
+    selected = selected[:top_term]
+    if order == "input":
+        selected = np.sort(selected)
+    selected_significance = significance[selected]
+    widths = -np.log10(
+        np.where(
+            selected_significance == 0, np.finfo(float).tiny, selected_significance
+        )
+    )
+
+    if ax is None:
+        ax = plt.gca()
+    positions = np.arange(len(selected))
+    ax.barh(positions, widths)
+    ax.set_yticks(positions, data.iloc[selected][y].astype(str).tolist())
+    ax.set_xlabel(f"\u2013log10({significance_column})")
+    ax.set_ylabel(y)
+    ax.set_ylim(max(len(selected) - 0.5, 0.5), -0.5)
+    if counts is not None:
+        for position, width, value in zip(positions, widths, counts[selected]):
+            if not np.isnan(value):
+                ax.annotate(
+                    f"n={int(value)}",
+                    (width, position),
+                    xytext=(2, 0),
+                    textcoords="offset points",
+                    va="center",
+                    fontsize=_legend_fontsize(),
+                )
+        ax.margins(x=0.2)
+    ax.set_xlim(left=0)
     return ax

--- a/tests/test_enrichmentbarplot.py
+++ b/tests/test_enrichmentbarplot.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.patches import Rectangle
+
+import cnsplots as cns
+from cnsplots.plots._genomics import enrichmentbarplot
+
+
+@pytest.fixture
+def enrichment_results() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Term": ["Repair", "Signaling", "Repair", "Boundary", "Outside", "Tie"],
+            "FDR q-val": [0.01, 0.001, 0.0001, 0.05, 0.06, 0.01],
+            "Count": [7, 12, 3, 0, 99, 8],
+        },
+        index=pd.Index([4, 2, 2, 9, 1, 4]),
+    )
+
+
+def _labels(ax: Axes) -> list[str]:
+    return [text.get_text() for text in ax.get_yticklabels()]
+
+
+def _bars(ax: Axes) -> list[Rectangle]:
+    return [cast(Rectangle, patch) for patch in ax.patches]
+
+
+def test_bar_lengths_selection_labels_and_counts(
+    enrichment_results: pd.DataFrame,
+) -> None:
+    original = enrichment_results.copy(deep=True)
+
+    ax = enrichmentbarplot(enrichment_results, "Term", count="Count", top_term=4)
+
+    assert _labels(ax) == ["Repair", "Signaling", "Repair", "Tie"]
+    assert [bar.get_width() for bar in _bars(ax)] == pytest.approx([4, 3, 2, 2])
+    assert [bar.get_y() + bar.get_height() / 2 for bar in _bars(ax)] == pytest.approx(
+        [0, 1, 2, 3]
+    )
+    assert ax.yaxis_inverted()
+    assert ax.get_xlabel() == "\u2013log10(FDR q-val)"
+    assert ax.get_ylabel() == "Term"
+    assert ax.get_xlim()[0] == 0
+    assert [text.get_text() for text in ax.texts] == ["n=3", "n=12", "n=7", "n=8"]
+    assert [cast(Any, text).xy for text in ax.texts] == [(4, 0), (3, 1), (2, 2), (2, 3)]
+    assert len(ax.containers) == 1
+    pd.testing.assert_frame_equal(enrichment_results, original)
+
+
+def test_input_display_order_keeps_significance_selection(
+    enrichment_results: pd.DataFrame,
+) -> None:
+    ax = enrichmentbarplot(enrichment_results, "Term", top_term=3, order="input")
+
+    assert _labels(ax) == ["Repair", "Signaling", "Repair"]
+    assert [bar.get_width() for bar in _bars(ax)] == pytest.approx([2, 3, 4])
+    assert not ax.texts
+
+
+def test_default_top_twenty_keeps_input_order_for_ties() -> None:
+    results = pd.DataFrame(
+        {"Term": [f"Term {i}" for i in range(25)], "FDR q-val": [0.01] * 25}
+    )
+
+    ax = enrichmentbarplot(results, "Term")
+
+    assert _labels(ax) == [f"Term {i}" for i in range(20)]
+
+
+def test_object_numeric_columns_from_enrichment_results_are_supported() -> None:
+    results = pd.DataFrame(
+        {
+            "Term": ["A", "B", "C"],
+            "FDR q-val": pd.Series([0.001, 0.02, 0.01], dtype=object),
+            "Count": pd.Series([12, np.nan, 3], dtype=object),
+        }
+    )
+    original = results.copy(deep=True)
+
+    ax = enrichmentbarplot(results, "Term", count="Count")
+
+    assert _labels(ax) == ["A", "C", "B"]
+    assert [bar.get_width() for bar in _bars(ax)] == pytest.approx(
+        [3, 2, -np.log10(0.02)]
+    )
+    assert [text.get_text() for text in ax.texts] == ["n=12", "n=3"]
+    pd.testing.assert_frame_equal(results, original)
+
+
+def test_count_annotations_have_space_inside_axes() -> None:
+    cns.figure(160, 100)
+    results = pd.DataFrame(
+        {"Term": ["A", "B"], "FDR q-val": [0.001, 0.02], "Count": [18, 7]}
+    )
+
+    ax = enrichmentbarplot(results, "Term", count="Count")
+    ax.figure.canvas.draw()
+
+    assert ax.get_xlim()[1] == pytest.approx(3.6)
+    for annotation in ax.texts:
+        assert annotation.get_window_extent().x1 <= ax.get_window_extent().x1
+
+
+def test_cutoff_is_inclusive_and_can_be_disabled(
+    enrichment_results: pd.DataFrame,
+) -> None:
+    _, (ax, unfiltered_ax) = plt.subplots(1, 2)
+    enrichmentbarplot(enrichment_results, "Term", top_term=None, ax=ax)
+    enrichmentbarplot(
+        enrichment_results,
+        "Term",
+        cutoff=None,
+        top_term=None,
+        order="input",
+        ax=unfiltered_ax,
+    )
+
+    assert _labels(ax) == ["Repair", "Signaling", "Repair", "Tie", "Boundary"]
+    assert _bars(ax)[-1].get_width() == pytest.approx(-np.log10(0.05))
+    assert _labels(unfiltered_ax) == enrichment_results["Term"].tolist()
+    assert len(unfiltered_ax.patches) == len(enrichment_results)
+
+
+def test_zero_significance_has_finite_width_without_clipping_positive_values() -> None:
+    smallest_positive = np.nextafter(0, 1)
+    results = pd.DataFrame(
+        {"Term": ["Zero", "Subnormal", "One"], "padj": [0, smallest_positive, 1]}
+    )
+    original = results.copy(deep=True)
+
+    ax = enrichmentbarplot(results, "Term", "padj", cutoff=None)
+
+    assert [bar.get_width() for bar in _bars(ax)] == pytest.approx(
+        [-np.log10(np.finfo(float).tiny), -np.log10(smallest_positive), 0]
+    )
+    assert _labels(ax) == ["Zero", "Subnormal", "One"]
+    assert ax.get_xlabel() == "\u2013log10(padj)"
+    pd.testing.assert_frame_equal(results, original)
+
+
+def test_cutoff_zero_selects_only_exact_zeros() -> None:
+    results = pd.DataFrame({"Term": ["Zero", "Positive"], "FDR q-val": [0, 0.001]})
+
+    ax = enrichmentbarplot(results, "Term", cutoff=0)
+
+    assert _labels(ax) == ["Zero"]
+
+
+@pytest.mark.parametrize("empty_mode", ["input", "filter", "selection"])
+def test_empty_results_return_labeled_axes(
+    enrichment_results: pd.DataFrame, empty_mode: str
+) -> None:
+    results = (
+        enrichment_results.iloc[:0] if empty_mode == "input" else enrichment_results
+    )
+    _, ax = plt.subplots()
+
+    returned = enrichmentbarplot(
+        results,
+        "Term",
+        count="Count",
+        cutoff=0 if empty_mode == "filter" else 0.05,
+        top_term=0 if empty_mode == "selection" else None,
+        ax=ax,
+    )
+
+    assert returned is ax
+    assert not ax.patches
+    assert not ax.texts
+    assert not _labels(ax)
+    assert ax.get_xlabel() == "\u2013log10(FDR q-val)"
+    ax.figure.canvas.draw()
+
+
+def test_untyped_empty_results_are_supported() -> None:
+    results = pd.DataFrame(columns=pd.Index(["Term", "FDR q-val", "Count"]))
+
+    ax = enrichmentbarplot(results, "Term", count="Count")
+
+    assert not ax.patches
+
+
+@pytest.mark.parametrize("all_missing", [False, True])
+def test_missing_counts_omit_annotations(all_missing: bool) -> None:
+    results = pd.DataFrame(
+        {
+            "Term": ["A", "B", "C"],
+            "FDR q-val": pd.array([0.001, 0.01, 0.02], dtype="Float64"),
+            "Count": pd.array(
+                [pd.NA, pd.NA, pd.NA] if all_missing else [3, pd.NA, 0], dtype="Int64"
+            ),
+        }
+    )
+    original = results.copy(deep=True)
+
+    ax = enrichmentbarplot(results, "Term", count="Count")
+
+    assert [text.get_text() for text in ax.texts] == (
+        [] if all_missing else ["n=3", "n=0"]
+    )
+    pd.testing.assert_frame_equal(results, original)
+
+
+def test_explicit_axes_and_multipanel(enrichment_results: pd.DataFrame) -> None:
+    mp = cns.multipanel(max_width=300)
+    target_ax = mp.panel("A", width=110, height=100)
+    other_ax = mp.panel("B", width=100, height=100)
+    original_texts = list(other_ax.texts)
+    plt.sca(other_ax)
+
+    returned = enrichmentbarplot(
+        enrichment_results, "Term", count="Count", ax=target_ax
+    )
+
+    assert returned is target_ax
+    assert not other_ax.patches
+    assert list(other_ax.texts) == original_texts
+    assert plt.gca() is other_ax
+    assert len(target_ax.patches) == 5
+    implicit_ax = enrichmentbarplot(enrichment_results, "Term", top_term=2)
+    assert implicit_ax is other_ax
+    mp.newline()
+    mp.panel("C", width=90, height=80)
+    assert mp.fig is not None
+    mp.fig.canvas.draw()
+    assert len(target_ax.patches) == 5
+    assert len(other_ax.patches) == 2
+
+
+@pytest.mark.parametrize("value", [np.nan, pd.NA, np.inf, -np.inf, -0.01, 1.01])
+def test_invalid_significance_is_rejected_before_filtering(value: Any) -> None:
+    results = pd.DataFrame(
+        {
+            "Term": ["Good", "Invalid"],
+            "FDR q-val": pd.array([0.01, value], dtype="Float64"),
+        }
+    )
+
+    with pytest.raises(ValueError, match="finite, nonmissing significance"):
+        enrichmentbarplot(results, "Term", top_term=1)
+
+
+@pytest.mark.parametrize("column", ["FDR q-val", "Count"])
+@pytest.mark.parametrize("value", ["0.01", True, 0.01 + 0j])
+def test_nonnumeric_columns_are_rejected(column: str, value: Any) -> None:
+    results = pd.DataFrame({"Term": ["A"], "FDR q-val": [0.01], "Count": [2]})
+    results[column] = [value]
+
+    with pytest.raises(ValueError, match="real numeric"):
+        enrichmentbarplot(results, "Term", count="Count")
+
+
+@pytest.mark.parametrize("value", [-1, 1.5, np.inf, -np.inf])
+def test_invalid_counts_are_rejected(value: float) -> None:
+    results = pd.DataFrame({"Term": ["A"], "FDR q-val": [0.01], "Count": [value]})
+
+    with pytest.raises(ValueError, match="nonnegative integer counts"):
+        enrichmentbarplot(results, "Term", count="Count", cutoff=0)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "match"),
+    [
+        ({"top_term": True}, TypeError, "'top_term'"),
+        ({"top_term": 1.5}, TypeError, "'top_term'"),
+        ({"top_term": -1}, ValueError, "'top_term'"),
+        ({"cutoff": True}, TypeError, "'cutoff'"),
+        ({"cutoff": "0.05"}, TypeError, "'cutoff'"),
+        ({"cutoff": -0.1}, ValueError, "'cutoff'"),
+        ({"cutoff": 1.1}, ValueError, "'cutoff'"),
+        ({"cutoff": np.nan}, ValueError, "'cutoff'"),
+        ({"order": "descending"}, ValueError, "'order'"),
+    ],
+)
+def test_invalid_options(
+    enrichment_results: pd.DataFrame,
+    kwargs: dict[str, Any],
+    error: type[Exception],
+    match: str,
+) -> None:
+    with pytest.raises(error, match=match):
+        enrichmentbarplot(enrichment_results, "Term", **kwargs)
+
+
+def test_dataframe_columns_and_term_names_are_validated(
+    enrichment_results: pd.DataFrame,
+) -> None:
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        enrichmentbarplot(cast(Any, []), "Term")
+    for column in ["Term", "FDR q-val", "Count"]:
+        with pytest.raises(ValueError, match="not found"):
+            enrichmentbarplot(
+                enrichment_results.drop(columns=column), "Term", count="Count"
+            )
+    missing_term = enrichment_results.copy()
+    missing_term.loc[9, "Term"] = None
+    with pytest.raises(ValueError, match="missing terms"):
+        enrichmentbarplot(missing_term, "Term")

--- a/tests/test_prerank_filtering.py
+++ b/tests/test_prerank_filtering.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import gseapy as gp
+import numpy as np
+import pandas as pd
+import pytest
+
+import cnsplots as cns
+
+
+@pytest.fixture
+def prerank_results(monkeypatch: pytest.MonkeyPatch) -> pd.DataFrame:
+    results = pd.DataFrame(
+        {
+            "Term": [
+                "GO_MODERATE",
+                "KEGG_FDR_BOUNDARY",
+                "GO_NEGATIVE",
+                "HALLMARK_POSITIVE_BOUNDARY",
+                "REACTOME_NEGATIVE_BOUNDARY",
+                "GO_WEAK_POSITIVE",
+                "GO_WEAK_NEGATIVE",
+                "BIOCARTA_ABOVE_FDR",
+                "GO_ZERO",
+                "GO_TIED",
+            ],
+            "NES": [2.0, 3.0, -2.5, 1.5, -1.5, 1.49, -1.49, -3.5, 0.0, -2.0],
+            "FDR q-val": [0.01, 0.25, 0.249, 0.01, 0.01, 0.01, 0.01, 0.251, 1, 0.01],
+            "ES": np.linspace(0.1, 1.0, 10),
+            "Lead_genes": [f"GENE{index};GENE{index + 1}" for index in range(10)],
+        },
+        index=pd.Index(range(10), name="result_row"),
+    )
+    results.attrs["ranking_metric"] = "log2 fold change"
+    monkeypatch.setattr(gp, "prerank", lambda **kwargs: SimpleNamespace(res2d=results))
+    return results
+
+
+def _prerank(**kwargs: float | None) -> pd.DataFrame:
+    return cns.prerank(
+        pd.DataFrame({"gene": ["A", "B", "C"], "rank": [3.0, 2.0, 1.0]}),
+        {"set": ["A", "B"]},
+        name_gene="gene",
+        name_rank="rank",
+        permutation_num=10,
+        **kwargs,
+    )
+
+
+def test_prerank_defaults_preserve_strict_thresholds_and_absolute_nes_order(
+    prerank_results: pd.DataFrame,
+) -> None:
+    result = _prerank()
+
+    assert result.index.tolist() == [2, 0, 9]
+    assert result["Clean_Term"].tolist() == ["Negative", "Moderate", "Tied"]
+    pd.testing.assert_frame_equal(
+        result.drop(columns="Clean_Term"), prerank_results.loc[[2, 0, 9]]
+    )
+
+
+@pytest.mark.parametrize(
+    ("fdr_cutoff", "min_abs_nes", "expected_rows"),
+    [
+        (None, None, [7, 1, 2, 0, 9, 3, 4, 5, 6, 8]),
+        (None, 1.5, [7, 1, 2, 0, 9]),
+        (0.25, None, [2, 0, 9, 3, 4, 5, 6]),
+        (0.02, 1.0, [0, 9, 3, 4, 5, 6]),
+        (0.01, None, []),
+    ],
+)
+def test_prerank_configurable_filters_preserve_result_data(
+    prerank_results: pd.DataFrame,
+    fdr_cutoff: float | None,
+    min_abs_nes: float | None,
+    expected_rows: list[int],
+) -> None:
+    original = prerank_results.copy(deep=True)
+
+    result = _prerank(fdr_cutoff=fdr_cutoff, min_abs_nes=min_abs_nes)
+
+    assert result.index.tolist() == expected_rows
+    assert result["Clean_Term"].notna().all()
+    assert result.attrs == original.attrs
+    pd.testing.assert_frame_equal(
+        result.drop(columns="Clean_Term"), original.loc[expected_rows]
+    )
+    pd.testing.assert_frame_equal(prerank_results, original)
+
+
+def test_prerank_all_results_allow_explicit_gseaplot_selection(
+    prerank_results: pd.DataFrame,
+) -> None:
+    results = _prerank(fdr_cutoff=None, min_abs_nes=None)
+    selected = results.loc[[1, 3, 7, 8]]
+
+    cns.figure(140, 160)
+    ax = cns.gseaplot(selected, y="Clean_Term", cutoff=1.0, top_term=len(selected))
+
+    offsets = np.asarray(ax.collections[0].get_offsets(), dtype=float)
+    rendered_nes = {
+        label.get_text(): offset[0]
+        for label, offset in zip(ax.get_yticklabels(), offsets, strict=True)
+    }
+    assert rendered_nes == pytest.approx(
+        selected.set_index("Clean_Term")["NES"].to_dict()
+    )

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -36,6 +36,7 @@ _PUBLIC_PLOT_NAMES = frozenset(
         "donutplot",
         "dotplot",
         "dumbbellplot",
+        "enrichmentbarplot",
         "forestplot",
         "gseaplot",
         "heatmapplot",
@@ -211,13 +212,17 @@ assert not {
     "cnsplots.plots._sets",
     "cnsplots.plots._survival",
 } & set(sys.modules)
+
+_ = cnsplots.enrichmentbarplot
+assert "cnsplots.plots._genomics" in sys.modules
+assert "gseapy" not in sys.modules
 """
     subprocess.run([sys.executable, "-c", script], check=True)
 
     src_path = Path(__file__).parents[1] / "src"
     no_site_script = (
         f"import sys; sys.path.insert(0, {str(src_path)!r}); "
-        "import cnsplots; assert len(cnsplots.__all__) == 77"
+        "import cnsplots; assert len(cnsplots.__all__) == 78"
     )
     subprocess.run([sys.executable, "-S", "-c", no_site_script], check=True)
 

--- a/tests/typing_contract.py
+++ b/tests/typing_contract.py
@@ -103,6 +103,30 @@ if TYPE_CHECKING:
         assert_type(cns.palettes("Set1"), list[tuple[float, float, float]])
         assert_type(cns.palettes("parula"), Colormap)
         assert_type(cns.boxplot(data, x="group", y="value"), Axes)
+        assert_type(
+            cns.enrichmentbarplot(
+                data,
+                y="Term",
+                significance_column="FDR q-val",
+                count="Count",
+                cutoff=None,
+                top_term=None,
+                order="input",
+                ax=ax,
+            ),
+            Axes,
+        )
+        assert_type(
+            cns.prerank(
+                data,
+                {"Pathway": ["A", "B"]},
+                "gene",
+                "rank",
+                fdr_cutoff=None,
+                min_abs_nes=None,
+            ),
+            pd.DataFrame,
+        )
         assert_type(cns.get_comparison_results(ax), pd.DataFrame)
         assert_type(cns.get_comparison_results(), pd.DataFrame)
         assert_type(


### PR DESCRIPTION
Allow callers to retain every prerank summary row, select terms explicitly, and plot enrichment significance with optional gene counts.

- Add keyword-only `fdr_cutoff` and `min_abs_nes` controls to `prerank`. Passing `None` disables either filter; existing strict defaults remain unchanged. Preserve backend columns, index, metadata, and cleaned terms, with stable sorting by absolute NES.
- Add `enrichmentbarplot` with horizontal `-log10` significance bars, stable top-term selection, an inclusive cutoff, display ordering, count labels, and explicit axes support. Handle duplicate labels, missing counts, empty selections, zero significance, and invalid values without changing input data.
- Add lazy public exports, typing coverage, API documentation, an offline gallery example, and numerical/artist regression tests. Verify compatibility with GSEApy's object-typed numeric columns and multipanel layouts.

Validation: `make test` (1,590 passed, 100% coverage), `make lint`, and execution plus visual inspection of the standalone and multipanel gallery figures.

Risks and follow-ups: exact zero significance uses the documented smallest positive normal float for display, giving a finite bar length of about 307.65. No pinned image-hash baseline was added because this macOS ARM environment does not meet the required Linux x86_64 configuration. Existing prerank selection defaults are preserved.

Closes #159
Closes #194
