### PR TITLE
🐛 Fix font caching and exports

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -189,6 +189,29 @@ def example_function(param1, param2):
 make test
 ```
 
+### Final PDF and SVG exports
+
+`tests/test_export_pipeline.py` checks saved files after export processing. It
+renders PDF with MuPDF's `mutool` and SVG with headless Chrome or Chromium, which
+supports SVG clipping and transparency masks. These optional executables are
+discovered locally; cases requiring an unavailable renderer explicitly skip.
+Missing and failed SVG conversion paths are also tested, including when `mutool`
+is absent but Chrome is available.
+
+```bash
+uv run pytest tests/test_export_pipeline.py tests/test_svg_font_weights.py --no-cov
+```
+
+The suite checks bounds, clipped geometry, alpha, rasterized layers, multipanel
+helper axes, and repeated text with different font weights. Geometric tolerances
+and ink coverage allow platform font and antialiasing differences; these checks
+do not require the pinned environment used for exact visual hashes. On failure,
+`mpl-results/export-pipeline/` retains the exported file, Agg reference, rendered
+PNG, enhanced difference image, and renderer log when available. Chrome profiles
+stay in the test's temporary directory and are excluded from comparison artifacts.
+Optimized SVG retains groups that carry clipping or masks, preserving the
+coordinate system and shared bounds needed by transformed and rasterized artists.
+
 ### Writing Tests
 
 - Place tests in the `tests/` directory

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -104,14 +104,15 @@ jobs:
       UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
       UV_PYTHON_INSTALL_DIR: ${{ github.workspace }}/.cache/uv-python
       UV_PYTHON_PREFERENCE: only-managed
-      TMPDIR: ${{ github.workspace }}/.cache/tmp
-      TEMP: ${{ github.workspace }}/.cache/tmp
-      TMP: ${{ github.workspace }}/.cache/tmp
     steps:
       - uses: actions/checkout@v5
 
-      - name: Prepare local temporary directory
-        run: mkdir -p "$TMPDIR"
+      - name: Prepare local test directories
+        run: |
+          mkdir -p .cache/tmp mpl-results
+          for name in TMPDIR TEMP TMP; do
+            printf '%s=%s/.cache/tmp\n' "$name" "$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+          done
 
       - name: Set up uv and Python
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -55,8 +55,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mupdf-tools
 
+      - name: Verify export renderers
+        run: |
+          mutool -v
+          google-chrome --version
+
       - name: Run tests
+        id: tests
         run: make test
+
+      - name: Upload export regression results
+        if: ${{ always() && steps.tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: export-results-linux-python-${{ matrix.python-version }}
+          path: mpl-results/export-pipeline/
+          if-no-files-found: warn
 
       - name: Run visual regression tests
         if: ${{ matrix.python-version == '3.12' }}
@@ -70,6 +84,60 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mpl-results-python-3.12
+          path: mpl-results/
+          if-no-files-found: warn
+
+  platform-smoke:
+    name: Smoke / ${{ matrix.os }} / Python 3.12
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      MPLBACKEND: Agg
+      MPLCONFIGDIR: ${{ github.workspace }}/.cache/matplotlib
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
+      UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
+      UV_PYTHON_INSTALL_DIR: ${{ github.workspace }}/.cache/uv-python
+      UV_PYTHON_PREFERENCE: only-managed
+      TMPDIR: ${{ github.workspace }}/.cache/tmp
+      TEMP: ${{ github.workspace }}/.cache/tmp
+      TMP: ${{ github.workspace }}/.cache/tmp
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Prepare local temporary directory
+        run: mkdir -p "$TMPDIR"
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Run platform smoke tests
+        id: smoke_tests
+        run: >-
+          uv run pytest --no-cov -ra
+          --basetemp=mpl-results/platform-smoke
+          tests/test_platform_smoke.py
+          tests/test_font_cache.py
+          tests/test_export_pipeline.py
+          tests/test_svg_font_weights.py
+          tests/test_svg_masks.py
+          tests/test_figure_exports.py
+
+      - name: Upload export regression results
+        if: ${{ always() && steps.smoke_tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: export-results-${{ matrix.os }}-python-3.12
           path: mpl-results/
           if-no-files-found: warn
 

--- a/src/cnsplots/_setup.py
+++ b/src/cnsplots/_setup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -45,10 +46,16 @@ def _ensure_helvetica_bold() -> None:
     except Exception:
         return
 
-    bold_ttf_path = Path.home() / ".cache" / "cnsplots" / "fonts" / "Helvetica-Bold.ttf"
     try:
-        bold_ttf_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_home = os.environ.get("XDG_CACHE_HOME", "")
+        cache_root = (
+            Path(cache_home)
+            if cache_home and Path(cache_home).is_absolute()
+            else Path.home() / ".cache"
+        )
+        bold_ttf_path = cache_root / "cnsplots" / "fonts" / "Helvetica-Bold.ttf"
         if not bold_ttf_path.exists():
+            bold_ttf_path.parent.mkdir(parents=True, exist_ok=True)
             ttc = TTCollection(str(ttc_path))
             bold_face = None
             for face in ttc.fonts:
@@ -170,6 +177,12 @@ def setup_matplotlib(
     - Math text: Custom fontset
     - Sizes: title=8pt, legend/ticks=7pt (by default)
     - Title weight: bold (by default)
+
+    On macOS, the extracted Helvetica bold face is cached under
+    ``$XDG_CACHE_HOME/cnsplots/fonts`` when ``XDG_CACHE_HOME`` is an absolute
+    path. If it is unset, empty, or relative, ``~/.cache/cnsplots/fonts`` is
+    used. If the cache is unavailable, plotting continues with the available
+    fonts without writing to another location.
 
     **Axes:**
     - Spines: Bottom and left only (top and right hidden)

--- a/src/cnsplots/_svg.py
+++ b/src/cnsplots/_svg.py
@@ -120,7 +120,7 @@ def _save_svg(
 
 def _correct_svg(input_file: str, output_file: str) -> None:
     """
-    Process an SVG file to ungroup both text elements and clipped elements.
+    Ungroup SVG text and simplify groups while preserving clipping and masks.
 
     Args:
         input_file (str): Path to the input SVG file
@@ -130,10 +130,8 @@ def _correct_svg(input_file: str, output_file: str) -> None:
     with open(input_file) as f:
         svg_content = f.read()
 
-    # note clip-path attributes and clipPath definitions are intentionally
-    # preserved so that axes clipping (e.g. from set_xlim / set_ylim) is
-    # rendered correctly.  The _flatten_groups helper propagates clip-path
-    # from parent <g> elements to their children when groups are dissolved.
+    # Keep clipping and masking groups intact so their coordinate systems and
+    # compositing remain correct for transformed children and rasterized layers.
 
     # Parse the modified SVG with lxml
     parser = etree.XMLParser(remove_blank_text=True)
@@ -148,7 +146,7 @@ def _correct_svg(input_file: str, output_file: str) -> None:
     # Preserve each element's style, including styles encoded in PDF font names.
     _normalize_text_fonts(root, ns)
 
-    # Flatten any remaining g elements
+    # Flatten groups without clipping or masks
     _flatten_groups(root, ns)
 
     # Create an ElementTree from the root element
@@ -252,16 +250,18 @@ def _prepend_transform(
 
 
 def _flatten_groups(root: _Element, ns: dict[str, str]) -> None:
-    """Flatten all group elements by moving their children to parent.
+    """Flatten groups without clipping or masking into their parent.
 
-    When a ``<g>`` carries a ``clip-path`` or ``transform`` attribute the
-    attribute is propagated to each child element so that clipping and
-    positioning remain preserved after the group is removed.
+    Transforms propagate to children when a group is removed. Clipped and masked
+    groups stay intact: moving their attributes onto transformed children would
+    change the clipping coordinates or combined-child mask bounds.
     """
     # Iteratively flatten groups until no more flattening occurs
     while True:
         # Find g elements
-        g_elements = root.xpath("//svg:g", namespaces=ns)
+        g_elements = root.xpath(
+            "//svg:g[not(@clip-path) and not(@mask)]", namespaces=ns
+        )
 
         if not g_elements:
             break
@@ -272,7 +272,6 @@ def _flatten_groups(root: _Element, ns: dict[str, str]) -> None:
             if parent is None:
                 continue
 
-            clip_path = g.get("clip-path")
             transform = g.get("transform")
 
             # Get index of g in parent
@@ -281,10 +280,6 @@ def _flatten_groups(root: _Element, ns: dict[str, str]) -> None:
             # Move all children of g to parent
             children = list(g)
             for child in children:
-                # Propagate clip-path from the group to children that
-                # don't already have their own clip-path.
-                if clip_path is not None and child.get("clip-path") is None:
-                    child.set("clip-path", clip_path)
                 child_transform = _prepend_transform(transform, child.get("transform"))
                 if child_transform is not None:
                     child.set("transform", child_transform)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -780,7 +780,9 @@ def test_svg_helpers_and_export(
     assert text_els[2].get("font-family") == "Helvetica"
     assert text_els[2].get("font-style") == "italic"
     assert text_els[3].get("font-family") is None
-    assert all(text_el.get("clip-path") == "url(#c1)" for text_el in text_els)
+    assert all(
+        text_el.getparent().get("clip-path") == "url(#c1)" for text_el in text_els
+    )
 
     svg_image_in = output_dir / "input-image.svg"
     svg_image_out = output_dir / "output-image.svg"
@@ -795,9 +797,9 @@ def test_svg_helpers_and_export(
     _svg._correct_svg(str(svg_image_in), str(svg_image_out))
     image_root = etree.parse(str(svg_image_out)).getroot()
     image_el = image_root.xpath(".//svg:image", namespaces=ns)[0]
-    assert not image_root.xpath(".//svg:g", namespaces=ns)
-    assert image_el.get("clip-path") == "url(#img-clip)"
-    assert image_el.get("transform") == "translate(10 20) scale(4)"
+    image_group = image_el.getparent()
+    assert image_group.get("clip-path") == "url(#img-clip)"
+    assert image_group.get("transform") == "translate(10 20) scale(4)"
 
     root2 = etree.fromstring(
         b'<svg xmlns="http://www.w3.org/2000/svg"><g><g><text>hello</text></g></g></svg>'

--- a/tests/test_export_pipeline.py
+++ b/tests/test_export_pipeline.py
@@ -1,0 +1,420 @@
+"""Round-trip checks of final exports, independent of platform-specific hashes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+import math
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import time
+from typing import Literal
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from lxml import etree  # ty: ignore[unresolved-import]
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import ListedColormap
+from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+from PIL import Image
+
+import cnsplots as cns
+from cnsplots import _svg
+
+
+@pytest.fixture
+def mutool(mode: str) -> str:
+    executable = shutil.which("mutool")
+    if executable is None and mode in {"pdf", "svg"}:
+        pytest.skip("MuPDF's mutool is required to round-trip PDF/SVG exports")
+    return executable or "mutool"
+
+
+def _chrome() -> str:
+    for name in ("google-chrome", "google-chrome-stable", "chromium", "chrome"):
+        executable = shutil.which(name)
+        if executable is not None:
+            return executable
+    locations = [Path("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")]
+    locations.extend(
+        Path(os.environ[root]) / "Google/Chrome/Application/chrome.exe"
+        for root in ("PROGRAMFILES", "PROGRAMFILES(X86)", "LOCALAPPDATA")
+        if root in os.environ
+    )
+    for location in locations:
+        if location.is_file():
+            return str(location)
+    pytest.skip("Chrome/Chromium is required to round-trip SVG clipping and masks")
+
+
+@contextmanager
+def _artifacts(directory: Path, name: str) -> Iterator[None]:
+    """Keep the final source, reference, rendering and difference on failures."""
+    try:
+        yield
+    except (
+        AssertionError,
+        OSError,
+        subprocess.SubprocessError,
+        pytest.fail.Exception,
+    ) as exc:
+        reference = directory / "reference.png"
+        rendered = directory / "rendered.png"
+        if reference.exists() and rendered.exists():
+            with Image.open(reference) as first, Image.open(rendered) as second:
+                size = (
+                    max(first.width, second.width),
+                    max(first.height, second.height),
+                )
+                left = Image.new("RGBA", size)
+                right = Image.new("RGBA", size)
+                left.paste(first)
+                right.paste(second)
+                delta = np.abs(
+                    np.asarray(left, dtype=int) - np.asarray(right, dtype=int)
+                )
+                difference = np.clip(delta.max(axis=2) * 4, 0, 255).astype("uint8")
+                Image.fromarray(difference).save(directory / "difference.png")
+        destination = Path("mpl-results/export-pipeline") / name
+        shutil.copytree(
+            directory,
+            destination,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("chrome-profile"),
+        )
+        raise AssertionError(
+            f"{exc}\nExport comparison artifacts: {destination}"
+        ) from exc
+
+
+def _export_and_render(
+    fig: Figure,
+    directory: Path,
+    mode: str,
+    mutool: str,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    bbox: Literal["tight"] | None = None,
+    transparent: bool = False,
+) -> np.ndarray:
+    chrome = None if mode == "pdf" else _chrome()
+    # Agg is an independent reference; it bypasses cns.savefig's PDF/SVG pipeline.
+    fig.savefig(
+        directory / "reference.png",
+        dpi=100,
+        bbox_inches=bbox,
+        pad_inches=0.1,
+        transparent=transparent,
+    )
+    suffix = "pdf" if mode == "pdf" else "svg"
+    final = directory / f"final.{suffix}"
+
+    def unavailable_converter(*args: object, **kwargs: object) -> None:
+        if mode == "svg-missing":
+            raise FileNotFoundError("mutool")
+        raise subprocess.CalledProcessError(1, ["mutool"], stderr=b"conversion failed")
+
+    # Restore subprocess.run before invoking the renderer, including fallback cases.
+    with monkeypatch.context() as patch:
+        if mode in {"svg-missing", "svg-failed"}:
+            patch.setattr(_svg.subprocess, "run", unavailable_converter)
+        current = plt.figure()
+
+        def save() -> None:
+            cns.savefig(
+                final,
+                fig=fig,
+                dpi=100,
+                bbox_inches=bbox,
+                pad_inches=0.1,
+                transparent=transparent,
+            )
+
+        if mode in {"svg-missing", "svg-failed"}:
+            with pytest.warns(RuntimeWarning, match="mutool"):
+                save()
+        else:
+            save()
+        assert plt.gcf() is current
+
+    rendered = directory / "rendered.png"
+    size = None
+    if chrome is None:
+        command = [
+            mutool,
+            "draw",
+            "-q",
+            "-r",
+            "100",
+            "-c",
+            "rgba",
+            "-o",
+            str(rendered),
+            str(final),
+        ]
+    else:
+        # MuPDF's SVG renderer ignores clipping; use a browser for final SVGs.
+        root = etree.parse(str(final)).getroot()
+        _, _, width, height = map(float, root.get("viewBox").split())
+        size = (math.ceil(width * 100 / 72), math.ceil(height * 100 / 72))
+        page = directory / "render.html"
+        page.write_text(
+            "<!doctype html><style>html,body{margin:0}img{display:block}</style>"
+            f'<img src="{final.name}" style="width:{width * 100 / 72}px;'
+            f'height:{height * 100 / 72}px">',
+            encoding="utf-8",
+        )
+        command = [
+            chrome,
+            "--headless",
+            "--disable-gpu",
+            "--hide-scrollbars",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--disable-background-networking",
+            "--force-device-scale-factor=1",
+            "--default-background-color=00000000",
+            f"--user-data-dir={directory / 'chrome-profile'}",
+            f"--window-size={max(size[0], 800)},{max(size[1], 600)}",
+            f"--screenshot={rendered}",
+            page.as_uri(),
+        ]
+    with (directory / "renderer.log").open("wb") as log:
+        if chrome is None:
+            subprocess.run(
+                command, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=30
+            )
+        else:
+            # Some Chrome builds stay alive after --screenshot completes. Reap this
+            # isolated browser as soon as a complete PNG is available.
+            with subprocess.Popen(
+                command,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=os.name == "posix",
+            ) as process:
+                deadline = time.monotonic() + 30
+                try:
+                    while time.monotonic() < deadline:
+                        if rendered.exists():
+                            try:
+                                with Image.open(rendered) as image:
+                                    image.verify()
+                                break
+                            except (OSError, SyntaxError):
+                                pass
+                        assert process.poll() is None, (
+                            "Chrome exited without a screenshot"
+                        )
+                        time.sleep(0.1)
+                    else:
+                        raise AssertionError(
+                            "Chrome did not produce a screenshot within 30s"
+                        )
+                finally:
+                    if process.poll() is None:
+                        if os.name == "posix":
+                            with suppress(ProcessLookupError):
+                                os.killpg(process.pid, signal.SIGKILL)
+                        else:
+                            subprocess.run(
+                                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                                stdout=log,
+                                stderr=subprocess.STDOUT,
+                                check=False,
+                                timeout=10,
+                            )
+                    process.wait()
+    with Image.open(rendered) as image:
+        pixels = image.convert("RGBA")
+        if size is not None:
+            # Chromium has a minimum viewport; retain just the SVG's point bounds.
+            pixels = pixels.crop((0, 0, *size))
+        pixels.save(rendered)
+        return np.asarray(pixels)
+
+
+def _assert_region(actual: np.ndarray, expected: np.ndarray) -> None:
+    """Allow antialiasing differences but detect missing, shifted or clipped shapes."""
+    assert actual.any(), "Export lost a colored region"
+    assert expected.any(), "Reference must contain the checked region"
+    actual_y, actual_x = np.nonzero(actual)
+    expected_y, expected_x = np.nonzero(expected)
+    actual_bounds = (actual_x.min(), actual_y.min(), actual_x.max(), actual_y.max())
+    expected_bounds = (
+        expected_x.min(),
+        expected_y.min(),
+        expected_x.max(),
+        expected_y.max(),
+    )
+    assert actual_bounds == pytest.approx(expected_bounds, abs=2)
+    # A one-pixel antialiased border can cover >8% of a narrow colorbar.
+    perimeter = 2 * (
+        expected_x.max() - expected_x.min() + expected_y.max() - expected_y.min()
+    )
+    assert actual.sum() == pytest.approx(expected.sum(), abs=perimeter)
+
+
+@pytest.mark.parametrize("mode", ["pdf", "svg", "svg-missing", "svg-failed"])
+@pytest.mark.parametrize("tight_transparent", [False, True])
+def test_exported_bounds_clipping_transparency_and_raster_layers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutool: str,
+    mode: str,
+    tight_transparent: bool,
+) -> None:
+    with (
+        plt.rc_context({"savefig.bbox": None}),
+        _artifacts(tmp_path, f"geometry-{mode}-{tight_transparent}"),
+    ):
+        fig = plt.figure(figsize=(3, 2), dpi=100)
+        ax = fig.add_axes((0.2, 0.2, 0.6, 0.6))
+        ax.set(xlim=(0, 1), ylim=(0, 1))
+        ax.set_axis_off()
+        ax.add_patch(Rectangle((-0.5, 0.1), 2, 0.3, color="red", alpha=0.5, lw=0))
+        ax.scatter(
+            [0.25, 0.75],
+            [0.75, 0.75],
+            s=225,
+            marker="s",
+            color="blue",
+            linewidth=0,
+            rasterized=True,
+        )
+        actual = _export_and_render(
+            fig,
+            tmp_path,
+            mode,
+            mutool,
+            monkeypatch,
+            bbox="tight" if tight_transparent else None,
+            transparent=tight_transparent,
+        )
+        with Image.open(tmp_path / "reference.png") as image:
+            expected = np.asarray(image.convert("RGBA"))
+
+        # The tight bbox is the 1.8 x 1.2 inch axes plus 0.1 inch padding per side.
+        expected_size = (200, 140) if tight_transparent else (300, 200)
+        assert actual.shape[1::-1] == pytest.approx(expected_size, abs=1)
+        assert actual[0, 0, 3] == (0 if tight_transparent else 255)
+        if tight_transparent:
+            # The rasterized collection's gap must retain its transparency mask.
+            assert actual[40, 100, 3] == 0
+
+        for channel in (0, 2):
+
+            def colored(pixels: np.ndarray) -> np.ndarray:
+                rgb = pixels[:, :, :3].astype(int)
+                others = np.delete(rgb, channel, axis=2).max(axis=2)
+                return (rgb[:, :, channel] - others > 80) & (pixels[:, :, 3] > 90)
+
+            actual_mask, expected_mask = colored(actual), colored(expected)
+            _assert_region(actual_mask, expected_mask)
+            expected_alpha = 128 if channel == 0 and tight_transparent else 255
+            assert np.median(actual[:, :, 3][actual_mask]) == pytest.approx(
+                expected_alpha, abs=2
+            )
+
+        final = tmp_path / ("final.pdf" if mode == "pdf" else "final.svg")
+        content = final.read_bytes()
+        assert (b"/Subtype /Image" if mode == "pdf" else b"<image") in content
+
+
+@pytest.mark.parametrize("mode", ["pdf", "svg", "svg-missing", "svg-failed"])
+def test_exported_multipanel_helper_axes_keep_their_layout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutool: str,
+    mode: str,
+) -> None:
+    with (
+        plt.rc_context(),
+        cns.settings.context(figure_dpi=100, font_sans_serif=("DejaVu Sans",)),
+        _artifacts(tmp_path, f"multipanel-{mode}"),
+    ):
+        mp = cns.multipanel(max_width=360)
+        ax = mp.panel("A", width=100, height=80, margin_right=30)
+        assert mp.fig is not None
+        ax.imshow([[0, 1], [0, 1]], cmap=ListedColormap(["red", "blue"]), aspect="auto")
+        ax.set(xticks=[], yticks=[])
+        cax = make_axes_locatable(ax).append_axes("right", size="12%", pad=0.05)
+        mp.fig.colorbar(
+            ScalarMappable(cmap=ListedColormap(["lime", "magenta"])), cax=cax
+        )
+        cax.set_yticks([])
+        inset = ax.inset_axes((0.15, 0.2, 0.25, 0.3))
+        inset.set(xticks=[], yticks=[])
+        inset.set_facecolor("cyan")
+        second = mp.panel("B", width=90, height=80)
+        second.set(xticks=[], yticks=[])
+        second.set_facecolor("orange")
+        mp.fig.canvas.draw()
+        mp.fig.canvas.draw()
+
+        actual = _export_and_render(
+            mp.fig, tmp_path, mode, mutool, monkeypatch, bbox="tight"
+        )
+        with Image.open(tmp_path / "reference.png") as image:
+            expected = np.asarray(image.convert("RGBA"))
+        assert actual.shape[:2] == pytest.approx(expected.shape[:2], abs=1)
+        for color in (
+            (255, 0, 0),
+            (0, 0, 255),
+            (0, 255, 0),
+            (255, 0, 255),
+            (0, 255, 255),
+            (255, 165, 0),
+        ):
+            actual_mask = (
+                np.max(np.abs(actual[:, :, :3].astype(int) - color), axis=2) < 25
+            )
+            expected_mask = (
+                np.max(np.abs(expected[:, :, :3].astype(int) - color), axis=2) < 25
+            )
+            _assert_region(actual_mask, expected_mask)
+
+
+@pytest.mark.parametrize("mode", ["pdf", "svg", "svg-missing", "svg-failed"])
+def test_exported_repeated_text_keeps_distinct_font_weights(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutool: str,
+    mode: str,
+) -> None:
+    with (
+        plt.rc_context(
+            {"pdf.fonttype": 42, "svg.fonttype": "none", "savefig.bbox": None}
+        ),
+        _artifacts(tmp_path, f"text-{mode}"),
+    ):
+        fig = plt.figure(figsize=(2.5, 2), dpi=100)
+        for index, (family, weight) in enumerate(
+            [
+                (family, weight)
+                for family in ("DejaVu Sans", "DejaVu Serif")
+                for weight in ("normal", "bold")
+            ]
+        ):
+            fig.text(
+                0.1,
+                0.875 - index * 0.25,
+                "SAME",
+                va="center",
+                fontsize=18,
+                family=family,
+                weight=weight,
+            )
+        actual = _export_and_render(fig, tmp_path, mode, mutool, monkeypatch)
+        # Integrate ink rather than comparing glyph pixels across font renderers.
+        ink = (255 - actual[:, :, :3].mean(axis=2)) / 255
+        row_ink = [region.sum() for region in np.array_split(ink, 4)]
+        assert all(amount > 100 for amount in row_ink)
+        assert row_ink[1] > row_ink[0] * 1.1
+        assert row_ink[3] > row_ink[2] * 1.1

--- a/tests/test_font_cache.py
+++ b/tests/test_font_cache.py
@@ -1,0 +1,150 @@
+"""Tests for the cache used to register the macOS Helvetica bold face."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+import fontTools.ttLib
+import pytest
+
+from cnsplots import _setup
+
+
+@pytest.fixture
+def font_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Mock, Mock]:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(_setup, "_HELVETICA_BOLD_REGISTERED", False)
+    monkeypatch.setattr(_setup.sys, "platform", "darwin")
+    real_exists = Path.exists
+    monkeypatch.setattr(
+        Path,
+        "exists",
+        lambda path: (
+            path == Path("/System/Library/Fonts/Helvetica.ttc") or real_exists(path)
+        ),
+    )
+
+    manager = Mock(ttflist=[])
+    manager.addfont.side_effect = lambda path: manager.ttflist.append(
+        SimpleNamespace(name="Helvetica", weight=700)
+    )
+    monkeypatch.setattr(_setup.fm, "fontManager", manager)
+    face = MagicMock()
+    face["name"].getDebugName.side_effect = ["Helvetica", "Bold"]
+    face.save.side_effect = lambda path: Path(path).write_bytes(b"cached bold font")
+    collection = Mock(return_value=Mock(fonts=[face]))
+    monkeypatch.setattr(fontTools.ttLib, "TTCollection", collection)
+    return collection, manager
+
+
+def test_helvetica_extraction_uses_configured_cache_only(
+    font_cache: tuple[Mock, Mock], tmp_path: Path
+) -> None:
+    collection, manager = font_cache
+
+    _setup._ensure_helvetica_bold()
+
+    font_path = tmp_path / "cache/cnsplots/fonts/Helvetica-Bold.ttf"
+    assert font_path.read_bytes() == b"cached bold font"
+    assert list(tmp_path.iterdir()) == [tmp_path / "cache"]
+    collection.assert_called_once_with(str(Path("/System/Library/Fonts/Helvetica.ttc")))
+    manager.addfont.assert_called_once_with(str(font_path))
+    assert _setup._HELVETICA_BOLD_REGISTERED
+
+    _setup._ensure_helvetica_bold()
+    manager.addfont.assert_called_once()
+
+
+@pytest.mark.parametrize("cache_home", [None, "", "relative/cache"])
+def test_helvetica_default_cache(
+    font_cache: tuple[Mock, Mock],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    cache_home: str | None,
+) -> None:
+    if cache_home is None:
+        monkeypatch.delenv("XDG_CACHE_HOME")
+    else:
+        monkeypatch.setenv("XDG_CACHE_HOME", cache_home)
+
+    _setup._ensure_helvetica_bold()
+
+    font_path = tmp_path / "home/.cache/cnsplots/fonts/Helvetica-Bold.ttf"
+    assert font_path.read_bytes() == b"cached bold font"
+    assert list(tmp_path.iterdir()) == [tmp_path / "home"]
+    font_cache[1].addfont.assert_called_once_with(str(font_path))
+
+
+def test_helvetica_reuses_cached_font_without_writing(
+    font_cache: tuple[Mock, Mock], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    font_path = tmp_path / "cache/cnsplots/fonts/Helvetica-Bold.ttf"
+    font_path.parent.mkdir(parents=True)
+    font_path.write_bytes(b"existing font")
+    mkdir = Mock(side_effect=PermissionError("read-only cache"))
+    monkeypatch.setattr(Path, "mkdir", mkdir)
+
+    _setup._ensure_helvetica_bold()
+
+    mkdir.assert_not_called()
+    font_cache[0].assert_not_called()
+    font_cache[1].addfont.assert_called_once_with(str(font_path))
+    assert font_path.read_bytes() == b"existing font"
+    assert _setup._HELVETICA_BOLD_REGISTERED
+
+
+@pytest.mark.parametrize("failure", ["unavailable", "mkdir", "save"])
+def test_helvetica_unwritable_cache_does_not_fall_back(
+    font_cache: tuple[Mock, Mock],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    if failure == "unavailable":
+        (tmp_path / "cache").write_text("not a directory")
+    elif failure == "mkdir":
+        monkeypatch.setattr(
+            Path, "mkdir", Mock(side_effect=PermissionError("read-only cache"))
+        )
+    else:
+        font_cache[0].return_value.fonts[0].save.side_effect = PermissionError(
+            "read-only font directory"
+        )
+
+    _setup._ensure_helvetica_bold()
+
+    font_cache[1].addfont.assert_not_called()
+    assert not _setup._HELVETICA_BOLD_REGISTERED
+    assert not (tmp_path / "home").exists()
+    assert not (tmp_path / "cache/cnsplots/fonts/Helvetica-Bold.ttf").exists()
+
+
+def test_helvetica_unavailable_home_is_graceful(
+    font_cache: tuple[Mock, Mock], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("XDG_CACHE_HOME")
+    monkeypatch.setattr(Path, "home", Mock(side_effect=RuntimeError("no home")))
+
+    _setup._ensure_helvetica_bold()
+
+    font_cache[0].assert_not_called()
+    font_cache[1].addfont.assert_not_called()
+    assert not _setup._HELVETICA_BOLD_REGISTERED
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize("platform", ["linux", "win32"])
+def test_helvetica_non_macos_does_not_create_cache(
+    font_cache: tuple[Mock, Mock],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    platform: str,
+) -> None:
+    monkeypatch.setattr(_setup.sys, "platform", platform)
+
+    _setup._ensure_helvetica_bold()
+
+    font_cache[0].assert_not_called()
+    font_cache[1].addfont.assert_not_called()
+    assert not list(tmp_path.iterdir())

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -158,6 +158,7 @@ def test_multipanel_calculate_layout_wraps_to_new_row() -> None:
 def test_setup_internal_coverage(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
     real_import = builtins.__import__
     real_exists = Path.exists
 

--- a/tests/test_platform_smoke.py
+++ b/tests/test_platform_smoke.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from lxml import etree  # ty: ignore[unresolved-import]
+from matplotlib import font_manager as fm
+
+import cnsplots as cns
+from cnsplots import _setup
+
+
+@pytest.mark.parametrize("format", ["png", "pdf", "svg"])
+def test_portable_plot_exports_with_font_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, format: str
+) -> None:
+    # Exercise a real failed executable lookup even on hosts with mutool installed.
+    monkeypatch.setenv("PATH", str(tmp_path))
+    before_rc = mpl.rcParams.copy()
+    before_settings = repr(cns.settings)
+    with cns.settings.context(
+        font_family="sans-serif",
+        font_sans_serif=("Cnsplots Missing Smoke Font", "DejaVu Sans"),
+        svg_fonttype="none",
+        pdf_fonttype=42,
+    ):
+        fig = cns.figure(width=216, height=144)
+        data = pd.DataFrame({"x": [0, 1, 2], "y": [0, 2, 1]})
+        ax = cns.scatterplot(data=data, x="x", y="y")
+        ax.plot(data["x"], data["y"], label="Series")
+        ax.set_title("Portable export")
+        ax.legend()
+        assert ax.figure is fig
+        np.testing.assert_array_equal(ax.collections[0].get_offsets(), data.values)
+        for weight in ("normal", "bold"):
+            resolved = fm.findfont(
+                fm.FontProperties(family="sans-serif", weight=weight),
+                fallback_to_default=False,
+            )
+            assert Path(resolved).is_file()
+            assert fm.FontProperties(fname=resolved).get_name() == "DejaVu Sans"
+
+        path = tmp_path / f"portable.{format}"
+        if format == "svg":
+            with pytest.warns(
+                RuntimeWarning,
+                match="mutool.*unavailable; saved a standard matplotlib SVG",
+            ) as warnings:
+                cns.savefig(path, fig=fig, dpi=96, bbox_inches=None)
+            assert len(warnings) == 1
+        else:
+            cns.savefig(path, fig=fig, dpi=96, bbox_inches=None)
+
+        if format == "png":
+            pixels = plt.imread(path)
+            assert pixels.shape == (192, 288, 4)
+            assert np.any(pixels[:, :, 3] > 0)
+            assert np.any(pixels[:, :, :3] < 0.5)
+        elif format == "pdf":
+            content = path.read_bytes()
+            assert content.startswith(b"%PDF-")
+            assert b"%%EOF" in content
+            media_box = re.search(rb"/MediaBox\s*\[([^]]+)\]", content)
+            assert media_box is not None
+            assert [float(value) for value in media_box[1].split()] == [0, 0, 216, 144]
+            assert b"/FontFile2" in content
+        else:
+            root = etree.parse(str(path)).getroot()
+            assert root.tag == "{http://www.w3.org/2000/svg}svg"
+            assert [float(value) for value in root.get("viewBox").split()] == [
+                0,
+                0,
+                216,
+                144,
+            ]
+            texts = root.xpath(
+                "//svg:text", namespaces={"svg": "http://www.w3.org/2000/svg"}
+            )
+            labels = ["".join(text.itertext()) for text in texts]
+            assert "Portable export" in labels
+            assert "Series" in labels
+            assert root.xpath(
+                "//svg:path", namespaces={"svg": "http://www.w3.org/2000/svg"}
+            )
+
+    assert mpl.rcParams == before_rc
+    assert repr(cns.settings) == before_settings
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin"
+    or not Path("/System/Library/Fonts/Helvetica.ttc").is_file(),
+    reason="Native macOS Helvetica collection is unavailable",
+)
+def test_native_macos_helvetica_extraction_uses_xdg_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_home = tmp_path / "fresh-cache"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache_home))
+    manager = fm.FontManager()
+    manager.ttflist = [
+        font
+        for font in manager.ttflist
+        if not (font.name == "Helvetica" and int(font.weight) >= 700)
+    ]
+    monkeypatch.setattr(fm, "fontManager", manager)
+    monkeypatch.setattr(_setup, "_HELVETICA_BOLD_REGISTERED", False)
+
+    with cns.settings.context():
+        cns.setup_matplotlib()
+        cached_font = cache_home / "cnsplots" / "fonts" / "Helvetica-Bold.ttf"
+        assert cached_font.is_file()
+        resolved = manager.findfont(
+            fm.FontProperties(family="Helvetica", weight="bold"),
+            fallback_to_default=False,
+        )
+        assert Path(resolved).resolve() == cached_font.resolve()
+        assert fm.FontProperties(fname=resolved).get_name() == "Helvetica"
+        assert _setup._HELVETICA_BOLD_REGISTERED

--- a/tests/test_svg_masks.py
+++ b/tests/test_svg_masks.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from lxml import etree  # ty: ignore[unresolved-import]
+
+from cnsplots import _svg
+
+
+def test_svg_cleanup_preserves_nested_group_masks(tmp_path: Path) -> None:
+    source = tmp_path / "source.svg"
+    output = tmp_path / "output.svg"
+    source.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg">'
+        '<defs><mask id="outer"><rect width="100" height="100" fill="white"/>'
+        '</mask><mask id="inner"><circle r="10" fill="white"/></mask></defs>'
+        '<g transform="translate(10 20)"><g mask="url(#outer)">'
+        '<rect width="20" height="20"/>'
+        '<g mask="url(#inner)"><g transform="scale(2)">'
+        '<image width="10" height="10"/>'
+        "</g></g></g></g></svg>",
+        encoding="utf-8",
+    )
+
+    _svg._correct_svg(str(source), str(output))
+
+    root = etree.parse(str(output))
+    ns = {"svg": "http://www.w3.org/2000/svg"}
+    outer, inner = root.xpath("//svg:g", namespaces=ns)
+    assert outer.get("mask") == "url(#outer)"
+    assert outer.get("transform") == "translate(10 20)"
+    assert inner.get("mask") == "url(#inner)"
+    assert inner.getparent() is outer
+    assert len(outer) == 2  # The outer mask still covers both siblings together.
+    image = inner.find("svg:image", namespaces=ns)
+    assert image is not None
+    assert image.get("transform") == "scale(2)"


### PR DESCRIPTION
## What changed

Keep font extraction within the configured cache and catch defects in the files produced by the complete export pipeline.

- Honor absolute `XDG_CACHE_HOME` for extracted Helvetica fonts, document the existing home-cache fallback, reuse cached fonts without writes, and handle unavailable caches without writing elsewhere.
- Preserve SVG groups carrying clips or masks so transformed images keep their clipping coordinates and rasterized layers retain their transparency, including nested masks.
- Add final PDF/SVG rendering checks for repeated text with distinct font weights, mixed fonts, bounds, clipping, transparency, rasterized layers, and multipanel helper axes. Exercise successful, missing, and failed SVG converters and retain comparison artifacts on failure.
- Add focused macOS and Windows Python 3.12 smoke jobs covering real plot output, font fallback, and native macOS extraction. Initialize temporary and artifact directories before setting temporary-path overrides. Keep the existing Linux visual-hash environment unchanged.

## How it was tested

- `make test` — 1,574 passed, 100% coverage on macOS.
- `make lint` — all required hooks passed.
- Ran the workflow bootstrap and all 91 smoke cases successfully from a fresh directory on macOS.
- [GitHub CI passed](https://github.com/faridrashidi/cnsplots/actions/runs/34137691187) on commit `3cb2ac6`, including the macOS/Windows smoke jobs, full Python matrix, visual checks, lint, documentation, and packaging.
- The 16 final-file rendering cases passed with actual MuPDF and Chrome, and native macOS Helvetica extraction/resolution passed.
- Confirmed the new regression fixtures fail before the SVG mask/clipping fixes and pass afterward.

## Risks or follow-ups

Clipped and masked SVG groups intentionally remain grouped to preserve geometry and compositing. Rendering checks use semantic tolerances; exact pixel hashes remain confined to the existing pinned Linux job. Optional renderer and native-font requirements produce explicit skips when unavailable. No package dependencies were added.

## Related issues

Closes #151
Closes #169
Closes #176
