### PR TITLE
🧑‍💻 Separate documentation and development workflows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -109,7 +109,19 @@ cd cnsplots
 make install
 ```
 
-This uses `uv sync --extra dev` to install the package in editable mode with all dependencies, and sets up pre-commit hooks.
+This uses `uv sync --locked --extra dev` to install the package in editable mode with all development tools, and sets up pre-commit hooks. The `dev` extra combines the focused extras below and remains available to pip users as `pip install -e '.[dev]'`.
+
+For a smaller environment, select the extra needed for your task:
+
+| Extra | Install command | Tools |
+| --- | --- | --- |
+| `test` | `uv sync --locked --extra test` | pytest, coverage, visual regression tools, and Sphinx-Gallery for documentation extension tests |
+| `docs` | `uv sync --locked --extra docs` | Sphinx, themes, extensions, and gallery example dependencies |
+| `lint` | `uv sync --locked --extra lint` | pre-commit, ty, and test dependencies required for type checking |
+| `notebook` | `uv sync --locked --extra notebook` | IPython kernel |
+| `release` | `uv sync --locked --extra release` | bump-my-version |
+
+All extras include the package's runtime dependencies. `uv sync` selects an exact environment; repeat `--extra` to combine extras or run `make install` to restore the full setup. Make targets select their required extra automatically and use the committed lockfile. After changing dependencies, run `uv lock` and include the updated `uv.lock` in your PR.
 
 ### Development Commands
 
@@ -120,9 +132,13 @@ After installation, you can use the following commands:
 | `make help`                          | Show available commands                |
 | `make lint`                          | Run linting and formatting             |
 | `make test`                          | Run all unit tests                     |
-| `make doc`                           | Build and serve documentation          |
+| `make doc`                           | Build documentation and exit           |
+| `make doc-serve`                     | Build and preview documentation on port 8080 |
+| `make doc-linkcheck`                 | Check documentation links              |
 | `make release [patch\|minor\|major]` | Bump the package version for a release |
 | `make clean`                         | Clean build artifacts                  |
+
+`make doc` now exits with the build status locally and in CI; `CI=true make doc` remains valid. To use the previous build-and-preview workflow, run `make doc-serve`, open `http://localhost:8080`, and press Ctrl+C to stop the server. Documentation builds clean only `docs/build`, stage generated sources there, and preserve unrelated coverage, test, and package-build artifacts. To remove generated documentation output explicitly, use `make -C docs clean`.
 
 ### 3. Verify Installation
 
@@ -199,7 +215,7 @@ Missing and failed SVG conversion paths are also tested, including when `mutool`
 is absent but Chrome is available.
 
 ```bash
-uv run pytest tests/test_export_pipeline.py tests/test_svg_font_weights.py --no-cov
+uv run --locked --extra test pytest tests/test_export_pipeline.py tests/test_svg_font_weights.py --no-cov
 ```
 
 The suite checks bounds, clipped geometry, alpha, rasterized layers, multipanel

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Sync docs dependencies
-        run: uv sync --locked --extra dev
+        run: uv sync --locked --extra docs
       - name: Prepare multiversion refs
         run: |
           git fetch --force --tags origin +refs/heads/main:refs/remotes/origin/main
@@ -43,7 +43,7 @@ jobs:
           fi
       - name: Verify docs font
         run: |
-          uv run python - <<'PY'
+          uv run --locked --extra docs python - <<'PY'
           import matplotlib as mpl
 
           import cnsplots as cns
@@ -72,13 +72,13 @@ jobs:
           PY
       - name: Check documentation links
         run: |
-          uv run python docs/_scripts/build_versioned_docs.py \
+          uv run --locked --extra docs python docs/_scripts/build_versioned_docs.py \
             --builder linkcheck \
             site-build-linkcheck/output
       - name: Build versioned documentation
         run: |
           rm -rf site-build
-          uv run python docs/_scripts/build_versioned_docs.py \
+          uv run --locked --extra docs python docs/_scripts/build_versioned_docs.py \
             --mode "${DOCS_BUILD_MODE}" \
             site-build
       - name: Publish to gh-pages

--- a/.github/workflows/ci-latest-dependencies.yml
+++ b/.github/workflows/ci-latest-dependencies.yml
@@ -38,4 +38,7 @@ jobs:
           sudo apt-get install -y mupdf-tools
 
       - name: Run tests
+        # Test the upgraded environment without re-resolving with default options.
+        env:
+          UV_NO_SYNC: "1"
         run: make test

--- a/.github/workflows/ci-latest-dependencies.yml
+++ b/.github/workflows/ci-latest-dependencies.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Sync latest dependencies
         # Avoid pairing prerelease Numba with an unsupported NumPy release.
-        run: uv sync --upgrade --extra dev --prerelease-package numba=disallow
+        run: uv sync --upgrade --extra test --prerelease-package numba=disallow
 
       - name: Install mutool
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Sync dependencies
-        run: uv sync --locked --extra dev
+        run: uv sync --locked --extra lint
 
       - name: Run lint
         run: make lint
@@ -48,7 +48,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Sync dependencies
-        run: uv sync --locked --extra dev
+        run: uv sync --locked --extra test
 
       - name: Install mutool
         run: |
@@ -120,12 +120,12 @@ jobs:
           python-version: "3.12"
 
       - name: Sync dependencies
-        run: uv sync --locked --extra dev
+        run: uv sync --locked --extra test
 
       - name: Run platform smoke tests
         id: smoke_tests
         run: >-
-          uv run pytest --no-cov -ra
+          uv run --locked --extra test pytest --no-cov -ra
           --basetemp=mpl-results/platform-smoke
           tests/test_platform_smoke.py
           tests/test_font_cache.py
@@ -159,7 +159,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Sync dependencies
-        run: uv sync --locked --extra dev
+        run: uv sync --locked --extra docs
 
       - name: Build docs
         run: make doc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        entry: uv run --with ty ty check .
+        entry: uv run --locked --extra lint ty check .
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ help:
 	@echo " - test         : run all unit tests"
 	@echo " - test-visual  : run visual regression tests"
 	@echo " - doc          : build the documentation"
+	@echo " - doc-serve    : build and serve documentation on port 8080"
 	@echo " - doc-linkcheck: check documentation links"
-	@echo " - install      : install the package"
+	@echo " - install      : install the full development environment and hooks"
 	@echo " - release      : bump version with [patch|minor|major]"
 
 clean:
@@ -33,33 +34,36 @@ clean:
 	rm -rf tests/__pycache__
 
 lint:
-	uv run pre-commit run --all-files
+	uv run --locked --extra lint pre-commit run --all-files
 
 test:
-	uv run pytest ./tests
+	uv run --locked --extra test pytest ./tests
 
 test-visual:
-	uv run pytest tests/test_visual_regressions.py --mpl --no-cov
+	uv run --locked --extra test pytest tests/test_visual_regressions.py --mpl --no-cov
 
-doc: clean
+.PHONY: doc doc-serve doc-linkcheck
+
+doc:
+	$(MAKE) -C docs clean
 	cd docs && $(MAKE) html
-ifneq ($(CI),true)
-	cd docs/build/html && python -m http.server 8080
-endif
+
+doc-serve: doc
+	uv run --locked --extra docs python -m http.server 8080 --directory docs/build/html
 
 doc-linkcheck:
 	cd docs && $(MAKE) linkcheck
 
 install:
-	uv sync --extra dev
-	uv run pre-commit install
+	uv sync --locked --extra dev
+	uv run --locked --extra lint pre-commit install
 
 release:
 	@if [ "$(words $(RELEASE_ARGS))" -ne 1 ] || [ -n "$(filter-out $(VALID_RELEASE_PARTS),$(RELEASE_ARGS))" ]; then \
 		echo "usage: make release [patch|minor|major]"; \
 		exit 1; \
 	fi
-	uv run bump-my-version bump $(RELEASE_ARGS)
+	uv run --locked --extra release bump-my-version bump $(RELEASE_ARGS)
 
 patch minor major:
 	@:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,9 +4,9 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-# Run Sphinx through uv so `make html` uses the project's development extra.
-SPHINXBUILD   ?= uv run --extra dev sphinx-build
-STAGEDBUILD   ?= uv run --extra dev python _scripts/build_versioned_docs.py
+# Run Sphinx through uv so `make html` uses the project's documentation extra.
+SPHINXBUILD   ?= uv run --locked --extra docs sphinx-build
+STAGEDBUILD   ?= uv run --locked --extra docs python _scripts/build_versioned_docs.py
 SOURCEDIR     = .
 BUILDDIR      = build
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -125,9 +125,19 @@ cd cnsplots
 make install
 ```
 
-This uses `uv sync --extra dev` to install the package in editable mode with
-the project's development and documentation extras, and sets up pre-commit
-hooks.
+This uses `uv sync --locked --extra dev` to install the package in editable mode
+with all development tools, and sets up pre-commit hooks. The `dev` extra combines
+the `test`, `docs`, `lint`, `notebook`, and `release` extras.
+
+For a focused environment, use `uv sync --locked --extra test` for tests or
+`uv sync --locked --extra docs` for documentation. Repeat `--extra` to combine
+extras, or run `make install` to restore the full development setup. Make targets
+select their required extra automatically and use the committed `uv.lock`.
+
+`make doc` builds the documentation and exits with the build status. Use
+`make doc-serve` to build and start the preview at `http://localhost:8080`;
+press Ctrl+C to stop it. Documentation builds preserve unrelated test and build
+artifacts.
 
 ## Dependencies
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -5,10 +5,10 @@ pushd %~dp0
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=uv run --extra dev sphinx-build
+	set SPHINXBUILD=uv run --locked --extra docs sphinx-build
 )
 if "%STAGEDBUILD%" == "" (
-	set STAGEDBUILD=uv run --extra dev python _scripts/build_versioned_docs.py
+	set STAGEDBUILD=uv run --locked --extra docs python _scripts/build_versioned_docs.py
 )
 set SOURCEDIR=.
 set BUILDDIR=build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,15 +55,20 @@ Repository = "https://github.com/faridrashidi/cnsplots"
 cnsplots = "cnsplots._cli:main"
 
 [project.optional-dependencies]
-dev = [
-  "bump-my-version",
+dev = ["cnsplots[test,docs,lint,notebook,release]"]
+test = [
   "fastcluster",
-  "glasbey",
-  "ipykernel",
-  "pre-commit",
   "pytest",
   "pytest-cov",
   "pytest-mpl>=0.19,<0.20",
+  # The documentation extension tests import Sphinx-Gallery and docutils.
+  "sphinx<9; python_version < '3.11'",
+  "sphinx>=9,<9.1; python_version >= '3.11'",
+  "sphinx-gallery",
+]
+docs = [
+  "fastcluster",
+  "glasbey",
   "furo",
   "myst-parser",
   "sphinx<9; python_version < '3.11'",
@@ -75,6 +80,9 @@ dev = [
   "sphinx-multiversion",
   "sphinx-sitemap",
 ]
+lint = ["cnsplots[test]", "pre-commit", "ty"]
+notebook = ["ipykernel"]
+release = ["bump-my-version"]
 
 [build-system]
 requires = ["setuptools>=77.0.3"]

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt" or shutil.which("make") is None,
+    reason="Makefile tests require make and a POSIX shell",
+)
+
+
+@pytest.fixture
+def docs_repo(tmp_path: Path) -> Path:
+    shutil.copyfile(
+        Path(__file__).resolve().parents[1] / "Makefile", tmp_path / "Makefile"
+    )
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "Makefile").write_text(
+        ".PHONY: html clean\n"
+        "clean:\n"
+        "\trm -rf build\n"
+        "html:\n"
+        "\tmkdir -p build/html\n"
+        "\tprintf 'built documentation\\n' > build/html/index.html\n",
+        encoding="utf-8",
+    )
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name in ("uv", "python"):
+        command = bin_dir / name
+        command.write_text(
+            "#!/bin/sh\n"
+            'printf "%s\\n" "$@" > "$CNSPLOTS_TEST_ROOT/preview-args"\n'
+            'test -f "$CNSPLOTS_TEST_ROOT/docs/build/html/index.html"\n',
+            encoding="utf-8",
+        )
+        command.chmod(0o755)
+    return tmp_path
+
+
+def _run_make(
+    repo_root: Path, target: str, ci: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("CI", None)
+    if ci is not None:
+        env["CI"] = ci
+    env["PATH"] = str(repo_root / "bin") + os.pathsep + env.get("PATH", "")
+    env["CNSPLOTS_TEST_ROOT"] = str(repo_root)
+    return subprocess.run(
+        ["make", target],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("ci", [None, "true"])
+def test_doc_build_exits_and_refreshes_only_docs_output(
+    docs_repo: Path, ci: str | None
+) -> None:
+    artifacts = (
+        ".coverage",
+        ".coverage.previous",
+        "coverage.xml",
+        "htmlcov/index.html",
+        ".pytest_cache/sentinel",
+        "tests/__pycache__/sentinel",
+        "build/sentinel",
+        "dist/sentinel",
+    )
+    for relative_path in artifacts:
+        artifact = docs_repo / relative_path
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("preserve me", encoding="utf-8")
+    obsolete_page = docs_repo / "docs/build/html/obsolete.html"
+    obsolete_page.parent.mkdir(parents=True)
+    obsolete_page.write_text("obsolete documentation", encoding="utf-8")
+
+    result = _run_make(docs_repo, "doc", ci)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (docs_repo / "docs/build/html/index.html").read_text() == (
+        "built documentation\n"
+    )
+    assert not obsolete_page.exists()
+    assert not (docs_repo / "preview-args").exists()
+    for relative_path in artifacts:
+        assert (docs_repo / relative_path).read_text() == "preserve me"
+
+
+@pytest.mark.parametrize("target", ["doc", "doc-serve"])
+def test_docs_build_failure_propagates_without_serving(
+    docs_repo: Path, target: str
+) -> None:
+    (docs_repo / "docs/Makefile").write_text(
+        ".PHONY: html clean\n"
+        "clean:\n"
+        "\trm -rf build\n"
+        "html:\n"
+        "\tprintf 'documentation build failed\\n' >&2\n"
+        "\texit 7\n",
+        encoding="utf-8",
+    )
+
+    result = _run_make(docs_repo, target)
+
+    assert result.returncode != 0
+    assert "documentation build failed" in result.stderr
+    assert not (docs_repo / "preview-args").exists()
+
+
+def test_doc_serve_starts_preview_after_build(docs_repo: Path) -> None:
+    result = _run_make(docs_repo, "doc-serve")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    args = (docs_repo / "preview-args").read_text().splitlines()
+    assert args[args.index("python") :] == [
+        "python",
+        "-m",
+        "http.server",
+        "8080",
+        "--directory",
+        "docs/build/html",
+    ]

--- a/tests/test_palette_registry.py
+++ b/tests/test_palette_registry.py
@@ -237,11 +237,12 @@ def test_builtin_palette_results_are_independent(name: str) -> None:
 def test_builtin_colormap_results_are_independent(name: str) -> None:
     palette = cns.palettes(name)
     assert isinstance(palette, Colormap)
-    palette.set_bad("red")
+    palette.name = "Modified palette"
 
     fresh = cns.palettes(name)
     assert isinstance(fresh, Colormap)
     assert fresh is not palette
+    assert fresh.name == name
     assert fresh(np.nan) == (0.0, 0.0, 0.0, 0.0)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -536,6 +536,50 @@ dev = [
     { name = "sphinx-gallery" },
     { name = "sphinx-multiversion" },
     { name = "sphinx-sitemap" },
+    { name = "ty" },
+]
+docs = [
+    { name = "fastcluster" },
+    { name = "furo" },
+    { name = "glasbey" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-copybutton" },
+    { name = "sphinx-design", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx-design", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-gallery" },
+    { name = "sphinx-multiversion" },
+    { name = "sphinx-sitemap" },
+]
+lint = [
+    { name = "fastcluster" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mpl" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-gallery" },
+    { name = "ty" },
+]
+notebook = [
+    { name = "ipykernel" },
+]
+release = [
+    { name = "bump-my-version" },
+]
+test = [
+    { name = "fastcluster" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mpl" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-gallery" },
 ]
 
 [package.metadata]
@@ -543,46 +587,53 @@ requires-dist = [
     { name = "adjusttext" },
     { name = "anndata" },
     { name = "biopython" },
-    { name = "bump-my-version", marker = "extra == 'dev'" },
+    { name = "bump-my-version", marker = "extra == 'release'" },
+    { name = "cnsplots", extras = ["test"], marker = "extra == 'lint'" },
+    { name = "cnsplots", extras = ["test", "docs", "lint", "notebook", "release"], marker = "extra == 'dev'" },
     { name = "comprisk", specifier = ">=0.7,<0.9" },
-    { name = "fastcluster", marker = "extra == 'dev'" },
-    { name = "furo", marker = "extra == 'dev'" },
-    { name = "glasbey", marker = "extra == 'dev'" },
+    { name = "fastcluster", marker = "extra == 'docs'" },
+    { name = "fastcluster", marker = "extra == 'test'" },
+    { name = "furo", marker = "extra == 'docs'" },
+    { name = "glasbey", marker = "extra == 'docs'" },
     { name = "gseapy" },
-    { name = "ipykernel", marker = "extra == 'dev'" },
+    { name = "ipykernel", marker = "extra == 'notebook'" },
     { name = "lifelines", specifier = ">=0.30" },
     { name = "lxml" },
     { name = "matplotlib", specifier = ">=3.10" },
     { name = "matplotlib-venn" },
-    { name = "myst-parser", marker = "extra == 'dev'" },
+    { name = "myst-parser", marker = "extra == 'docs'" },
     { name = "natsort" },
     { name = "num2tex" },
     { name = "numpy" },
     { name = "palettable" },
     { name = "pandas" },
     { name = "patsy" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pre-commit", marker = "extra == 'lint'" },
     { name = "pycomplexheatmap", specifier = ">=1.8.4,<1.9" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "pytest-mpl", marker = "extra == 'dev'", specifier = ">=0.19,<0.20" },
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-cov", marker = "extra == 'test'" },
+    { name = "pytest-mpl", marker = "extra == 'test'", specifier = ">=0.19,<0.20" },
     { name = "scanpy" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn", specifier = ">=0.13.2" },
-    { name = "sphinx", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = ">=9,<9.1" },
-    { name = "sphinx", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = "<9" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'dev'" },
-    { name = "sphinx-copybutton", marker = "extra == 'dev'" },
-    { name = "sphinx-design", marker = "extra == 'dev'" },
-    { name = "sphinx-gallery", marker = "extra == 'dev'" },
-    { name = "sphinx-multiversion", marker = "extra == 'dev'" },
-    { name = "sphinx-sitemap", marker = "extra == 'dev'" },
+    { name = "sphinx", marker = "python_full_version >= '3.11' and extra == 'docs'", specifier = ">=9,<9.1" },
+    { name = "sphinx", marker = "python_full_version >= '3.11' and extra == 'test'", specifier = ">=9,<9.1" },
+    { name = "sphinx", marker = "python_full_version < '3.11' and extra == 'docs'", specifier = "<9" },
+    { name = "sphinx", marker = "python_full_version < '3.11' and extra == 'test'", specifier = "<9" },
+    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'" },
+    { name = "sphinx-copybutton", marker = "extra == 'docs'" },
+    { name = "sphinx-design", marker = "extra == 'docs'" },
+    { name = "sphinx-gallery", marker = "extra == 'docs'" },
+    { name = "sphinx-gallery", marker = "extra == 'test'" },
+    { name = "sphinx-multiversion", marker = "extra == 'docs'" },
+    { name = "sphinx-sitemap", marker = "extra == 'docs'" },
     { name = "statannotations", specifier = ">=0.7.2,<0.8" },
     { name = "statsmodels" },
+    { name = "ty", marker = "extra == 'lint'" },
     { name = "upsetplot" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "test", "docs", "lint", "notebook", "release"]
 
 [[package]]
 name = "colorama"
@@ -4110,6 +4161,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.78"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/c7/2ba0861384c5b5097ac354383abb98188112cb330208c21d5197e98a29e5/ty-0.0.78.tar.gz", hash = "sha256:770b45854f85fa11595208f08c0f28df80943164d10a2832d86be6ac29f135b2", size = 7050609, upload-time = "2026-09-02T22:41:33.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/ed/f34cfc06a9ba72979df219e48dae1a0b6a6c74a340763ccd30a547edf913/ty-0.0.78-py3-none-linux_armv6l.whl", hash = "sha256:122700b98f9d45785c1ce91a9418154562e7f64f4bf34679f6f7b38c5b97453f", size = 13304624, upload-time = "2026-09-02T22:40:56.649Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/28/5576e2a08b57676d9b2a736d528f077a6c6e32c3d1de2d75dbbe28346966/ty-0.0.78-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cbe7e3709ccf29ef3d9f58f5914cc30ec36fb647008a5a4ff8483abe401bfe8d", size = 12928383, upload-time = "2026-09-02T22:40:59.162Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/027d49c3da5235e634da3d3fc52c4874ec89f50830388c9c259f8fb71e0e/ty-0.0.78-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c3528897b3ab9d3589561bc2b5e61a4d5d686de527a4400bb09a439b922a6c70", size = 12730058, upload-time = "2026-09-02T22:41:01.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/bc/6bf8ffefd8063730a70ae889cf85def72bc155fd1453135ebf8a09c2f1c2/ty-0.0.78-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8bfba4c44a06484093f527b8ef43a317abcf91395b49396170266629eedf74aa", size = 12813321, upload-time = "2026-09-02T22:41:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c0/b3cdf26f82108908d92fdb7ddb741019c446ceb666cf204d4dbf611bde33/ty-0.0.78-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f903c06fdee17baf8373173039ab28f1bce28e66b1c734929a5f50b37eb54d9", size = 13072219, upload-time = "2026-09-02T22:41:05.225Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/36/16bfb0abdd178dae11dbc4b57b9a86c2b62642a18c1103fd2c2930aa5879/ty-0.0.78-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd83e5fe3f07291d1bd4e591f8d2607c204f3eab53bcb1b8060c40e876e1aa61", size = 13903958, upload-time = "2026-09-02T22:41:07.333Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/0c/74d3b1f0344b13156c719dd68a7edf7e48c2051718c9f326ba3cbf45ea53/ty-0.0.78-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:325285377319cf7168a2b8b771ae5027f411530e3c7eab1faf4583cdd72fd7c9", size = 14355581, upload-time = "2026-09-02T22:41:09.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d7/7ca0359e1e61b15b8b02328c8d120db3c507876b9b7c6bd9f26935353e0e/ty-0.0.78-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b7846a404da6492697b524a769755ee9bee157d67674063ecd9c5f69dc52ff", size = 14044749, upload-time = "2026-09-02T22:41:11.678Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6a/731f16ff42c5fc96e742c2f4e0a6915356bae114ae02ae4af6f33502175f/ty-0.0.78-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:169d3b9d134c0b48fe1af8a844142d374655552054a9d6c15a4b6e51bb0382ea", size = 13391647, upload-time = "2026-09-02T22:41:13.928Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/af/250cc29daf310e837188509ea4d78460c495d8a74c4fb84b4152d9ef2d4f/ty-0.0.78-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6108cb3b2d28dac5981d4e25008a0a5547d8c877a67f6da9e8c38e7e946be44f", size = 13945020, upload-time = "2026-09-02T22:41:15.968Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f9/96aab1dee4535e66554e8dc7657c69f6c61c181d8e70b9c3527908e93ef4/ty-0.0.78-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:589ad03608d9d2975ef4b23c41c4f847e325bcc7686f51d4c66066b8dbc18a2a", size = 12851149, upload-time = "2026-09-02T22:41:18.06Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b0/53d8fe9a847534ef5fe2165c7d5292cb853b29dfd7011cbfb1cdb90a8012/ty-0.0.78-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b3fa0786edc1af06030f872d83499c0cea7c261dbbb651e0aee8306bf2c8a869", size = 13091464, upload-time = "2026-09-02T22:41:20.227Z" },
+    { url = "https://files.pythonhosted.org/packages/21/65/94a4e5a02de559f6c6c0ee7a14b88660b4eee058ec6fec5c0ff6ecfbf5cc/ty-0.0.78-py3-none-musllinux_1_2_i686.whl", hash = "sha256:92c5639befc577578c8abd4e5a7fccf98d828db98b09e8d4dd81605dc0e54aef", size = 13389389, upload-time = "2026-09-02T22:41:22.27Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/d0c7fe6be64ca5a15100c4b1f0e39c19660d53bc544f609fa117b346e661/ty-0.0.78-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0dce70bc51652b2775debd1d1e422fb0179f5207c73deb4d5d0aca37e5f61695", size = 13691928, upload-time = "2026-09-02T22:41:24.292Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5d/36081205611ba3fa802efc4ad63e4b1e949bda2f7bb37b34ac9bb6c00db0/ty-0.0.78-py3-none-win32.whl", hash = "sha256:1c80976ca9185d7a9d1baab1fb57240331b8dac58d3b11e46200284086a6de8d", size = 12647346, upload-time = "2026-09-02T22:41:26.699Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/89/b925fe1ea1bc56fc7f11d2496e29072fdd2ceb7b389884fc7b2d07cf0c41/ty-0.0.78-py3-none-win_amd64.whl", hash = "sha256:32e82b704471eab34f67b51c151660ca8a00815977b28278905d76fba54f7415", size = 13241810, upload-time = "2026-09-02T22:41:28.857Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f1/090ef7b52355bcedfbfbff6ce70fa81ba5bd5f6ed3f8d99ae05e6f2fe75b/ty-0.0.78-py3-none-win_arm64.whl", hash = "sha256:3a14d641a3c04fa9a80f2a46be1531d915f60d4fb79d4b894627bbe46bb35d64", size = 13077433, upload-time = "2026-09-02T22:41:31.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Make documentation builds usable from scripts and keep routine development environments focused. `make doc` now cleans only generated documentation, builds, and exits with the build status. `make doc-serve` explicitly builds and starts the preview on port 8080.

Split development dependencies into `test`, `docs`, `lint`, `notebook`, and `release` extras while preserving the aggregate `dev` extra and full `make install` workflow. Update Make targets, CI, Windows docs commands, and contributor instructions to use the matching locked extra. Add ty to the lockfile so the type-check hook uses a resolved version. The latest-dependencies test step reuses its freshly upgraded environment, preserving the custom Numba resolution policy. Update the palette-isolation test to mutate public name metadata, preserving its independent-return checks on current Matplotlib.

## How it was tested

- GitHub CI on `9419c7e0`: all 11 checks passed, including Python 3.10–3.14, latest dependencies, docs, packaging, lint, and macOS/Windows smoke tests.
- `tests/test_palette_registry.py` with Matplotlib 3.11.1: all 110 passed after reproducing the five deprecated-setter failures.
- Isolated uv reproduction: confirmed the resolver-option mismatch fails with `--locked`, while step-scoped `UV_NO_SYNC=1` runs successfully without changing the generated lockfile.
- `make test` in a fresh test-only environment: 1,579 passed, 100% coverage on Python 3.12.
- `make lint` in a fresh lint-only environment: passed.
- `make doc` in a fresh docs-only environment: all gallery examples built successfully and the command exited.
- `make doc-linkcheck` in the docs-only environment: passed.
- Five Makefile regression cases cover local/CI completion, stale docs removal, unrelated artifact preservation, build failure propagation, and preview ordering.
- Live preview smoke check: `make -o doc doc-serve` served the completed docs with HTTP 200 on port 8080, then shut down cleanly.
- `make install` in a disposable checkout: all developer tools and the pre-commit hook installed successfully.
- `uv lock --check` and package inventories: focused extras contain the required tools; runtime requirements and all existing locked package versions are unchanged.

## Risks or follow-ups

The local preview command changes from `make doc` to `make doc-serve`; this migration is documented. The test extra retains Sphinx-Gallery for existing documentation-extension tests, and lint includes test dependencies for type checking.

## Related issue

Closes #156
Closes #172

## Release Notes Label

`maintenance`
