### PR TITLE
⚡️ Bound bootstrap and clustering memory

### DIFF
--- a/src/cnsplots/helpers/_heatmap.py
+++ b/src/cnsplots/helpers/_heatmap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import importlib
 from typing import Any
 
 import matplotlib as mpl
@@ -13,6 +14,42 @@ from PyComplexHeatmap import ClusterMapPlotter, DotClustermapPlotter
 from PyComplexHeatmap.clustermap import mm2inch
 
 import cnsplots._utils as utils
+
+
+def _check_cluster_memory(
+    n_items: int,
+    method: str,
+    metric: str,
+    max_cluster_bytes: int | None,
+    axis: str,
+) -> None:
+    """Guard one linkage run using its condensed float64 distance-array size."""
+    distance_bytes = n_items * (n_items - 1) // 2 * np.dtype(np.float64).itemsize
+    if max_cluster_bytes is None or distance_bytes <= max_cluster_bytes:
+        return
+
+    # Mirror PyComplexHeatmap's optional backend and linkage_vector selection.
+    try:
+        importlib.import_module("fastcluster")
+    except ImportError:
+        backend = "SciPy"
+    else:
+        if method == "single" or (
+            metric == "euclidean" and method in {"centroid", "median", "ward"}
+        ):
+            return
+        backend = "fastcluster"
+
+    raise ValueError(
+        f"{axis.capitalize()} clustering of {n_items:,} items using {backend} "
+        f"({method}, {metric}) would require approximately "
+        f"{distance_bytes / 1024**2:.1f} MiB for one condensed distance array, "
+        f"exceeding max_cluster_bytes={max_cluster_bytes}. "
+        "Subset or aggregate data, disable clustering (including between split "
+        "groups by setting an explicit split order), or supply "
+        f"{axis}_dendrogram_kws={{'linkage': Z}} for an unsplit axis. "
+        "Increase max_cluster_bytes or set it to None to override this guard."
+    )
 
 
 def _get_canvas_renderer(canvas: Any) -> Any | None:
@@ -363,8 +400,19 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
         legend_delta_x: float | None = None,
         verbose: int = 1,
         ax: Axes | None = None,
+        max_cluster_bytes: int | None = 512 * 1024**2,
         **kwargs: Any,
     ) -> None:
+        if max_cluster_bytes is not None:
+            if isinstance(max_cluster_bytes, bool) or not isinstance(
+                max_cluster_bytes, int
+            ):
+                raise TypeError(
+                    "max_cluster_bytes must be a nonnegative integer or None"
+                )
+            if max_cluster_bytes < 0:
+                raise ValueError("max_cluster_bytes must be nonnegative")
+        self.max_cluster_bytes = max_cluster_bytes
         self.data = data
         self.legend_gap = legend_gap
         self._host_ax = ax
@@ -434,6 +482,32 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
         )
         if not plot:
             self.post_processing()
+
+    def calculate_row_dendrograms(
+        self, data: pd.DataFrame, sizes: Any = None, use_linkage: bool = True
+    ) -> None:
+        if not (use_linkage and self.row_dendrogram_kws.get("linkage") is not None):
+            _check_cluster_memory(
+                data.shape[0],
+                self.row_cluster_method,
+                self.row_cluster_metric,
+                self.max_cluster_bytes,
+                "row",
+            )
+        super().calculate_row_dendrograms(data, sizes=sizes, use_linkage=use_linkage)
+
+    def calculate_col_dendrograms(
+        self, data: pd.DataFrame, sizes: Any = None, use_linkage: bool = True
+    ) -> None:
+        if not (use_linkage and self.col_dendrogram_kws.get("linkage") is not None):
+            _check_cluster_memory(
+                data.shape[1],
+                self.col_cluster_method,
+                self.col_cluster_metric,
+                self.max_cluster_bytes,
+                "col",
+            )
+        super().calculate_col_dendrograms(data, sizes=sizes, use_linkage=use_linkage)
 
     def plot(
         self,

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -27,6 +27,7 @@ from cnsplots._validation import (
 LollipopError = float | tuple[float, float]
 
 _LOLLIPOP_BOOTSTRAP_SAMPLES = 1000
+_LOLLIPOP_BOOTSTRAP_BATCH_SIZE = 64
 _LOLLIPOP_BOOTSTRAP_SEED = 0
 _BAR_LABEL_PADDING = 2
 _BAR_LABEL_PVALUE_GAP = 2
@@ -114,12 +115,15 @@ def _compute_lollipop_error(
     if estimator == "median":
         samples = values.to_numpy(dtype=float)
         rng = np.random.default_rng(_LOLLIPOP_BOOTSTRAP_SEED)
-        indices = rng.integers(
-            0,
-            sample_size,
-            size=(_LOLLIPOP_BOOTSTRAP_SAMPLES, sample_size),
-        )
-        bootstrap_medians = np.median(samples[indices], axis=1)
+        bootstrap_medians = np.empty(_LOLLIPOP_BOOTSTRAP_SAMPLES)
+        for start in range(
+            0, _LOLLIPOP_BOOTSTRAP_SAMPLES, _LOLLIPOP_BOOTSTRAP_BATCH_SIZE
+        ):
+            stop = min(
+                start + _LOLLIPOP_BOOTSTRAP_BATCH_SIZE, _LOLLIPOP_BOOTSTRAP_SAMPLES
+            )
+            indices = rng.integers(0, sample_size, size=(stop - start, sample_size))
+            bootstrap_medians[start:stop] = np.median(samples[indices], axis=1)
         if errorbar == "se":
             return float(bootstrap_medians.std(ddof=1))
         lower, upper = np.percentile(bootstrap_medians, [2.5, 97.5])
@@ -524,6 +528,11 @@ def lollipopplot(
     -----
     When ``pairs`` is provided, ``get_comparison_results(ax)`` returns the
     comparison table without rerunning the statistical tests.
+
+    Median standard errors and confidence intervals use 1,000 deterministic
+    bootstrap replicates in batches of at most 64. Each index or resampled-value
+    array therefore holds at most ``64 * n`` elements for ``n`` non-missing
+    observations in a group, rather than ``1000 * n``.
 
     Examples
     --------

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -128,6 +128,7 @@ def heatmapplot(
     ylabel_labelpad: float = 3,
     *,
     ax: Axes | None = None,
+    max_cluster_bytes: int | None = 512 * 1024**2,
     **kwargs: Any,
 ) -> ClusterMapPlotterNew:
     """
@@ -192,6 +193,11 @@ def heatmapplot(
         Padding between the y-axis label and the tick labels.
     ax : matplotlib.axes.Axes, optional
         Host axes for the heatmap layout. If None, uses the current axes.
+    max_cluster_bytes : int or None, default: 536870912
+        Maximum estimated bytes for one condensed float64 distance array per
+        clustering call (512 MiB). Raises ValueError before a call exceeding this
+        limit. Increase the limit or use None to disable this check. This is not
+        a limit on total plot memory; inputs and backend working copies add to it.
     **kwargs
         Additional keyword arguments passed to `ClusterMapPlotterNew`.
 
@@ -210,6 +216,29 @@ def heatmapplot(
     Categorical annotations automatically use predefined color palettes (Set1, Set2, etc.),
     while continuous annotations use sequential colormaps (parula, gnuplot, bwr, hot).
     The function cycles through available palettes when multiple annotations are present.
+
+    Clustering checks rows and columns independently, including each split group
+    and clustering of group averages. Integer splits first cluster the entire
+    axis. Metadata splits cluster group averages even when ``row_cluster`` or
+    ``col_cluster`` is False, unless an explicit ``row_split_order`` or
+    ``col_split_order`` is supplied. Unclustered axes do not incur distance costs.
+
+    SciPy linkage uses quadratic memory for every method. When fastcluster is
+    available, PyComplexHeatmap uses its memory-saving vector implementation for
+    single linkage, and for centroid, median, or ward linkage with the Euclidean
+    metric; those paths do not allocate a condensed distance array and are exempt
+    from this check. Other fastcluster methods use quadratic distance storage.
+    For example, 50,000 items require 9,999,800,000 bytes (about 9.3 GiB) for one
+    condensed distance array alone. Subset or aggregate large data before plotting.
+    See the `SciPy linkage notes
+    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html>`_.
+
+    For an unsplit axis, pass a precomputed SciPy-format linkage matrix using
+    ``row_dendrogram_kws={"linkage": Z}`` or ``col_dendrogram_kws={"linkage": Z}``.
+    It must match the corresponding input axis order and bypasses distance
+    computation. Precomputed distance matrices are not accepted as linkage;
+    PyComplexHeatmap does not support separate linkage matrices per split group.
+    The existing sparse-to-dense 512 MiB guard remains independent of this limit.
 
     Examples
     --------
@@ -381,6 +410,7 @@ def heatmapplot(
             xlabel_kws={"labelpad": xlabel_labelpad},
             verbose=0,
             ax=ax,
+            max_cluster_bytes=max_cluster_bytes,
             row_names_side="left" if left_annotation is None else "right",
             xticklabels=True,
             yticklabels=True,

--- a/tests/test_heatmap_memory.py
+++ b/tests/test_heatmap_memory.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import anndata as ad
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from PyComplexHeatmap.clustermap import DendrogramPlotter
+from scipy.cluster.hierarchy import linkage
+
+import cnsplots as cns
+from cnsplots.helpers import _heatmap as helper_heatmap
+
+
+def _matrix(rows: int = 4, cols: int = 3) -> pd.DataFrame:
+    return pd.DataFrame(
+        np.random.default_rng(42).normal(size=(rows, cols)),
+        index=pd.Index([f"sample_{i}" for i in range(rows)]),
+        columns=pd.Index([f"feature_{i}" for i in range(cols)]),
+    )
+
+
+def test_cluster_memory_estimates_fifty_thousand_items() -> None:
+    required_bytes = 9_999_800_000
+
+    helper_heatmap._check_cluster_memory(
+        50_000, "average", "correlation", required_bytes, "row"
+    )
+    with pytest.raises(ValueError, match="max_cluster_bytes"):
+        helper_heatmap._check_cluster_memory(
+            50_000, "average", "correlation", required_bytes - 1, "row"
+        )
+
+
+def test_heatmapplot_has_keyword_only_cluster_memory_limit() -> None:
+    parameter = inspect.signature(cns.heatmapplot).parameters["max_cluster_bytes"]
+
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default == 512 * 1024**2
+
+
+@pytest.mark.parametrize(
+    ("method", "metric"),
+    [
+        ("single", "correlation"),
+        ("centroid", "euclidean"),
+        ("median", "euclidean"),
+        ("ward", "euclidean"),
+    ],
+)
+def test_cluster_memory_allows_fastcluster_vector_algorithms(
+    method: str, metric: str
+) -> None:
+    helper_heatmap._check_cluster_memory(50_000, method, metric, 0, "row")
+
+
+@pytest.mark.parametrize(
+    ("method", "metric"),
+    [
+        ("average", "euclidean"),
+        ("complete", "correlation"),
+        ("weighted", "euclidean"),
+        ("centroid", "correlation"),
+    ],
+)
+def test_cluster_memory_guards_condensed_distance_algorithms(
+    method: str, metric: str
+) -> None:
+    with pytest.raises(ValueError, match="max_cluster_bytes"):
+        helper_heatmap._check_cluster_memory(50_000, method, metric, 0, "row")
+
+
+@pytest.mark.parametrize("method", ["single", "ward"])
+def test_cluster_memory_guards_scipy_fallback(
+    monkeypatch: pytest.MonkeyPatch, method: str
+) -> None:
+    def missing_fastcluster(name: str) -> Any:
+        assert name == "fastcluster"
+        raise ImportError("fastcluster is unavailable")
+
+    monkeypatch.setattr(helper_heatmap.importlib, "import_module", missing_fastcluster)
+
+    with pytest.raises(ValueError, match="max_cluster_bytes"):
+        helper_heatmap._check_cluster_memory(50_000, method, "euclidean", 0, "row")
+
+
+@pytest.mark.parametrize("axis", ["row", "col"])
+def test_heatmapplot_guards_each_clustered_axis_independently(
+    monkeypatch: pytest.MonkeyPatch, axis: str
+) -> None:
+    data = _matrix()
+    if axis == "col":
+        data = data.T
+    other_axis = "col" if axis == "row" else "row"
+    cluster_kwargs: dict[str, Any] = {f"{other_axis}_cluster": True}
+
+    # Three clustered items require 24 bytes; four require 48 bytes.
+    plotter = cns.heatmapplot(
+        data,
+        max_cluster_bytes=24,
+        **cluster_kwargs,
+    )
+    assert plotter.data2d.shape == data.shape
+
+    def unexpected_clustering(self: Any) -> None:
+        pytest.fail("Memory guard should reject before distance computation")
+
+    monkeypatch.setattr(
+        DendrogramPlotter, "_calculate_linkage_fastcluster", unexpected_clustering
+    )
+    monkeypatch.setattr(
+        DendrogramPlotter, "_calculate_linkage_scipy", unexpected_clustering
+    )
+    plt.figure()
+    cluster_kwargs = {f"{axis}_cluster": True}
+    with pytest.raises(ValueError, match=f"(?i){axis}"):
+        cns.heatmapplot(
+            data,
+            max_cluster_bytes=24,
+            **cluster_kwargs,
+        )
+
+
+def test_heatmapplot_does_not_guard_unclustered_axes() -> None:
+    data = _matrix()
+
+    plotter = cns.heatmapplot(data, max_cluster_bytes=0)
+
+    pd.testing.assert_frame_equal(plotter.data2d, data)
+
+
+def test_cluster_memory_override_disables_guard() -> None:
+    helper_heatmap._check_cluster_memory(50_000, "average", "correlation", None, "row")
+    plotter = cns.heatmapplot(
+        _matrix(), row_cluster=True, col_cluster=True, max_cluster_bytes=None
+    )
+
+    assert len(plotter.dendrogram_row.linkage) == 3
+    assert len(plotter.dendrogram_col.linkage) == 2
+
+
+@pytest.mark.parametrize(
+    ("limit", "error"),
+    [(-1, ValueError), (1.5, TypeError), ("512", TypeError), (True, TypeError)],
+)
+def test_heatmapplot_rejects_invalid_cluster_memory_limits(
+    limit: Any, error: type[Exception]
+) -> None:
+    with pytest.raises(error, match="max_cluster_bytes"):
+        cns.heatmapplot(_matrix(), max_cluster_bytes=limit)
+
+
+@pytest.mark.parametrize("axis", ["row", "col"])
+def test_heatmapplot_checks_actual_metadata_split_sizes(axis: str) -> None:
+    data = _matrix(rows=6)
+    adata = ad.AnnData(data if axis == "row" else data.T)
+    metadata = adata.obs if axis == "row" else adata.var
+    metadata["group"] = ["A"] * 3 + ["B"] * 3
+    split_kwargs: dict[str, Any] = {
+        f"{axis}_cluster": True,
+        f"{axis}_split": "group",
+    }
+
+    # Each group requires 24 bytes; clustering all six items would require 120.
+    plotter = cns.heatmapplot(
+        adata,
+        max_cluster_bytes=24,
+        **split_kwargs,
+    )
+
+    assert [len(group) for group in getattr(plotter, f"{axis}_order")] == [3, 3]
+
+    with pytest.raises(ValueError, match=f"(?i){axis}"):
+        cns.heatmapplot(
+            adata,
+            max_cluster_bytes=8,
+            **split_kwargs,
+        )
+
+
+@pytest.mark.parametrize("axis", ["row", "col"])
+def test_heatmapplot_guards_between_group_clustering_when_cluster_is_false(
+    axis: str,
+) -> None:
+    data = _matrix(rows=6)
+    adata = ad.AnnData(data if axis == "row" else data.T)
+    metadata = adata.obs if axis == "row" else adata.var
+    metadata["group"] = ["A", "A", "B", "B", "C", "C"]
+    split_kwargs: dict[str, Any] = {
+        f"{axis}_cluster": False,
+        f"{axis}_split": "group",
+    }
+
+    # Groups each fit in 8 bytes, but clustering three group means needs 24.
+    with pytest.raises(ValueError, match=f"(?i){axis}"):
+        cns.heatmapplot(
+            adata,
+            max_cluster_bytes=8,
+            **split_kwargs,
+        )
+
+    plt.figure()
+    split_kwargs[f"{axis}_split_order"] = ["A", "B", "C"]
+    plotter = cns.heatmapplot(
+        adata,
+        max_cluster_bytes=0,
+        **split_kwargs,
+    )
+    assert [len(group) for group in getattr(plotter, f"{axis}_order")] == [2, 2, 2]
+
+
+@pytest.mark.parametrize("axis", ["row", "col"])
+def test_heatmapplot_integer_split_requires_full_axis_clustering(axis: str) -> None:
+    data = _matrix(rows=6)
+    if axis == "col":
+        data = data.T
+    split_kwargs: dict[str, Any] = {f"{axis}_cluster": True, f"{axis}_split": 3}
+
+    with pytest.raises(ValueError, match=f"(?i){axis}"):
+        cns.heatmapplot(
+            data,
+            max_cluster_bytes=24,
+            **split_kwargs,
+        )
+
+
+def test_heatmapplot_reuses_precomputed_unsplit_linkages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _matrix()
+    row_linkage = linkage(data, method="average", metric="correlation")
+    col_linkage = linkage(data.T, method="average", metric="correlation")
+
+    def unexpected_clustering(self: Any) -> None:
+        pytest.fail("Precomputed linkage should avoid distance computation")
+
+    monkeypatch.setattr(
+        DendrogramPlotter, "_calculate_linkage_fastcluster", unexpected_clustering
+    )
+    monkeypatch.setattr(
+        DendrogramPlotter, "_calculate_linkage_scipy", unexpected_clustering
+    )
+
+    plotter = cns.heatmapplot(
+        data,
+        row_cluster=True,
+        col_cluster=True,
+        max_cluster_bytes=0,
+        row_dendrogram_kws={"linkage": row_linkage},
+        col_dendrogram_kws={"linkage": col_linkage},
+    )
+
+    np.testing.assert_array_equal(plotter.dendrogram_row.linkage, row_linkage)
+    np.testing.assert_array_equal(plotter.dendrogram_col.linkage, col_linkage)
+
+
+@pytest.mark.parametrize("axis", ["row", "col"])
+def test_cluster_memory_guard_applies_when_precomputed_linkage_is_disabled(
+    axis: str,
+) -> None:
+    data = _matrix()
+    plotter = cns.heatmapplot(data, max_cluster_bytes=0)
+    getattr(plotter, f"{axis}_dendrogram_kws")["linkage"] = linkage(
+        data if axis == "row" else data.T
+    )
+
+    with pytest.raises(ValueError, match=f"(?i){axis}"):
+        getattr(plotter, f"calculate_{axis}_dendrograms")(data, use_linkage=False)

--- a/tests/test_lollipop_memory.py
+++ b/tests/test_lollipop_memory.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from cnsplots.plots._categorical import _compute_lollipop_error
+
+
+@pytest.mark.parametrize("errorbar", ["se", "ci"])
+@pytest.mark.parametrize(
+    "values",
+    [
+        [1.0, 9.0],
+        [1.0, 2.0, 10.0],
+        [0.0, 1.0, 1.0, 4.0, 20.0, 100.0],
+        [1.0, 2.0, np.nan, 9.0, 16.0, np.nan],
+    ],
+)
+def test_median_bootstrap_matches_unbatched_reference(
+    values: list[float], errorbar: str
+) -> None:
+    group = pd.Series(values)
+    samples = group.dropna().to_numpy(dtype=float)
+    indices = np.random.default_rng(0).integers(
+        0, len(samples), size=(1000, len(samples))
+    )
+    bootstrap_medians = np.median(samples[indices], axis=1)
+    if errorbar == "se":
+        expected = float(bootstrap_medians.std(ddof=1))
+    else:
+        lower, upper = np.percentile(bootstrap_medians, [2.5, 97.5])
+        estimate = float(np.median(samples))
+        expected = estimate - float(lower), float(upper) - estimate
+
+    assert _compute_lollipop_error(group, errorbar, "median") == expected
+
+
+@pytest.mark.parametrize("errorbar", ["se", "ci"])
+@pytest.mark.parametrize("values", [[], [np.nan], [3.0], [np.nan, 3.0, np.nan]])
+def test_median_bootstrap_skips_groups_with_fewer_than_two_values(
+    values: list[float], errorbar: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def unexpected_rng(*args: Any, **kwargs: Any) -> None:
+        pytest.fail("Groups with fewer than two values must not be bootstrapped")
+
+    monkeypatch.setattr(np.random, "default_rng", unexpected_rng)
+
+    assert np.isnan(
+        _compute_lollipop_error(pd.Series(values, dtype=float), errorbar, "median")
+    )
+
+
+def test_median_bootstrap_bounds_index_and_sample_allocations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sample_size = 10_000
+    batch_limit = 64
+    original_rng = np.random.default_rng
+    original_median = np.median
+    index_shapes: list[tuple[int, int]] = []
+    sample_shapes: list[tuple[int, int]] = []
+
+    class TrackingRng:
+        def __init__(self, seed: int) -> None:
+            self.rng = original_rng(seed)
+
+        def integers(self, low: int, high: int, *, size: tuple[int, int]) -> Any:
+            assert size[0] <= batch_limit
+            indices = self.rng.integers(low, high, size=size)
+            index_shapes.append(indices.shape)
+            assert indices.nbytes <= batch_limit * sample_size * 8
+            return indices
+
+    def track_median(values: np.ndarray, *args: Any, **kwargs: Any) -> Any:
+        if values.ndim == 2:
+            sample_shapes.append(values.shape)
+            assert values.shape[0] <= batch_limit
+            assert values.nbytes <= batch_limit * sample_size * 8
+        return original_median(values, *args, **kwargs)
+
+    monkeypatch.setattr(np.random, "default_rng", TrackingRng)
+    monkeypatch.setattr(np, "median", track_median)
+
+    error = _compute_lollipop_error(
+        pd.Series(np.arange(sample_size, dtype=float)), "se", "median"
+    )
+
+    assert isinstance(error, float)
+    assert error > 0
+    assert sample_shapes == index_shapes
+    assert sum(rows for rows, _ in index_shapes) == 1000
+    assert all(columns == sample_size for _, columns in index_shapes)


### PR DESCRIPTION
## What changed

Reduce temporary memory used by median error bars and guard heatmap clustering before excessive distance allocations.

- Compute the same 1,000 deterministic median bootstrap replicates in batches of 64, preserving SE and CI results while bounding each index/sample array to `64 * n` elements.
- Add `heatmapplot(max_cluster_bytes=512 * 1024**2)` to check each row, column, split-group, and between-group clustering call. Respect fastcluster vector algorithms and supported precomputed linkage.
- Document memory estimates, backend limits, and overrides, with allocation-oriented regression tests that avoid huge distance matrices.

## How it was tested

- `make test` — 1,625 passed, 100% coverage.
- `make lint` — passed.
- Exact bootstrap SE/CI reference comparisons, missing/small groups, and measured index/sample allocation sizes. At 10,000 observations, each array is at most 5.12 MB instead of 80 MB.
- Heatmap tests cover exact distance estimates, independent axes, split phases, backend algorithms, overrides, and precomputed linkage; sentinels verify rejection before distance computation.

## Risks or follow-ups

Oversized quadratic clustering now raises `ValueError` by default. Increase `max_cluster_bytes` or set it to `None` to override. The estimate covers one condensed distance array, not total process memory; input data and backend working copies require additional memory. Existing sparse densification checks remain independent.

## Related issue

Closes #173
Closes #174

## Release Notes Label

`maintenance`
