### PR TITLE
🔧 Improve lint and coverage

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -132,6 +132,7 @@ After installation, you can use the following commands:
 | `make help`                          | Show available commands                |
 | `make lint`                          | Run linting and formatting             |
 | `make test`                          | Run all unit tests                     |
+| `make test-branches`                 | Report statement and branch coverage separately |
 | `make doc`                           | Build documentation and exit           |
 | `make doc-serve`                     | Build and preview documentation on port 8080 |
 | `make doc-linkcheck`                 | Check documentation links              |
@@ -220,6 +221,43 @@ def example_function(param1, param2):
 ```bash
 make test
 ```
+
+### Statement and branch coverage
+
+`make test` enforces **100% statement coverage** on every supported Python version
+in CI. It does not measure branches. The existing `--cov-fail-under=100` and
+`[tool.coverage.report] fail_under = 100` settings remain statement-only gates.
+
+Run the separate branch audit locally with the locked test environment:
+
+```bash
+make test-branches
+```
+
+This reruns the tests with branch measurement and prints a table separating
+statement coverage from branch coverage. It writes `.coverage.branches` and
+`.coverage.branches.json`, preserving the standard `.coverage` data. The JSON
+includes per-file missing branches for investigation. In coverage.py's detailed
+terminal report, the `Cover` column combines statements and branches; it is
+neither the statement percentage nor the branch percentage in the summary table.
+See [coverage.py's branch measurement documentation](https://coverage.readthedocs.io/en/7.13.4/branch.html).
+
+The branch audit is **reporting only**, with no numeric branch or combined
+coverage threshold. Its explicit `--cov-fail-under=0` disables the combined gate
+for that invocation only; test failures still fail the command. It supplements
+`make test` and does not replace its required statement gate. CI runs both on
+Python 3.12, publishes the separate percentages in the job summary, and uploads
+the branch JSON as an artifact.
+
+The adoption baseline on Python 3.12.12/macOS with coverage.py 7.13.4 and the
+locked dependencies is **5,390/5,390 statements (100%)** and **2,070/2,112 branches
+(98.01%)**, with 42 missing branches. Platform and Python-version differences
+may change branch counts; the CI artifact records the Linux baseline per run.
+
+Review changes in missing branches against this baseline, prioritizing tests of
+observable behavior. A future branch threshold requires an explicit policy
+change after evaluating results across supported Python versions; do not add
+tests merely to force 100% branch coverage.
 
 ### Final PDF and SVG exports
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -152,6 +152,22 @@ The project is CI-tested on Python 3.10 through 3.14.
 
 We use [Ruff](https://github.com/astral-sh/ruff) for code formatting and linting.
 
+The selected checks keep the existing `E4`, `E7`, `E9`, and `F` rules and add:
+
+- `I`: consistent import ordering using the existing first-party package setting.
+- `UP006`, `UP007`, `UP035`, and `UP045`: built-in generic types, union/optional
+  annotations, and current import locations compatible with Python 3.10.
+- `B023`: detect deferred functions that accidentally capture changing loop
+  variables; bind the intended value explicitly.
+
+The Ruff target remains `py310`. Only reviewed, safe fixes are applied. Other
+rule families require a separate compatibility audit: `B905` is deferred because
+calls such as `zip(columns, columns[1:])` deliberately truncate; `B009`/`B010`
+would rewrite intentional dynamic attribute access used with Matplotlib.
+`RUF001`–`RUF003` remain unselected to preserve scientific Unicode in labels,
+docstrings, and comments. Broad `C4`, `SIM`, and remaining `UP`/`B` checks are not
+enabled wholesale.
+
 ### Running Linters
 
 ```bash

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -64,8 +64,24 @@ jobs:
         id: tests
         run: make test
 
+      - name: Report branch coverage
+        if: ${{ matrix.python-version == '3.12' }}
+        id: branch_coverage
+        run: |
+          make test-branches
+          uv run --locked --extra test python tools/report_coverage.py .coverage.branches.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload branch coverage report
+        if: ${{ always() && steps.branch_coverage.outcome != 'skipped' && matrix.python-version == '3.12' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: branch-coverage-python-3.12
+          path: .coverage.branches.json
+          include-hidden-files: true
+          if-no-files-found: warn
+
       - name: Upload export regression results
-        if: ${{ always() && steps.tests.outcome == 'failure' }}
+        if: ${{ always() && (steps.tests.outcome == 'failure' || steps.branch_coverage.outcome == 'failure') }}
         uses: actions/upload-artifact@v4
         with:
           name: export-results-linux-python-${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ help:
 	@echo " - clean        : clean the repo"
 	@echo " - lint         : run linting and flaking"
 	@echo " - test         : run all unit tests"
+	@echo " - test-branches: report statement and branch coverage separately"
 	@echo " - test-visual  : run visual regression tests"
 	@echo " - doc          : build the documentation"
 	@echo " - doc-serve    : build and serve documentation on port 8080"
@@ -38,6 +39,12 @@ lint:
 
 test:
 	uv run --locked --extra test pytest ./tests
+
+.PHONY: test-branches
+
+test-branches:
+	COVERAGE_FILE=.coverage.branches uv run --locked --extra test pytest ./tests --cov-branch --cov-fail-under=0 --cov-report=json:.coverage.branches.json
+	uv run --locked --extra test python tools/report_coverage.py .coverage.branches.json
 
 test-visual:
 	uv run --locked --extra test pytest tests/test_visual_regressions.py --mpl --no-cov

--- a/docs/_ext/theme_aware_matplotlib.py
+++ b/docs/_ext/theme_aware_matplotlib.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from textwrap import indent
-from typing import Iterator
 
 import matplotlib as mpl
 import matplotlib.colors as mcolors

--- a/docs/_scripts/build_versioned_docs.py
+++ b/docs/_scripts/build_versioned_docs.py
@@ -6,14 +6,14 @@ import json
 import os
 import re
 import shutil
-from string import Template
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Iterator
+from string import Template
 from urllib.parse import urlparse
 
 SITE_URL = "https://cnsplots.farid.one/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,13 +22,14 @@ _execute_gallery = os.environ.get("CNSPLOTS_DOCS_EXECUTE_GALLERY", "1") == "1"
 sys.path.insert(0, str(_active_repo_root / "src"))
 sys.path.insert(0, str(_conf_dir / "_ext"))
 
-import cnsplots as cns  # noqa: E402
 from gallery_order import GALLERY_CATEGORIES  # noqa: E402
 from theme_aware_matplotlib import (  # noqa: E402
     fallback_linkcheck_showcase_images,
     prepare_dark_gallery_thumbnails,
     theme_gallery_thumbnail_nodes,
 )
+
+import cnsplots as cns  # noqa: E402
 
 # -- Project information -----------------------------------------------------
 

--- a/examples/matplotlib_integration.py
+++ b/examples/matplotlib_integration.py
@@ -19,7 +19,6 @@ import numpy as np
 
 import cnsplots as cns
 
-
 # %%
 # Generate synthetic assay data
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/seaborn_integration.py
+++ b/examples/seaborn_integration.py
@@ -19,7 +19,6 @@ import seaborn as sns
 
 import cnsplots as cns
 
-
 # %%
 # Load example datasets
 # ~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ line-length = 88
 src = ["src"]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I", "UP006", "UP007", "UP035", "UP045", "B023"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["cnsplots"]

--- a/src/cnsplots/_multipanels.py
+++ b/src/cnsplots/_multipanels.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, cast
 
-from matplotlib.backend_bases import DrawEvent, Event, RendererBase
 import matplotlib.pyplot as plt
 from matplotlib import transforms as mtransforms
 from matplotlib.axes import Axes
+from matplotlib.backend_bases import DrawEvent, Event, RendererBase
 from matplotlib.text import Text
 from matplotlib.transforms import Bbox
 
@@ -16,8 +16,8 @@ import cnsplots._utils as utils
 from cnsplots._settings import settings
 from cnsplots._setup import ColorCycle, setup_matplotlib
 from cnsplots._sizing import (
-    _SizeUnit,
     _dimension_to_points,
+    _SizeUnit,
     _validate_positive_finite_dimension,
 )
 
@@ -704,7 +704,7 @@ class multipanel:
         get_renderer = getattr(canvas, "get_renderer", None)
         if not callable(get_renderer):
             return None
-        return cast(Optional[RendererBase], get_renderer())
+        return cast(RendererBase | None, get_renderer())
 
     def _on_draw(self, event: Event) -> None:
         """Relayout once after draw when left-side axis decorations change width."""

--- a/src/cnsplots/_settings.py
+++ b/src/cnsplots/_settings.py
@@ -33,11 +33,11 @@ Examples
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator, Sequence
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from typing import Literal

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-import logging
-from collections.abc import Callable, Sequence
-from enum import Enum
-from typing import Any, Literal, cast, overload
-
 import itertools
+import logging
 import math
 import os
 import re
+from collections.abc import Callable, Sequence
+from enum import Enum
 from pathlib import Path
+from typing import Any, Literal, cast, overload
 
 import matplotlib as mpl
 import matplotlib.colors as mcolors
@@ -34,7 +33,7 @@ import cnsplots._palettes as _palettes
 from cnsplots._comparison_types import HueComparisons
 from cnsplots._settings import settings
 from cnsplots._setup import setup_matplotlib
-from cnsplots._sizing import _SizeUnit, _dimension_to_points
+from cnsplots._sizing import _dimension_to_points, _SizeUnit
 from cnsplots._svg import _save_svg
 
 logger = logging.getLogger(__name__)

--- a/src/cnsplots/_validation.py
+++ b/src/cnsplots/_validation.py
@@ -1,6 +1,6 @@
 """Validation utilities for cnsplots."""
 
-from typing import Any, List, Optional, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -110,7 +110,7 @@ def validate_column_exists(
 
 
 def validate_columns_exist(
-    data: pd.DataFrame, columns: List[str], function_name: str
+    data: pd.DataFrame, columns: list[str], function_name: str
 ) -> None:
     """
     Validate that multiple columns exist in a DataFrame.
@@ -119,7 +119,7 @@ def validate_columns_exist(
     ----------
     data : pd.DataFrame
         The DataFrame to check.
-    columns : List[str]
+    columns : list[str]
         The column names to validate.
     function_name : str
         The name of the calling function for error messages.
@@ -184,7 +184,7 @@ def validate_adata_layer(adata, layer: str, function_name: str) -> None:
 
 
 def validate_adata_obs_columns(
-    adata, columns: Union[str, List[str]], function_name: str
+    adata, columns: str | list[str], function_name: str
 ) -> None:
     """
     Validate that columns exist in adata.obs.
@@ -193,7 +193,7 @@ def validate_adata_obs_columns(
     ----------
     adata : AnnData
         The AnnData object to check.
-    columns : Union[str, List[str]]
+    columns : str | list[str]
         The column name(s) to validate.
     function_name : str
         The name of the calling function for error messages.
@@ -221,7 +221,7 @@ def validate_adata_obs_columns(
 
 
 def validate_adata_var_columns(
-    adata, columns: Union[str, List[str]], function_name: str
+    adata, columns: str | list[str], function_name: str
 ) -> None:
     """
     Validate that columns exist in adata.var.
@@ -230,7 +230,7 @@ def validate_adata_var_columns(
     ----------
     adata : AnnData
         The AnnData object to check.
-    columns : Union[str, List[str]]
+    columns : str | list[str]
         The column name(s) to validate.
     function_name : str
         The name of the calling function for error messages.
@@ -257,9 +257,7 @@ def validate_adata_var_columns(
         )
 
 
-def validate_adata_uns_keys(
-    adata, keys: Union[str, List[str]], function_name: str
-) -> None:
+def validate_adata_uns_keys(adata, keys: str | list[str], function_name: str) -> None:
     """Validate that keys exist in ``adata.uns``."""
     if isinstance(keys, str):
         keys = [keys]
@@ -301,7 +299,7 @@ def validate_dataframe_not_empty(data: pd.DataFrame, function_name: str) -> None
 
 def validate_no_nulls(
     data: pd.DataFrame,
-    columns: Union[str, List[str]],
+    columns: str | list[str],
     function_name: str,
     allow_partial: bool = False,
 ) -> None:
@@ -312,7 +310,7 @@ def validate_no_nulls(
     ----------
     data : pd.DataFrame
         The DataFrame to check.
-    columns : Union[str, List[str]]
+    columns : str | list[str]
         The column name(s) to validate.
     function_name : str
         The name of the calling function for error messages.
@@ -359,7 +357,7 @@ def validate_no_nulls(
 
 
 def validate_column_type(
-    data: pd.DataFrame, column: str, expected_types: List[str], function_name: str
+    data: pd.DataFrame, column: str, expected_types: list[str], function_name: str
 ) -> None:
     """
     Validate that a column has the expected data type.
@@ -370,7 +368,7 @@ def validate_column_type(
         The DataFrame to check.
     column : str
         The column name to validate.
-    expected_types : List[str]
+    expected_types : list[str]
         List of acceptable type names (e.g., ['int', 'float', 'numeric']).
     function_name : str
         The name of the calling function for error messages.
@@ -526,8 +524,8 @@ def validate_time_to_event_data(
 def validate_categorical_has_levels(
     data: pd.DataFrame,
     column: str,
-    min_levels: Optional[int] = None,
-    max_levels: Optional[int] = None,
+    min_levels: int | None = None,
+    max_levels: int | None = None,
     function_name: str = "",
 ) -> None:
     """
@@ -539,9 +537,9 @@ def validate_categorical_has_levels(
         The DataFrame to check.
     column : str
         The column name to validate.
-    min_levels : Optional[int]
+    min_levels : int | None
         Minimum number of unique values required.
-    max_levels : Optional[int]
+    max_levels : int | None
         Maximum number of unique values allowed.
     function_name : str
         The name of the calling function for error messages.
@@ -569,8 +567,8 @@ def validate_categorical_has_levels(
 def validate_numeric_range(
     data: pd.DataFrame,
     column: str,
-    min_val: Optional[float] = None,
-    max_val: Optional[float] = None,
+    min_val: float | None = None,
+    max_val: float | None = None,
     function_name: str = "",
 ) -> None:
     """
@@ -582,9 +580,9 @@ def validate_numeric_range(
         The DataFrame to check.
     column : str
         The column name to validate.
-    min_val : Optional[float]
+    min_val : float | None
         Minimum acceptable value.
-    max_val : Optional[float]
+    max_val : float | None
         Maximum acceptable value.
     function_name : str
         The name of the calling function for error messages.
@@ -741,7 +739,7 @@ def safe_column_access(
 
 def safe_numeric_conversion(
     value: Any, function_name: str, context: str = ""
-) -> Union[int, float]:
+) -> int | float:
     """
     Safely convert a value to numeric, with helpful error on failure.
 
@@ -756,7 +754,7 @@ def safe_numeric_conversion(
 
     Returns
     -------
-    Union[int, float]
+    int | float
         The converted numeric value.
 
     Raises

--- a/src/cnsplots/helpers/_heatmap.py
+++ b/src/cnsplots/helpers/_heatmap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 import importlib
+from collections.abc import Sequence
 from typing import Any
 
 import matplotlib as mpl

--- a/src/cnsplots/plots/_heatmap.py
+++ b/src/cnsplots/plots/_heatmap.py
@@ -19,10 +19,9 @@ from natsort import natsort_keygen
 from scipy import sparse
 from scipy.stats import fisher_exact
 
-from cnsplots._settings import settings
 import cnsplots._utils as utils
 import cnsplots.helpers._heatmap as helper_heatmap
-from cnsplots.helpers._heatmap import ClusterMapPlotterNew, DotClustermapPlotterNew
+from cnsplots._settings import settings
 from cnsplots._utils import _legend_fontsize
 from cnsplots._validation import (
     validate_adata_layer,
@@ -33,7 +32,7 @@ from cnsplots._validation import (
     validate_dataframe_not_empty,
     validate_no_nulls,
 )
-
+from cnsplots.helpers._heatmap import ClusterMapPlotterNew, DotClustermapPlotterNew
 
 _MAX_DENSE_HEATMAP_BYTES = 512 * 1024**2
 

--- a/src/cnsplots/plots/_sets.py
+++ b/src/cnsplots/plots/_sets.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
-
+import importlib
+import sys
 from collections.abc import Mapping
 from collections.abc import Set as AbstractSet
-import importlib
 from pathlib import Path
-import sys
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/src/cnsplots/plots/_specialized.py
+++ b/src/cnsplots/plots/_specialized.py
@@ -28,7 +28,6 @@ from cnsplots._validation import (
     validate_no_nulls,
 )
 
-
 _FOREST_LABEL = "_forest_label"
 _FOREST_ESTIMATE = "_forest_estimate"
 _FOREST_LOWER = "_forest_lower"

--- a/src/cnsplots/plots/_survival.py
+++ b/src/cnsplots/plots/_survival.py
@@ -1073,9 +1073,10 @@ def cumulativeincidenceplot(
             f"non-negative, got {censor_mark_length!r}"
         )
 
-    import cnsplots.helpers._cmprsk as helper_cmprsk
     import lifelines as ll
     from lifelines.plotting import add_at_risk_counts
+
+    import cnsplots.helpers._cmprsk as helper_cmprsk
 
     data = data.copy()
     if ax is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 import types
+from collections.abc import Iterator
 from pathlib import Path
 
 import matplotlib

--- a/tests/test_axes_api.py
+++ b/tests/test_axes_api.py
@@ -12,7 +12,6 @@ from matplotlib.axes import Axes
 
 import cnsplots as cns
 
-
 PLOT_NAMES = [
     "barplot",
     "lollipopplot",

--- a/tests/test_coverage_report.py
+++ b/tests/test_coverage_report.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _report(report_path: Path) -> subprocess.CompletedProcess[str]:
+    script = Path(__file__).resolve().parents[1] / "tools" / "report_coverage.py"
+    return subprocess.run(
+        [sys.executable, str(script), str(report_path)],
+        cwd=report_path.parent,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_report_distinguishes_real_statement_and_branch_coverage(tmp_path: Path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "def choose(value):\n"
+        "    if value:\n"
+        "        value += 1\n"
+        "    return value\n"
+        "choose(True)\n",
+        encoding="utf-8",
+    )
+    data_file = tmp_path / ".coverage.sample"
+    report_path = tmp_path / "coverage.json"
+    for args in (
+        ["run", "--branch", "--source=.", str(sample)],
+        ["json", "--fail-under=0", "-o", str(report_path)],
+    ):
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "coverage",
+                args[0],
+                f"--rcfile={os.devnull}",
+                f"--data-file={data_file}",
+                *args[1:],
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+
+    assert json.loads(report_path.read_text())["totals"]["percent_covered"] < 100
+
+    result = _report(report_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "| Coverage | Covered | Total | Percent | Policy |" in result.stdout
+    assert (
+        "| Statements | 5 | 5 | 100.00% | 100% required by `make test` |"
+        in result.stdout
+    )
+    assert "| Branches | 1 | 2 | 50.00% | Reporting only |" in result.stdout
+
+
+@pytest.mark.parametrize("covered,total,percent", [(9, 10, "90.00%"), (0, 0, "n/a")])
+def test_report_does_not_apply_a_combined_coverage_gate(
+    tmp_path: Path, covered: int, total: int, percent: str
+):
+    report_path = tmp_path / "coverage.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "meta": {"branch_coverage": True},
+                "totals": {
+                    "covered_lines": covered,
+                    "num_statements": total,
+                    "covered_branches": covered,
+                    "num_branches": total,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _report(report_path)
+
+    assert result.returncode == 0, result.stderr
+    assert f"| Statements | {covered} | {total} | {percent} |" in result.stdout
+    assert f"| Branches | {covered} | {total} | {percent} |" in result.stdout
+
+
+def test_report_rejects_statement_only_data(tmp_path: Path):
+    report_path = tmp_path / "coverage.json"
+    report_path.write_text(
+        json.dumps({"meta": {"branch_coverage": False}}), encoding="utf-8"
+    )
+
+    result = _report(report_path)
+
+    assert result.returncode != 0
+    assert "Expected a branch coverage report" in result.stderr

--- a/tests/test_distribution_plot_defects.py
+++ b/tests/test_distribution_plot_defects.py
@@ -1,7 +1,7 @@
 """Regression tests for distribution plot validation."""
 
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 import matplotlib.pyplot as plt

--- a/tests/test_docs_theme_images.py
+++ b/tests/test_docs_theme_images.py
@@ -14,8 +14,8 @@ from theme_aware_matplotlib import (  # noqa: E402  # ty: ignore[unresolved-impo
     _mark_theme,
     _prepare_dark_gallery_thumbnails,
     fallback_linkcheck_showcase_images,
-    theme_gallery_thumbnail_nodes,
     theme_aware_matplotlib_scraper,
+    theme_gallery_thumbnail_nodes,
 )
 
 

--- a/tests/test_export_pipeline.py
+++ b/tests/test_export_pipeline.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager, suppress
 import math
 import os
-from pathlib import Path
 import shutil
 import signal
 import subprocess
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+from pathlib import Path
 from typing import Literal
 
 import matplotlib.pyplot as plt
@@ -310,7 +310,7 @@ def test_exported_bounds_clipping_transparency_and_raster_layers(
 
         for channel in (0, 2):
 
-            def colored(pixels: np.ndarray) -> np.ndarray:
+            def colored(pixels: np.ndarray, channel: int = channel) -> np.ndarray:
                 rgb = pixels[:, :, :3].astype(int)
                 others = np.delete(rgb, channel, axis=2).max(axis=2)
                 return (rgb[:, :, channel] - others > 80) & (pixels[:, :, 3] > 90)

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import builtins
-from collections.abc import Mapping, Sequence
 import sys
 import types
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, cast
 
@@ -20,7 +20,8 @@ from matplotlib.patches import PathPatch, Rectangle, Wedge
 
 import cnsplots as cns
 from cnsplots import _methods, _setup, _svg, _utils, _validation
-from cnsplots.helpers import _heatmap as helper_heatmap, _phylo, _sankey
+from cnsplots.helpers import _heatmap as helper_heatmap
+from cnsplots.helpers import _phylo, _sankey
 from cnsplots.plots import _distribution as dist_mod
 from cnsplots.plots import _genomics as genomics_mod
 from cnsplots.plots import _heatmap as heatmap_mod

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -131,3 +132,67 @@ def test_doc_serve_starts_preview_after_build(docs_repo: Path) -> None:
         "--directory",
         "docs/build/html",
     ]
+
+
+def test_branch_audit_preserves_statement_gate_and_propagates_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in tuple(os.environ):
+        if name in {"COVERAGE_FILE", "COVERAGE_PROCESS_START"} or name.startswith(
+            "COV_CORE_"
+        ):
+            monkeypatch.delenv(name)
+    repo = Path(__file__).resolve().parents[1]
+    for name in ("Makefile", "pyproject.toml", "tools/report_coverage.py"):
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(repo / name, target)
+    package = tmp_path / "src/cnsplots/__init__.py"
+    package.parent.mkdir(parents=True)
+    package.write_text(
+        'def select(flag):\n    if flag:\n        return "enabled"\n',
+        encoding="utf-8",
+    )
+    test_file = tmp_path / "tests/test_sample.py"
+    test_file.parent.mkdir()
+    test_file.write_text(
+        "from cnsplots import select\n"
+        'def test_select():\n    assert select(True) == "enabled"\n',
+        encoding="utf-8",
+    )
+    # Use the current test environment without syncing a second project.
+    uv = tmp_path / "bin/uv"
+    uv.parent.mkdir()
+    uv.write_text(
+        f"#!{sys.executable}\n"
+        "import os, sys\n"
+        "args = sys.argv[5:]\n"
+        "args = args[1:] if args[0] == 'python' else ['-m', *args]\n"
+        "os.execv(sys.executable, [sys.executable, *args])\n",
+        encoding="utf-8",
+    )
+    uv.chmod(0o755)
+
+    result = _run_make(tmp_path, "test")
+    assert result.returncode == 0, result.stdout + result.stderr
+    statement_data = (tmp_path / ".coverage").read_bytes()
+    result = _run_make(tmp_path, "test-branches")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "| Statements | 3 | 3 | 100.00% |" in result.stdout
+    assert "| Branches | 1 | 2 | 50.00% | Reporting only |" in result.stdout
+    assert (tmp_path / ".coverage").read_bytes() == statement_data
+
+    package.write_text(
+        package.read_text() + '\ndef unused():\n    return "missing"\n',
+        encoding="utf-8",
+    )
+    result = _run_make(tmp_path, "test")
+    assert result.returncode != 0
+    assert "Required test coverage of 100% not reached" in result.stdout
+
+    test_file.write_text("def test_failure():\n    assert False\n", encoding="utf-8")
+    result = _run_make(tmp_path, "test-branches")
+    assert result.returncode != 0
+    assert "1 failed" in result.stdout
+    assert "| Coverage |" not in result.stdout

--- a/tests/test_methods_and_helpers.py
+++ b/tests/test_methods_and_helpers.py
@@ -16,7 +16,8 @@ from matplotlib.transforms import Bbox
 
 import cnsplots as cns
 from cnsplots import _utils
-from cnsplots.helpers import _cmprsk, _heatmap as helper_heatmap, _phylo, _sankey
+from cnsplots.helpers import _cmprsk, _phylo, _sankey
+from cnsplots.helpers import _heatmap as helper_heatmap
 
 
 @pytest.mark.parametrize(

--- a/tests/test_methods_regressions.py
+++ b/tests/test_methods_regressions.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import Counter
 from typing import Any
 from unittest.mock import Mock
-import warnings
 
 import lifelines as ll
 import numpy as np

--- a/tests/test_palette_registry.py
+++ b/tests/test_palette_registry.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 import hashlib
 import subprocess
 import sys
+from collections.abc import Sequence
 from typing import Any, cast, get_args
 
 import matplotlib as mpl
@@ -17,7 +17,6 @@ from matplotlib.typing import ColorType
 
 import cnsplots as cns
 from cnsplots import _palettes, _utils
-
 
 # Captured from main before replacing palette dispatch with the registry.
 _QUALITATIVE_COLORS = {

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -11,8 +11,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from matplotlib.axes import Axes
-from matplotlib.colorbar import Colorbar
 from matplotlib.collections import LineCollection
+from matplotlib.colorbar import Colorbar
 from matplotlib.colors import to_rgba
 from matplotlib.legend import Legend
 

--- a/tests/test_precision_recall.py
+++ b/tests/test_precision_recall.py
@@ -14,7 +14,6 @@ from cnsplots.plots._precision_recall import (
     precisionrecallplot,
 )
 
-
 CURVE_COLUMNS = ["model", "recall", "precision", "threshold"]
 METRIC_COLUMNS = [
     "model",

--- a/tests/test_public_api_contracts.py
+++ b/tests/test_public_api_contracts.py
@@ -24,7 +24,6 @@ from matplotlib.text import Text
 
 import cnsplots as cns
 
-
 _PUBLIC_PLOT_NAMES = frozenset(
     {
         "barplot",
@@ -306,12 +305,13 @@ def test_public_callable_annotations_resolve() -> None:
 
 
 def test_public_plot_axes_signature_and_return_contract() -> None:
+    from matplotlib_venn._common import VennDiagram
+
     import cnsplots.plots as plots
     from cnsplots.helpers._heatmap import (
         ClusterMapPlotterNew,
         DotClustermapPlotterNew,
     )
-    from matplotlib_venn._common import VennDiagram
 
     assert set(plots.__all__) == _PUBLIC_PLOT_NAMES
     assert all(getattr(plots, name) is getattr(cns, name) for name in plots.__all__)

--- a/tests/test_roc_results.py
+++ b/tests/test_roc_results.py
@@ -14,7 +14,6 @@ import cnsplots as cns
 from cnsplots.helpers import _roc
 from cnsplots.plots import _specialized
 
-
 _TABLES: tuple[Literal["curves", "metrics", "bands", "comparisons"], ...] = (
     "curves",
     "metrics",

--- a/tests/test_sankey_multistage_helper.py
+++ b/tests/test_sankey_multistage_helper.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import Any, cast
 
 import matplotlib.pyplot as plt
-from matplotlib.axes import Axes
-from matplotlib.colors import to_rgba
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.axes import Axes
+from matplotlib.colors import to_rgba
 
 from cnsplots.helpers import _sankey
 

--- a/tests/test_special_axes.py
+++ b/tests/test_special_axes.py
@@ -16,7 +16,6 @@ from matplotlib.transforms import Bbox
 import cnsplots as cns
 import cnsplots._utils as plot_utils
 
-
 SPECIAL_PLOT_NAMES = [
     "placeholderplot",
     "sankeyplot",

--- a/tests/test_statistical_options.py
+++ b/tests/test_statistical_options.py
@@ -9,7 +9,6 @@ import pytest
 
 import cnsplots as cns
 
-
 _CONTINUOUS_PLOTS = ("boxplot", "violinplot", "barplot", "lollipopplot")
 _P_ADJUST_METHODS = ("bonferroni", "holm", "fdr_bh", "fdr_by")
 

--- a/tests/test_survival_results.py
+++ b/tests/test_survival_results.py
@@ -16,7 +16,6 @@ from statsmodels.stats.multitest import multipletests
 
 import cnsplots as cns
 
-
 _COLUMNS = {
     "kind",
     "groups",

--- a/tests/test_violin_layers.py
+++ b/tests/test_violin_layers.py
@@ -5,12 +5,12 @@ from typing import Any
 from unittest.mock import patch
 
 import matplotlib.pyplot as plt
-from matplotlib.colors import to_rgba
-from matplotlib.patches import PathPatch
 import numpy as np
 import pandas as pd
 import pytest
 import seaborn as sns
+from matplotlib.colors import to_rgba
+from matplotlib.patches import PathPatch
 
 import cnsplots as cns
 

--- a/tests/test_visual_regressions.py
+++ b/tests/test_visual_regressions.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 import os
 import platform
 import sys
+from collections.abc import Iterator
 
 import anndata as ad
 import matplotlib as mpl

--- a/tools/report_coverage.py
+++ b/tools/report_coverage.py
@@ -1,0 +1,34 @@
+"""Display separate statement and branch totals from a coverage.py JSON report."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    if not report["meta"]["branch_coverage"]:
+        raise SystemExit("Expected a branch coverage report")
+    totals = report["totals"]
+    print("| Coverage | Covered | Total | Percent | Policy |")
+    print("| --- | ---: | ---: | ---: | --- |")
+    for label, covered, total, policy in (
+        (
+            "Statements",
+            totals["covered_lines"],
+            totals["num_statements"],
+            "100% required by `make test`",
+        ),
+        (
+            "Branches",
+            totals["covered_branches"],
+            totals["num_branches"],
+            "Reporting only",
+        ),
+    ):
+        percent = f"{100 * covered / total:.2f}%" if total else "n/a"
+        print(f"| {label} | {covered} | {total} | {percent} | {policy} |")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

Strengthen lint checks and make branch coverage visible while preserving Python 3.10 compatibility and the existing 100% statement coverage gate.

- Enable Ruff import ordering, four compatible typing modernization rules, and loop-variable capture checks; apply reviewed fixes and document exclusions for deliberate zip truncation, dynamic attributes, and scientific Unicode.
- Add `make test-branches` with isolated coverage data, separate statement/branch percentages, and a documented reporting-only threshold policy.
- Publish the branch summary and JSON artifact in Python 3.12 CI, retaining export diagnostics if the audit fails.
- Test the report and Make commands with real coverage data, including statement-gate enforcement, preserved data, and failure propagation.

## How it was tested

- `make test`: 1,631 passed; 5,390/5,390 statements covered (100%).
- `make lint`: passed all checks.
- `make test-branches`: 1,631 passed; 2,070/2,112 branches covered (98.01%), with 42 missing branches.
- Python 3.10 syntax checks passed for the Ruff-modified Python files.

## Risks or follow-ups

The branch audit adds one full test run to Python 3.12 CI. Branch coverage is informational; a future numeric threshold requires an explicit policy change. The recorded baseline uses Python 3.12.12/macOS and coverage.py 7.13.4; CI artifacts capture Linux results. Dependencies and plotting behavior are unchanged.

## Related issue

Closes #150
Closes #170
