### PR TITLE
✨ Align paired comparisons by subject

### DIFF
--- a/docs/statistical_methods.md
+++ b/docs/statistical_methods.md
@@ -17,29 +17,60 @@ package-wide imputation or complete-case policy.
 `pairs` is supplied. `pairs="all"` compares displayed category pairs;
 `pairs="hue"` compares hue levels within every displayed category. Explicit
 hue comparisons use tuples such as `[(("A", "control"), ("A", "treated"))]`.
+Here, `pairs` selects group contrasts; it does not identify matched subjects.
 
-| Functions | Default test when comparisons are requested | Other supported test |
+| Functions | Default test when comparisons are requested | Other supported tests |
 | --- | --- | --- |
-| `boxplot`, `violinplot` | `"Mann-Whitney"` | `"t-test_welch"` |
-| `barplot`, `lollipopplot` | `"t-test_welch"` | `"Mann-Whitney"` |
+| `boxplot`, `violinplot` | `"Mann-Whitney"` | `"t-test_welch"`, `"t-test_paired"`, `"Wilcoxon"` |
+| `barplot`, `lollipopplot` | `"t-test_welch"` | `"Mann-Whitney"`, `"t-test_paired"`, `"Wilcoxon"` |
 
-Both tests are two-sided and use **independent** samples. Mann–Whitney tests
-equality of the underlying distributions; interpreting it only as a median
-difference requires additional distributional assumptions. It delegates to
+Mann–Whitney and Welch's t-test are two-sided tests of **independent** samples.
+Mann–Whitney tests equality of the underlying distributions; interpreting it only
+as a median difference requires additional distributional assumptions. It delegates to
 SciPy through statannotations, including automatic exact/asymptotic selection
 and tie handling. Welch's t-test compares means without assuming equal
-variances; its small-sample justification assumes normal populations. Neither
-option is a paired test. See [SciPy Mann–Whitney](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mannwhitneyu.html)
+variances; its small-sample justification assumes normal populations.
+See [SciPy Mann–Whitney](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mannwhitneyu.html)
 and [Welch's t-test](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ttest_ind.html).
+
+For matched or repeated measurements, select `test="t-test_paired"` or
+`test="Wilcoxon"` and supply the subject identifier column with
+`subject="subject_id"`. Both are two-sided tests and assume independent
+subjects. The paired t-test compares the mean within-subject difference with
+zero; its small-sample normality assumption concerns those differences.
+Wilcoxon tests whether their distribution is symmetric about zero. It uses
+SciPy's `zero_method="wilcox"` (discard zero differences from the ranks),
+`correction=False`, and `method="auto"`; SciPy determines the p-value method
+and tie handling. See [SciPy's paired t-test](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ttest_rel.html)
+and [Wilcoxon signed-rank test](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.wilcoxon.html).
+`subject` is required for paired tests and is rejected with independent tests.
 
 These four plots exclude rows missing `x`, `y`, or the selected `hue`, and
 exclude levels omitted from `order` or `hue_order`. The resulting rows feed
-drawing, summaries, counts, and tests. This cleaning does not remove infinity.
+drawing, summaries, counts, and independent tests. This cleaning does not remove
+infinity.
 Hiding boxplot outliers does not remove those observations from tests or counts.
 Category counts pool the displayed hue levels.
 
+Paired tests additionally align each requested contrast by subject identifier,
+regardless of row order. Rows with missing identifiers and subjects absent from
+either group are excluded from that test. Each compared group must have at most
+one complete displayed observation per subject; duplicates raise an error,
+rather than being averaged. Both paired tests require at least two matched
+subjects. Nonfinite matched response values and comparisons in which every
+within-subject difference is zero are rejected. Ties and mixtures of zero and
+nonzero differences otherwise follow SciPy's defaults.
+Nonfinite p-values returned by SciPy are rejected before correction or annotation.
+Matching is performed separately for every contrast, so different comparisons
+can use different subjects. Plot summaries and tick-label counts still use all
+displayed observations and can exceed the matched test counts. Selecting a paired
+test does not change the plotted summaries, error bars, or bootstrap resampling
+unit into a paired analysis.
+
 `get_comparison_results(ax)` returns the tested sample sizes and raw and
 adjusted p-values without rerunning tests. It estimates no effect size.
+For paired tests, `paired` is `True` and `n1 == n2` is the number of matched
+subjects before Wilcoxon discards zero differences from the ranks.
 `group1` and `group2` follow categorical axis order, which can differ from the
 supplied pair order; the two-sided p-value does not establish a direction of
 effect. The accessor reports the latest stored comparisons on the axes, so use
@@ -73,22 +104,15 @@ comparisons = cns.get_comparison_results(ax)
 print(comparisons[["n1", "n2", "paired", "pvalue_raw", "pvalue_adjusted"]])
 ```
 
-For repeated measurements, `slopeplot` draws paired observations using the
-`pair` identifier. It requires one value per condition per subject, exactly two
-conditions, and one `x` group per subject; missing values and incomplete or
-duplicate pairs are rejected. It performs **no hypothesis test**. This example
-aligns complete subjects explicitly and computes a separate, unadjusted,
-prespecified paired t-test of after-minus-before differences. Its normality
-assumption concerns the within-subject differences, with independent subjects.
-See [SciPy's paired t-test](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ttest_rel.html).
+For repeated measurements, select the subject column explicitly. Shuffling
+these rows does not change which observations are paired:
 
 ```python
 import cnsplots as cns
 import matplotlib.pyplot as plt
 import pandas as pd
-from scipy.stats import ttest_rel
 
-wide = (
+paired = (
     pd.DataFrame(
         {
             "subject": ["s1", "s2", "s3", "s4", "s5"],
@@ -96,27 +120,29 @@ wide = (
             "after": [6.5, 6.8, 7.0, 5.0, 7.5],
         }
     )
-    .set_index("subject")
-    .dropna(subset=["before", "after"])
+    .melt(id_vars="subject", var_name="condition", value_name="response")
+    .sample(frac=1, random_state=42)
 )
-paired = wide.reset_index().melt(
-    id_vars="subject", var_name="condition", value_name="response"
-)
-paired["cohort"] = "Study"
 fig, ax = plt.subplots()
-cns.slopeplot(
+cns.boxplot(
     paired,
-    "cohort",
+    "condition",
     "response",
-    hue="condition",
-    pair="subject",
-    hue_order=["before", "after"],
+    order=["before", "after"],
+    pairs=[("before", "after")],
+    test="t-test_paired",
+    subject="subject",
+    p_adjust=None,  # one prespecified comparison
     ax=ax,
 )
-paired_result = ttest_rel(wide["after"], wide["before"], alternative="two-sided")
-print("Mean after - before:", (wide["after"] - wide["before"]).mean())
-print("Paired t-test, one prespecified test, no correction:", paired_result.pvalue)
+comparisons = cns.get_comparison_results(ax)
+print(comparisons[["n1", "n2", "paired", "pvalue_raw", "pvalue_adjusted"]])
 ```
+
+`slopeplot` draws paired observations using its `pair` identifier. It requires
+one value per condition per subject, exactly two conditions, and one `x` group
+per subject; missing values and incomplete or duplicate pairs are rejected.
+It performs **no hypothesis test**.
 
 Implementation: [categorical comparisons and results](https://github.com/faridrashidi/cnsplots/blob/main/src/cnsplots/_utils.py),
 [distribution plots](https://github.com/faridrashidi/cnsplots/blob/main/src/cnsplots/plots/_distribution.py),

--- a/examples/boxplot.py
+++ b/examples/boxplot.py
@@ -13,6 +13,7 @@ including statistical testing, outlier display, grouping, and styling.
 # ~~~~~~~~~
 # We'll use classic datasets for demonstration.
 import matplotlib.pyplot as plt
+import pandas as pd
 import seaborn as sns
 
 import cnsplots as cns
@@ -122,6 +123,43 @@ with cns.settings.context(pvalue_format="full", pvalue_fontsize=8):
         p_adjust="fdr_bh",
     )
 ax.set_title("Welch Tests with FDR Correction")
+
+
+# %%
+# Boxplot with paired subject comparisons
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ``pairs`` chooses conditions; ``subject`` identifies matched observations.
+# The paired t-test aligns subjects even when the rows are shuffled.
+# Use ``test="Wilcoxon"`` for a two-sided Wilcoxon signed-rank test instead.
+paired = (
+    pd.DataFrame(
+        {
+            "subject": ["s1", "s2", "s3", "s4", "s5"],
+            "before": [8.0, 7.0, 9.0, 6.0, 8.5],
+            "after": [6.5, 6.8, 7.0, 5.0, 7.5],
+        }
+    )
+    .melt(id_vars="subject", var_name="condition", value_name="response")
+    .sample(frac=1, random_state=42)
+)
+with cns.settings.context(pvalue_format="full", pvalue_fontsize=8):
+    cns.figure(100, 150)
+    ax = cns.boxplot(
+        data=paired,
+        x="condition",
+        y="response",
+        order=["before", "after"],
+        pairs=[("before", "after")],
+        test="t-test_paired",
+        subject="subject",
+        p_adjust=None,  # one prespecified comparison
+        add_count=True,
+    )
+ax.set_title("Subject-Matched Paired t-Test")
+comparisons = cns.get_comparison_results(ax)
+print(comparisons[["n1", "n2", "paired", "pvalue_raw", "pvalue_adjusted"]])
+# Test counts are matched subjects. Tick counts include all displayed rows,
+# which can be larger when some subjects lack one of the compared measurements.
 
 
 # %%

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -78,6 +78,7 @@ _ContinuousPaletteName = Literal[
 ]
 _RGBColor = tuple[float, float, float]
 _P_ADJUST_METHODS = ("bonferroni", "holm", "fdr_bh", "fdr_by")
+_PAIRED_TESTS = ("t-test_paired", "Wilcoxon")
 _COMPARISON_COLUMNS = [
     "group1",
     "group2",
@@ -966,6 +967,56 @@ def _resolve_categorical_orientation(data, x, y, orient=None):
     return "h" if infer_orient(data[x], data[y], orient) == "y" else "v"
 
 
+def _validate_paired_subject(data, test, subject):
+    if test in _PAIRED_TESTS:
+        if not isinstance(subject, str) or subject not in data.columns:
+            raise ValueError(
+                "Paired tests require subject to name a column in data; "
+                f"got {subject!r}."
+            )
+    elif subject is not None:
+        raise ValueError("subject is only supported with paired tests.")
+
+
+def _align_paired_comparisons(annotator, data, plotting, subject):
+    """Replace each contrast's test samples without changing its plot geometry."""
+    category, value = (
+        (plotting["y"], plotting["x"])
+        if plotting["orient"] == "h"
+        else (plotting["x"], plotting["y"])
+    )
+    hue = plotting.get("hue")
+    columns = [category, value, subject] + ([] if hue is None else [hue])
+    complete = data.dropna(subset=columns)
+    categories = complete[category].map(annotator._plotter.plotter.formatter)
+    for first, second in annotator._struct_pairs:
+        samples = []
+        for struct in (first, second):
+            group = struct["group"]
+            selected = categories == group[0]
+            if len(group) > 1:
+                selected &= complete[hue] == group[1]
+            sample = complete.loc[selected].set_index(subject, drop=False)[value]
+            if sample.index.has_duplicates:
+                raise ValueError(
+                    f"Duplicate subject observations in compared group {group!r}."
+                )
+            samples.append(sample)
+        aligned = pd.concat(samples, axis=1, join="inner")
+        if len(aligned) < 2:
+            raise ValueError(
+                "Paired tests require at least two complete subject pairs."
+            )
+        values = aligned.to_numpy(dtype=float)
+        if not np.isfinite(values).all():
+            raise ValueError("Paired tests require finite values in matched pairs.")
+        if (values[:, 0] == values[:, 1]).all():
+            raise ValueError("Paired tests require at least one nonzero difference.")
+        # Sort by values for reproducible reductions regardless of row/ID order.
+        values = values[np.lexsort((values[:, 1], values[:, 0]))]
+        first["group_data"], second["group_data"] = values.T
+
+
 def _prepare_categorical_plot_data(plotting):
     """Share complete displayed rows across rendering, summaries, and counts."""
     data = plotting["data"]
@@ -1039,11 +1090,14 @@ def get_comparison_results(ax: Axes | None = None) -> pd.DataFrame:
         order (shorter brackets first). ``group1`` and ``group2`` follow the
         categorical axis order, not necessarily the supplied pair order. They
         are category labels, or ``(category, hue)`` tuples for hue comparisons.
-        ``test``, ``alternative``, and ``paired`` identify the test; all currently
-        supported tests use independent observations (``paired=False``).
+        ``test``, ``alternative``, and ``paired`` identify the test;
+        ``t-test_paired`` and ``Wilcoxon`` use subject-aligned observations
+        (``paired=True``). Other tests use independent observations.
         ``alternative`` is ``'two-sided'`` for continuous tests and 2-by-2 Fisher
         tests, and None for chi-squared and larger Fisher independence tests.
-        ``n1`` and ``n2`` count contributing observations. ``pvalue_raw`` and
+        ``n1`` and ``n2`` count contributing observations; for paired tests both
+        equal the number of complete matched pairs, including zero differences
+        discarded from Wilcoxon ranks. ``pvalue_raw`` and
         ``pvalue_adjusted`` contain raw and corrected p-values; without correction
         they are equal and ``p_adjust`` is None. ``pvalue_annotation``,
         ``significant``, and ``annotation`` describe the exact rendered result.
@@ -1063,6 +1117,12 @@ def get_comparison_results(ax: Axes | None = None) -> pd.DataFrame:
     these can differ from its raw category tick counts when stack values are
     missing. Correction covers all resolved pairs in one plot call, including
     all categories for pairs='hue', and does not extend across plot calls.
+
+    Paired tests additionally exclude missing subject identifiers and incomplete
+    pairs separately for each contrast. Duplicate subjects within either compared
+    group among complete displayed rows raise ValueError. At least two matched
+    pairs with finite values and at least one nonzero difference are required.
+    Plot summaries and tick counts can include observations excluded by pairing.
 
     Existing statannotations display semantics are preserved: Bonferroni uses
     adjusted p-values in labels; Holm and FDR methods display raw p-values with
@@ -1091,6 +1151,8 @@ def _collect_comparison_results(annotator, test, correction, p_adjust, contingen
     annotations = annotator.annotations
     results = [annotation.data for annotation in annotations]
     raw = np.asarray([result.pvalue for result in results])
+    if test in _PAIRED_TESTS and not np.isfinite(raw).all():
+        raise ValueError("Paired test returned a nonfinite p-value.")
     adjusted = raw.copy()
     if correction is not None:
         adjusted = multipletests(raw, method=p_adjust)[1]
@@ -1120,7 +1182,7 @@ def _collect_comparison_results(annotator, test, correction, p_adjust, contingen
                 "group2": group2[0] if len(group2) == 1 else group2,
                 "test": test,
                 "alternative": alternative,
-                "paired": False,
+                "paired": test in _PAIRED_TESTS,
                 "n1": n1,
                 "n2": n2,
                 "pvalue_raw": pvalue_raw,
@@ -1144,6 +1206,7 @@ def _p_value_helper(
     format=None,
     label_clearance=None,
     p_adjust=None,
+    subject=None,
 ):
     resolved_format = settings.pvalue_format if format is None else format
     if resolved_format not in {"star", "threshold", "full"}:
@@ -1260,6 +1323,8 @@ def _p_value_helper(
     correction = annotator.comparisons_correction
     annotator.comparisons_correction = None
     if contingency is None:
+        if test in _PAIRED_TESTS:
+            _align_paired_comparisons(annotator, data, plotting, subject)
         annotator.apply_test()
     else:
         annotator.set_pvalues(pvalues=pvalues)
@@ -1279,6 +1344,15 @@ def _p_value_helper(
         logger.info("P-values were determined by two-sided Mann-Whitney U test.")
     if test == "t-test_welch":
         logger.info("P-values were determined by two-sided Welch's t-test.")
+    if test == "t-test_paired":
+        logger.info(
+            "P-values were determined by a two-sided subject-aligned paired t-test."
+        )
+    if test == "Wilcoxon":
+        logger.info(
+            "P-values were determined by a two-sided subject-aligned Wilcoxon "
+            "signed-rank test."
+        )
     if test == "fisher-exact":
         logger.info("P-values were determined by two-sided Fisher's exact test.")
     if test == "chi-squared":

--- a/src/cnsplots/plots/_categorical.py
+++ b/src/cnsplots/plots/_categorical.py
@@ -245,7 +245,10 @@ def barplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
-    test: Literal["Mann-Whitney", "t-test_welch"] = "t-test_welch",
+    test: Literal[
+        "Mann-Whitney", "t-test_welch", "t-test_paired", "Wilcoxon"
+    ] = "t-test_welch",
+    subject: str | None = None,
     p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
     **kwargs: Any,
@@ -280,8 +283,19 @@ def barplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
-    test : {'Mann-Whitney', 't-test_welch'}, default: 't-test_welch'
-        Statistical test used for pairwise comparisons.
+    test : {'Mann-Whitney', 't-test_welch', 't-test_paired', 'Wilcoxon'}, default: 't-test_welch'
+        Two-sided statistical test used for group comparisons. Paired tests
+        require ``subject``; ``pairs`` still selects the groups to compare.
+    subject : str, optional
+        Subject identifier column, required only for paired tests. Within each
+        contrast, align complete displayed observations by subject, excluding
+        missing identifiers and incomplete pairs. Duplicate subjects within a
+        compared group raise ValueError, even if unmatched in the other group.
+        At least two matched pairs with finite values and at least one nonzero
+        difference are required. Wilcoxon uses SciPy's ``zero_method='wilcox'``,
+        ``correction=False``, and ``method='auto'`` defaults. Plot summaries and
+        tick counts still use all displayed observations; result-table counts
+        report matched pairs. Invalid subjects or paired samples raise ValueError.
     p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
         Multiple-comparison correction applied across the resolved pairs.
     ax : matplotlib.axes.Axes, optional
@@ -332,8 +346,9 @@ def barplot(
     utils._validate_statistical_options(
         test,
         p_adjust,
-        valid_tests=("Mann-Whitney", "t-test_welch"),
+        valid_tests=("Mann-Whitney", "t-test_welch", "t-test_paired", "Wilcoxon"),
     )
+    utils._validate_paired_subject(data, test, subject)
 
     if "addtip" in kwargs:
         raise TypeError(
@@ -416,6 +431,7 @@ def barplot(
             plotting,
             pairs,
             p_adjust=p_adjust,
+            subject=subject,
             **pvalue_kwargs,
         )
     if show_legend:
@@ -448,7 +464,10 @@ def lollipopplot(
     palette: Any = None,
     baseline: float = 0,
     *,
-    test: Literal["Mann-Whitney", "t-test_welch"] = "t-test_welch",
+    test: Literal[
+        "Mann-Whitney", "t-test_welch", "t-test_paired", "Wilcoxon"
+    ] = "t-test_welch",
+    subject: str | None = None,
     p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
 ) -> Axes:
@@ -505,8 +524,19 @@ def lollipopplot(
         or a column name in data for palette-as-column mapping.
     baseline : float, default: 0
         Value at which the stems originate.
-    test : {'Mann-Whitney', 't-test_welch'}, default: 't-test_welch'
-        Statistical test used for pairwise comparisons.
+    test : {'Mann-Whitney', 't-test_welch', 't-test_paired', 'Wilcoxon'}, default: 't-test_welch'
+        Two-sided statistical test used for group comparisons. Paired tests
+        require ``subject``; ``pairs`` still selects the groups to compare.
+    subject : str, optional
+        Subject identifier column, required only for paired tests. Within each
+        contrast, align complete displayed observations by subject, excluding
+        missing identifiers and incomplete pairs. Duplicate subjects within a
+        compared group raise ValueError, even if unmatched in the other group.
+        At least two matched pairs with finite values and at least one nonzero
+        difference are required. Wilcoxon uses SciPy's ``zero_method='wilcox'``,
+        ``correction=False``, and ``method='auto'`` defaults. Plot summaries and
+        tick counts still use all displayed observations; result-table counts
+        report matched pairs. Invalid subjects or paired samples raise ValueError.
     p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
         Multiple-comparison correction applied across the resolved pairs.
     ax : matplotlib.axes.Axes, optional
@@ -565,8 +595,9 @@ def lollipopplot(
     utils._validate_statistical_options(
         test,
         p_adjust,
-        valid_tests=("Mann-Whitney", "t-test_welch"),
+        valid_tests=("Mann-Whitney", "t-test_welch", "t-test_paired", "Wilcoxon"),
     )
+    utils._validate_paired_subject(data, test, subject)
 
     palette_is_column = isinstance(palette, str) and palette in data.columns
     if hue is not None and palette_is_column and palette != hue:
@@ -719,6 +750,7 @@ def lollipopplot(
             plotting,
             pairs,
             p_adjust=p_adjust,
+            subject=subject,
         )
 
     # Legend

--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -41,7 +41,10 @@ def boxplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
-    test: Literal["Mann-Whitney", "t-test_welch"] = "Mann-Whitney",
+    test: Literal[
+        "Mann-Whitney", "t-test_welch", "t-test_paired", "Wilcoxon"
+    ] = "Mann-Whitney",
+    subject: str | None = None,
     p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
     **kwargs: Any,
@@ -84,8 +87,19 @@ def boxplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
-    test : {'Mann-Whitney', 't-test_welch'}, default: 'Mann-Whitney'
-        Statistical test used for pairwise comparisons.
+    test : {'Mann-Whitney', 't-test_welch', 't-test_paired', 'Wilcoxon'}, default: 'Mann-Whitney'
+        Two-sided statistical test used for group comparisons. Paired tests
+        require ``subject``; ``pairs`` still selects the groups to compare.
+    subject : str, optional
+        Subject identifier column, required only for paired tests. Within each
+        contrast, align complete displayed observations by subject, excluding
+        missing identifiers and incomplete pairs. Duplicate subjects within a
+        compared group raise ValueError, even if unmatched in the other group.
+        At least two matched pairs with finite values and at least one nonzero
+        difference are required. Wilcoxon uses SciPy's ``zero_method='wilcox'``,
+        ``correction=False``, and ``method='auto'`` defaults. Plot summaries and
+        tick counts still use all displayed observations; result-table counts
+        report matched pairs. Invalid subjects or paired samples raise ValueError.
     p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
         Multiple-comparison correction applied across the resolved pairs.
     ax : matplotlib.axes.Axes, optional
@@ -133,8 +147,9 @@ def boxplot(
     utils._validate_statistical_options(
         test,
         p_adjust,
-        valid_tests=("Mann-Whitney", "t-test_welch"),
+        valid_tests=("Mann-Whitney", "t-test_welch", "t-test_paired", "Wilcoxon"),
     )
+    utils._validate_paired_subject(data, test, subject)
 
     if "addcount" in kwargs:
         raise TypeError(
@@ -221,6 +236,7 @@ def boxplot(
             plotting,
             pairs,
             p_adjust=p_adjust,
+            subject=subject,
         )
 
     if add_count:
@@ -244,7 +260,10 @@ def violinplot(
     hue: str | None = None,
     order: list[str] | None = None,
     hue_order: list[str] | None = None,
-    test: Literal["Mann-Whitney", "t-test_welch"] = "Mann-Whitney",
+    test: Literal[
+        "Mann-Whitney", "t-test_welch", "t-test_paired", "Wilcoxon"
+    ] = "Mann-Whitney",
+    subject: str | None = None,
     p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None = None,
     ax: Axes | None = None,
     **kwargs: Any,
@@ -295,8 +314,19 @@ def violinplot(
         Order of categories along the categorical axis.
     hue_order : list of str, optional
         Order of hue levels.
-    test : {'Mann-Whitney', 't-test_welch'}, default: 'Mann-Whitney'
-        Statistical test used for pairwise comparisons.
+    test : {'Mann-Whitney', 't-test_welch', 't-test_paired', 'Wilcoxon'}, default: 'Mann-Whitney'
+        Two-sided statistical test used for group comparisons. Paired tests
+        require ``subject``; ``pairs`` still selects the groups to compare.
+    subject : str, optional
+        Subject identifier column, required only for paired tests. Within each
+        contrast, align complete displayed observations by subject, excluding
+        missing identifiers and incomplete pairs. Duplicate subjects within a
+        compared group raise ValueError, even if unmatched in the other group.
+        At least two matched pairs with finite values and at least one nonzero
+        difference are required. Wilcoxon uses SciPy's ``zero_method='wilcox'``,
+        ``correction=False``, and ``method='auto'`` defaults. Plot summaries and
+        tick counts still use all displayed observations; result-table counts
+        report matched pairs. Invalid subjects or paired samples raise ValueError.
     p_adjust : {'bonferroni', 'holm', 'fdr_bh', 'fdr_by'}, optional
         Multiple-comparison correction applied across the resolved pairs.
     ax : matplotlib.axes.Axes, optional
@@ -350,8 +380,9 @@ def violinplot(
     utils._validate_statistical_options(
         test,
         p_adjust,
-        valid_tests=("Mann-Whitney", "t-test_welch"),
+        valid_tests=("Mann-Whitney", "t-test_welch", "t-test_paired", "Wilcoxon"),
     )
+    utils._validate_paired_subject(data, test, subject)
 
     if "addcount" in kwargs:
         raise TypeError(
@@ -431,6 +462,7 @@ def violinplot(
             annotation_kwargs,
             pairs,
             p_adjust=p_adjust,
+            subject=subject,
         )
 
     if add_count:

--- a/tests/test_paired_comparisons.py
+++ b/tests/test_paired_comparisons.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, Literal, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import stats
+from statannotations.stats.StatTest import StatTest
+from statsmodels.stats.multitest import multipletests
+
+import cnsplots as cns
+
+_PLOTS = ("boxplot", "violinplot", "barplot", "lollipopplot")
+_TESTS = ("t-test_paired", "Wilcoxon")
+PairedTest = Literal["t-test_paired", "Wilcoxon"]
+
+
+@pytest.fixture
+def paired_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "group": np.repeat(["A", "B", "C"], 7),
+            "subject": list(range(7)) * 3,
+            "value": [1, 3, 8, 2, 12, 5, 10]
+            + [1, 4, 9, 1, 14, 7, 8]
+            + [5, 7, 9, 7, 11, 13, 12],
+        }
+    ).astype({"value": float})
+
+
+@pytest.fixture
+def paired_annotations(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    instances = []
+    original = cns.utils.Annotator
+
+    def capture(*args: Any, **kwargs: Any) -> Any:
+        annotator = original(*args, **kwargs)
+        instances.append(annotator)
+        return annotator
+
+    monkeypatch.setattr(cns.utils, "Annotator", capture)
+    return instances
+
+
+def _reference(test: PairedTest, first: Any, second: Any) -> Any:
+    if test == "t-test_paired":
+        return stats.ttest_rel(first, second, alternative="two-sided")
+    return stats.wilcoxon(
+        first,
+        second,
+        alternative="two-sided",
+        zero_method="wilcox",
+        correction=False,
+        method="auto",
+    )
+
+
+@pytest.mark.parametrize("plot_name", _PLOTS)
+@pytest.mark.parametrize("test", _TESTS)
+def test_subject_alignment_is_invariant_to_row_order(
+    plot_name: str, test: PairedTest, paired_df: pd.DataFrame
+) -> None:
+    parameters = inspect.signature(getattr(cns, plot_name)).parameters
+    assert parameters["subject"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["subject"].default is None
+    original = paired_df.copy(deep=True)
+    results = []
+    for data in (paired_df, paired_df.sample(frac=1, random_state=21)):
+        _, ax = plt.subplots()
+        getattr(cns, plot_name)(
+            data,
+            x="group",
+            y="value",
+            order=["B", "A"],
+            pairs=[("A", "B")],
+            test=test,
+            subject="subject",
+            ax=ax,
+        )
+        results.append(cns.get_comparison_results(ax))
+    pd.testing.assert_frame_equal(results[0], results[1])
+    pd.testing.assert_frame_equal(paired_df, original)
+    row = results[0].iloc[0]
+    assert (row.group1, row.group2) == ("B", "A")
+    expected = _reference(
+        test,
+        paired_df.loc[paired_df.group == "B", "value"],
+        paired_df.loc[paired_df.group == "A", "value"],
+    )
+    assert row.paired
+    assert (row.n1, row.n2) == (7, 7)
+    assert row.pvalue_raw == pytest.approx(expected.pvalue)
+
+
+@pytest.mark.parametrize("test", _TESTS)
+@pytest.mark.parametrize("p_adjust", [None, "bonferroni", "holm", "fdr_bh", "fdr_by"])
+def test_paired_statistics_and_corrections_match_scipy(
+    test: PairedTest,
+    p_adjust: Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None,
+    paired_df: pd.DataFrame,
+    paired_annotations: list[Any],
+) -> None:
+    ax = cns.boxplot(
+        paired_df.sample(frac=1, random_state=17),
+        x="group",
+        y="value",
+        order=["C", "B", "A"],
+        pairs="all",
+        test=test,
+        subject="subject",
+        p_adjust=p_adjust,
+    )
+    results = cns.get_comparison_results(ax)
+    assert list(results.columns) == [
+        "group1",
+        "group2",
+        "test",
+        "alternative",
+        "paired",
+        "n1",
+        "n2",
+        "pvalue_raw",
+        "pvalue_adjusted",
+        "p_adjust",
+        "pvalue_annotation",
+        "significant",
+        "annotation",
+    ]
+    assert len(results) == 3
+    raw = []
+    for (_, row), annotation in zip(
+        results.iterrows(), paired_annotations[0].annotations
+    ):
+        expected = _reference(
+            test,
+            paired_df.loc[paired_df.group == row.group1, "value"],
+            paired_df.loc[paired_df.group == row.group2, "value"],
+        )
+        raw.append(expected.pvalue)
+        assert annotation.data.stat_value == pytest.approx(expected.statistic)
+        assert row.pvalue_raw == pytest.approx(expected.pvalue)
+        assert row.test == test
+        assert row.alternative == "two-sided"
+        assert row.paired
+        assert (row.n1, row.n2) == (7, 7)
+        assert row.p_adjust == p_adjust
+        assert row.pvalue_annotation == annotation.data.pvalue
+        assert row.significant == annotation.data.is_significant
+        assert row.annotation == annotation.text
+        assert row.annotation in [text.get_text() for text in ax.texts]
+    adjusted = raw if p_adjust is None else multipletests(raw, method=p_adjust)[1]
+    np.testing.assert_allclose(results.pvalue_adjusted, adjusted)
+    np.testing.assert_array_equal(results.significant, np.asarray(adjusted) <= 0.05)
+    np.testing.assert_allclose(
+        results.pvalue_annotation, adjusted if p_adjust == "bonferroni" else raw
+    )
+
+
+@pytest.mark.parametrize("horizontal", [False, True])
+@pytest.mark.parametrize("custom_formatter", [False, True])
+def test_paired_alignment_preserves_formatted_categorical_labels(
+    horizontal: bool, custom_formatter: bool, paired_df: pd.DataFrame
+) -> None:
+    data = paired_df.assign(
+        group=pd.Categorical(
+            paired_df.group.map({"A": 10, "B": 20, "C": 30}),
+            categories=[30, 20, 10],
+        )
+    )
+    formatter = (lambda label: f"group-{label}") if custom_formatter else str
+    plotting = {"formatter": formatter} if custom_formatter else {}
+    ax = cns.boxplot(
+        data.sample(frac=1, random_state=4),
+        x="value" if horizontal else "group",
+        y="group" if horizontal else "value",
+        order=cast(Any, [20, 10]),
+        pairs=[(10, 20)],
+        test="t-test_paired",
+        subject="subject",
+        **plotting,
+    )
+    row = cns.get_comparison_results(ax).iloc[0]
+    assert (row.group1, row.group2) == (formatter(20), formatter(10))
+    assert (row.n1, row.n2) == (7, 7)
+    expected = stats.ttest_rel(
+        paired_df.loc[paired_df.group == "B", "value"],
+        paired_df.loc[paired_df.group == "A", "value"],
+    )
+    assert row.pvalue_raw == pytest.approx(expected.pvalue)
+
+
+@pytest.mark.parametrize("plot_name", _PLOTS)
+@pytest.mark.parametrize("horizontal", [False, True])
+def test_hue_pairing_uses_displayed_numeric_groups(
+    plot_name: str, horizontal: bool
+) -> None:
+    data = pd.DataFrame(
+        [
+            (group, hue, subject, subject**2 + group + hue * (subject % 3))
+            for group in [10, 20, 30]
+            for hue in [1, 2, 9]
+            for subject in range(6)
+        ],
+        columns=pd.Index(["group", "hue", "subject", "value"]),
+    )
+    # Repeated IDs in excluded categories or hues must not affect comparisons.
+    excluded = data.loc[(data.group == 30) | (data.hue == 9)]
+    data = pd.concat([data, excluded], ignore_index=True).sample(
+        frac=1, random_state=11
+    )
+    plotting = (
+        {} if plot_name == "lollipopplot" else {"orient": "h" if horizontal else "v"}
+    )
+    if plot_name == "lollipopplot":
+        data["group"] = data["group"].astype(object)
+    ax = getattr(cns, plot_name)(
+        data,
+        x="value" if horizontal else "group",
+        y="group" if horizontal else "value",
+        order=[20, 10],
+        hue="hue",
+        hue_order=[2, 1],
+        pairs="hue",
+        test="t-test_paired",
+        subject="subject",
+        **plotting,
+    )
+    results = cns.get_comparison_results(ax)
+    assert set(zip(results.group1, results.group2)) == {
+        ((20, 2), (20, 1)),
+        ((10, 2), (10, 1)),
+    }
+    for _, row in results.iterrows():
+        first, second = [
+            data.loc[(data.group == group) & (data.hue == hue)].sort_values("subject")[
+                "value"
+            ]
+            for group, hue in [row.group1, row.group2]
+        ]
+        assert (row.n1, row.n2) == (6, 6)
+        assert row.paired
+        assert row.pvalue_raw == pytest.approx(stats.ttest_rel(first, second).pvalue)
+
+
+def test_paired_comparisons_allow_hue_repeating_category(
+    paired_df: pd.DataFrame,
+) -> None:
+    ax = cns.boxplot(
+        paired_df.sample(frac=1, random_state=8),
+        x="group",
+        y="value",
+        hue="group",
+        order=["B", "A"],
+        pairs="all",
+        test="t-test_paired",
+        subject="subject",
+    )
+    row = cns.get_comparison_results(ax).iloc[0]
+    assert (row.group1, row.group2) == ("B", "A")
+    assert (row.n1, row.n2) == (7, 7)
+    expected = stats.ttest_rel(
+        paired_df.loc[paired_df.group == "B", "value"],
+        paired_df.loc[paired_df.group == "A", "value"],
+    )
+    assert row.paired
+    assert row.pvalue_raw == pytest.approx(expected.pvalue)
+
+
+@pytest.mark.parametrize("test", _TESTS)
+def test_missing_subjects_are_excluded_separately_for_each_contrast(
+    test: PairedTest,
+) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A"] * 5 + ["B"] * 5 + ["C"] * 4,
+            "subject": [1, 2, 3, 4, 5] * 2 + [3, 4, 5, 6],
+            "value": [1, 4, 9, 16, 25, 3, 4, np.nan, 18, 30, 10, 19, 29, 37],
+        }
+    )
+    incomplete = pd.DataFrame(
+        {
+            "group": ["A", "A", "B", "B", "A", None],
+            "subject": [None, None, None, None, 1, 1],
+            "value": [100, 200, 300, 400, np.nan, 500],
+        }
+    )
+    data = pd.concat([data, incomplete]).assign(unrelated=np.nan)
+    ax = cns.boxplot(
+        data,
+        x="group",
+        y="value",
+        order=["A", "B", "C"],
+        pairs="all",
+        test=test,
+        subject="subject",
+    )
+    matches = {("A", "B"): [1, 2, 4, 5], ("A", "C"): [3, 4, 5], ("B", "C"): [4, 5]}
+    results = cns.get_comparison_results(ax)
+    assert len(results) == 3
+    for _, row in results.iterrows():
+        subjects = matches[(row.group1, row.group2)]
+        first, second = [
+            data.loc[(data.group == group) & data.value.notna()]
+            .set_index("subject")
+            .loc[subjects, "value"]
+            for group in [row.group1, row.group2]
+        ]
+        assert (row.n1, row.n2) == (len(subjects), len(subjects))
+        assert row.pvalue_raw == pytest.approx(_reference(test, first, second).pvalue)
+
+
+@pytest.mark.parametrize("plot_name", _PLOTS)
+@pytest.mark.parametrize("test", _TESTS)
+@pytest.mark.parametrize("pairs", [None, [("A", "B")]])
+def test_paired_tests_require_subject_column(
+    plot_name: str, test: PairedTest, pairs: Any, paired_df: pd.DataFrame
+) -> None:
+    with pytest.raises(ValueError, match="subject"):
+        getattr(cns, plot_name)(paired_df, x="group", y="value", pairs=pairs, test=test)
+
+
+@pytest.mark.parametrize("plot_name", _PLOTS)
+def test_independent_tests_reject_subject_and_missing_column_is_reported(
+    plot_name: str, paired_df: pd.DataFrame
+) -> None:
+    plotter = getattr(cns, plot_name)
+    with pytest.raises(ValueError, match="subject"):
+        plotter(paired_df, x="group", y="value", subject="subject")
+    with pytest.raises(ValueError, match="absent"):
+        plotter(paired_df, x="group", y="value", test="Wilcoxon", subject="absent")
+
+
+@pytest.mark.parametrize("test", _TESTS)
+@pytest.mark.parametrize("group", ["A", "B"])
+@pytest.mark.parametrize("matched", [False, True])
+def test_duplicate_subjects_are_rejected_before_alignment(
+    test: PairedTest, group: str, matched: bool, paired_df: pd.DataFrame
+) -> None:
+    duplicate = pd.DataFrame(
+        {"group": [group, group], "subject": [99, 99], "value": [5, 7]}
+    )
+    if matched:
+        duplicate = paired_df.loc[paired_df.group == group].iloc[:1]
+    data = pd.concat([paired_df, duplicate])
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        cns.boxplot(
+            data,
+            x="group",
+            y="value",
+            pairs=[("A", "B")],
+            test=test,
+            subject="subject",
+        )
+
+
+@pytest.mark.parametrize("test", _TESTS)
+@pytest.mark.parametrize("matched_count", [0, 1])
+def test_paired_tests_require_two_complete_matches(
+    test: PairedTest, matched_count: int
+) -> None:
+    data = pd.DataFrame(
+        {
+            "group": ["A", "A", "B", "B"],
+            "subject": [1, 2, 1 if matched_count else 3, 4],
+            "value": [1, 3, 2, 5],
+        }
+    )
+    with pytest.raises(ValueError, match="at least (2|two)"):
+        cns.boxplot(
+            data,
+            x="group",
+            y="value",
+            pairs=[("A", "B")],
+            test=test,
+            subject="subject",
+        )
+
+
+@pytest.mark.parametrize("test", _TESTS)
+@pytest.mark.parametrize("count", [2, 14])
+def test_all_zero_differences_are_rejected(test: PairedTest, count: int) -> None:
+    data = pd.DataFrame(
+        {
+            "group": np.repeat(["A", "B"], count),
+            "subject": list(range(count)) * 2,
+            "value": list(range(count)) * 2,
+        }
+    )
+    with pytest.raises(ValueError, match="zero"):
+        cns.boxplot(
+            data,
+            x="group",
+            y="value",
+            pairs=[("A", "B")],
+            test=test,
+            subject="subject",
+        )
+
+
+@pytest.mark.parametrize("test", _TESTS)
+@pytest.mark.parametrize("value", [np.inf, -np.inf])
+def test_nonfinite_aligned_measurements_are_rejected(
+    test: PairedTest, value: float, paired_df: pd.DataFrame
+) -> None:
+    paired_df.loc[0, "value"] = value
+    with pytest.raises(ValueError, match="finite"):
+        cns.boxplot(
+            paired_df,
+            x="group",
+            y="value",
+            pairs=[("A", "B")],
+            test=test,
+            subject="subject",
+        )
+
+
+@pytest.mark.parametrize("test", _TESTS)
+def test_get_paired_results_does_not_rerun_tests(
+    test: PairedTest, paired_df: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    statistical_test = StatTest.from_library(test)
+    original = statistical_test._func
+    calls = []
+
+    def capture(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(statistical_test, "_func", capture)
+    ax = cns.boxplot(
+        paired_df,
+        x="group",
+        y="value",
+        pairs="all",
+        test=test,
+        subject="subject",
+        p_adjust="bonferroni",
+    )
+    assert len(calls) == 3
+    first = cns.get_comparison_results(ax)
+    second = cns.get_comparison_results(ax)
+    assert len(calls) == 3
+    pd.testing.assert_frame_equal(first, second)
+
+
+@pytest.mark.parametrize("test", _TESTS)
+def test_nonfinite_paired_result_is_not_annotated(
+    test: PairedTest, paired_df: pd.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        StatTest.from_library(test), "_func", lambda *args, **kwargs: (0.0, np.nan)
+    )
+    _, ax = plt.subplots()
+    with pytest.raises(ValueError, match="nonfinite p-value"):
+        cns.boxplot(
+            paired_df,
+            x="group",
+            y="value",
+            pairs=[("A", "B")],
+            test=test,
+            subject="subject",
+            ax=ax,
+        )
+    assert not ax.texts
+    assert cns.get_comparison_results(ax).empty


### PR DESCRIPTION
## What changed
Add subject-aligned paired t-tests and Wilcoxon comparisons to `boxplot`, `violinplot`, `barplot`, and `lollipopplot`. The required `subject` column aligns observations separately for each requested contrast, so row order does not determine the matches. Existing independent-test defaults and the meaning of `pairs` are preserved.

Incomplete pairs and missing identifiers are excluded per contrast; duplicate complete subject observations in either compared group raise an error. The existing comparison table reports `paired=True` and matched sample counts. Public typing, docstrings, statistical guidance, and a shuffled-data example document the behavior.

## How it was tested
- `make test` — 1,703 tests passed with 100% coverage
- `make lint` — all hooks passed
- Regression coverage checks SciPy statistics and all supported p-value corrections, row shuffling, ties and zero differences, missing data, duplicate validation, hue/orientation, categorical formatting, and result reuse.
- Both paired documentation examples execute and match SciPy's paired t-test.

## Risks or follow-ups
Paired tests require at least two matched subjects and at least one nonzero difference; nonfinite matched values or returned p-values raise an error. Wilcoxon uses SciPy's default zero handling and automatic p-value method. Plot summaries and error bars still use the displayed observations, so their sample counts can exceed the paired test counts.

## Related issue
Closes #166

## Release Notes Label
`enhancement`
