### PR TITLE
🐛 Match heatmap legends to cells

### DIFF
--- a/src/cnsplots/helpers/_heatmap.py
+++ b/src/cnsplots/helpers/_heatmap.py
@@ -10,6 +10,7 @@ import matplotlib.legend as mlegend
 import numpy as np
 import pandas as pd
 from matplotlib.axes import Axes
+from matplotlib.transforms import nonsingular
 from PyComplexHeatmap import ClusterMapPlotter, DotClustermapPlotter
 from PyComplexHeatmap.clustermap import mm2inch
 
@@ -546,6 +547,20 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
 
     def plot_legends(self, ax: Any = None) -> None:
         super().plot_legends(ax=ax)
+        mesh = self.heatmap_axes[0, 0].collections[0]
+        for cbar in getattr(self, "cbars", []):
+            if isinstance(cbar, mpl.colorbar.Colorbar) and cbar.cmap is getattr(
+                self, "_heatmap_legend_cmap", None
+            ):
+                # PyComplexHeatmap creates a linear mappable for every colorbar.
+                locator, formatter = cbar.locator, cbar.formatter
+                if mesh.norm.vmin == mesh.norm.vmax:
+                    # Colorbar expands constant limits; update every split together.
+                    for heatmap_ax in self.heatmap_axes.flat:
+                        heatmap_ax.collections[0].set_norm(mesh.norm)
+                cbar.update_normal(mesh)
+                cbar.locator, cbar.formatter = locator, formatter
+                cbar.update_ticks()
         self._legend_anchor_ax = self.ax if ax is None else ax
         _capture_detached_colorbar_layout(self)
         _sync_detached_legend_axes(self)
@@ -569,21 +584,10 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
                 if annotation.label_max_width > self.label_max_width:
                     self.label_max_width = annotation.label_max_width
         if self.legend:
+            mesh = self.heatmap_axes[0, 0].collections[0]
             if utils._is_qualitative_cmap(self.cmap):
-                if isinstance(self.data, pd.DataFrame):
-                    unique_values = sorted(np.unique(self.data.values.astype(str)))
-                else:
-                    unique_values = sorted(np.unique(self.data.astype(str)))
-                if isinstance(self.cmap, list):
-                    cmap = self.cmap
-                    cmap = {k: v for k, v in zip(unique_values, cmap)}
-                elif isinstance(self.cmap, dict):
-                    cmap = {k: v for k, v in self.cmap.items() if k in unique_values}
-                else:
-                    cmap = utils._get_hex_colors_from_colorbar(
-                        self.cmap, len(unique_values)
-                    )
-                    cmap = {k: v for k, v in zip(unique_values, cmap)}
+                unique_values = np.unique(self.data2d.values)
+                cmap = {str(value): mesh.to_rgba(value) for value in unique_values}
                 self.legend_kws.setdefault("frameon", False)
                 self.legend_kws.setdefault("labelspacing", 0.2)
                 self.legend_kws.setdefault("handletextpad", 0.4)
@@ -592,16 +596,17 @@ class ClusterMapPlotterNew(ClusterMapPlotter):
                     [cmap, self.label, self.legend_kws, 4, "color_dict"]
                 )
             else:
-                vmax = self.kwargs.get(
-                    "vmax", np.nanmax(self.data2d[self.data2d != np.inf])
-                )
-                vmin = self.kwargs.get(
-                    "vmin", np.nanmin(self.data2d[self.data2d != -np.inf])
-                )
-                self.legend_kws.setdefault("vmin", round(vmin, 2))
-                self.legend_kws.setdefault("vmax", round(vmax, 2))
+                legend_kws = self.legend_kws.copy()
+                vmin, vmax = mesh.norm.vmin, mesh.norm.vmax
+                if vmin == vmax:
+                    vmin, vmax = nonsingular(vmin, vmax, expander=0.1)
+                legend_kws.update(vmin=vmin, vmax=vmax)
+                # The mesh already includes centering and custom normalization.
+                legend_kws.pop("center", None)
+                legend_kws.pop("norm", None)
+                self._heatmap_legend_cmap = mesh.cmap.copy()
                 self.legend_list.append(
-                    [self.cmap, self.label, self.legend_kws, 4, "cmap"]
+                    [self._heatmap_legend_cmap, self.label, legend_kws, 4, "cmap"]
                 )
             heatmap_label_max_width = (
                 max(label.get_window_extent().width for label in self.yticklabels)

--- a/tests/test_heatmap_legend_mapping.py
+++ b/tests/test_heatmap_legend_mapping.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import anndata as ad
+import matplotlib as mpl
+from matplotlib.collections import QuadMesh
+from matplotlib.colorbar import Colorbar
+from matplotlib.colors import LogNorm
+from matplotlib.legend import Legend
+from matplotlib.patches import Patch
+import numpy as np
+import pandas as pd
+import PyComplexHeatmap as pch
+import pytest
+
+import cnsplots as cns
+from cnsplots.helpers._heatmap import ClusterMapPlotterNew
+
+
+def _plot_heatmap(
+    values: np.ndarray, split: bool, **kwargs: Any
+) -> ClusterMapPlotterNew:
+    cns.figure(180, 180)
+    if split:
+        data = ad.AnnData(np.repeat(np.repeat(values, 2, axis=0), 2, axis=1))
+        data.obs["group"] = ["A", "A", "B", "B"]
+        data.var["group"] = ["A", "A", "B", "B"]
+        plotter = cns.heatmapplot(
+            data,
+            row_split="group",
+            col_split="group",
+            row_split_order=["A", "B"],
+            col_split_order=["A", "B"],
+            **kwargs,
+        )
+    else:
+        plotter = cns.heatmapplot(pd.DataFrame(values), **kwargs)
+    plotter.ax.figure.canvas.draw()
+    assert plotter.heatmap_axes.shape == ((2, 2) if split else (1, 1))
+    return plotter
+
+
+@pytest.mark.parametrize("split", [False, True], ids=["unsplit", "split"])
+@pytest.mark.parametrize(
+    ("values", "kwargs", "limits"),
+    [
+        ([[0.001, 0.002], [0.003, 0.004]], {}, (0.001, 0.004)),
+        ([[1, 2], [3, 4]], {"cmap": "viridis"}, (1, 4)),
+        ([[-1, 0], [1, 10]], {"cmap": "bwr", "center": 0}, (-1, 10)),
+        (
+            [[1, 10], [100, 1000]],
+            {"cmap": "viridis", "norm": LogNorm(1, 1000)},
+            (1, 1000),
+        ),
+        (
+            [[0.1, 0.4], [0.7, 0.9]],
+            {"cmap": "viridis", "vmin": -0.1234, "vmax": 1.2345},
+            (-0.1234, 1.2345),
+        ),
+        (
+            [[-1, 0], [1, 10]],
+            {
+                "cmap": "bwr",
+                "center": 0,
+                "legend_kws": {"center": 5, "vmin": -10, "vmax": 20},
+            },
+            (-1, 10),
+        ),
+    ],
+    ids=[
+        "small",
+        "ordinary",
+        "centered",
+        "logarithmic",
+        "explicit-limits",
+        "conflicting-legend-mapping",
+    ],
+)
+def test_heatmap_colorbar_matches_rendered_cells(
+    values: list[list[float]],
+    kwargs: dict[str, Any],
+    limits: tuple[float, float],
+    split: bool,
+) -> None:
+    plotter = _plot_heatmap(np.asarray(values), split, **kwargs)
+    colorbar = next(item for item in plotter.cbars if isinstance(item, Colorbar))
+
+    assert (colorbar.norm.vmin, colorbar.norm.vmax) == pytest.approx(limits)
+    for ax in plotter.heatmap_axes.flat:
+        mesh = next(item for item in ax.collections if isinstance(item, QuadMesh))
+        assert (mesh.norm.vmin, mesh.norm.vmax) == pytest.approx(limits)
+        cell_values = np.asarray(mesh.get_array()).ravel()
+        np.testing.assert_allclose(
+            colorbar.mappable.to_rgba(cell_values), mesh.get_facecolors()
+        )
+
+
+@pytest.mark.parametrize("split", [False, True], ids=["unsplit", "split"])
+def test_heatmap_constant_cells_match_colorbar(split: bool) -> None:
+    plotter = _plot_heatmap(np.ones((2, 2)), split)
+    colorbar = next(item for item in plotter.cbars if isinstance(item, Colorbar))
+    assert colorbar.norm.vmin < 1 < colorbar.norm.vmax
+
+    for ax in plotter.heatmap_axes.flat:
+        mesh = next(item for item in ax.collections if isinstance(item, QuadMesh))
+        assert (mesh.norm.vmin, mesh.norm.vmax) == pytest.approx(
+            (colorbar.norm.vmin, colorbar.norm.vmax)
+        )
+        np.testing.assert_allclose(
+            colorbar.mappable.to_rgba(np.asarray(mesh.get_array()).ravel()),
+            mesh.get_facecolors(),
+        )
+
+
+@pytest.mark.parametrize("split", [False, True], ids=["unsplit", "split"])
+@pytest.mark.parametrize("codes", [[2, 10, 20], [2, 3, 20]])
+def test_heatmap_categorical_legend_matches_rendered_cells(
+    codes: list[int], split: bool
+) -> None:
+    values = np.array([[codes[0], codes[1]], [codes[1], codes[2]]])
+    plotter = _plot_heatmap(values, split, cmap="Set1")
+    legend = next(item for item in plotter.cbars if isinstance(item, Legend))
+    legend_colors = {}
+    for label, handle in zip(legend.get_texts(), legend.legend_handles):
+        assert isinstance(handle, Patch)
+        legend_colors[int(label.get_text())] = handle.get_facecolor()
+
+    assert set(legend_colors) == set(codes)
+    for ax in plotter.heatmap_axes.flat:
+        mesh = next(item for item in ax.collections if isinstance(item, QuadMesh))
+        cell_values = np.asarray(mesh.get_array()).ravel()
+        np.testing.assert_allclose(
+            [legend_colors[value] for value in cell_values], mesh.get_facecolors()
+        )
+
+
+@pytest.mark.parametrize(
+    ("values", "kwargs", "ticks", "labels"),
+    [
+        (
+            [[-1, 0], [1, 10]],
+            {"cmap": "bwr", "center": 0},
+            [-1, 0, 10],
+            ["-1.0", "0.0", "10.0"],
+        ),
+        (
+            [[1, 10], [100, 1000]],
+            {"cmap": "viridis", "norm": LogNorm(1, 1000)},
+            [1, 10, 1000],
+            ["1.0", "10.0", "1000.0"],
+        ),
+    ],
+    ids=["centered", "logarithmic"],
+)
+def test_heatmap_colorbar_preserves_explicit_ticks_and_format(
+    values: list[list[float]],
+    kwargs: dict[str, Any],
+    ticks: list[int],
+    labels: list[str],
+) -> None:
+    plotter = _plot_heatmap(
+        np.asarray(values),
+        False,
+        legend_kws={"ticks": ticks, "format": "%.1f"},
+        **kwargs,
+    )
+    colorbar = next(item for item in plotter.cbars if isinstance(item, Colorbar))
+
+    np.testing.assert_array_equal(colorbar.get_ticks(), ticks)
+    assert [label.get_text() for label in colorbar.ax.get_yticklabels()] == labels
+
+
+def test_heatmap_preserves_annotation_colorbar_with_shared_colormap() -> None:
+    cns.figure(180, 180)
+    cmap = mpl.colormaps["viridis"]
+    annotation = pch.HeatmapAnnotation(
+        score=pch.anno_simple(pd.Series([10.0, 20.0]), cmap=cmap),
+        verbose=0,
+    )
+    plotter = ClusterMapPlotterNew(
+        pd.DataFrame([[1.0, 2.0], [3.0, 4.0]]),
+        cmap=cast(Any, cmap),
+        top_annotation=annotation,
+        row_cluster=False,
+        col_cluster=False,
+        label="value",
+        verbose=0,
+    )
+    plotter.ax.figure.canvas.draw()
+    colorbars = {
+        item.ax.get_ylabel(): item
+        for item in plotter.cbars
+        if isinstance(item, Colorbar)
+    }
+
+    assert set(colorbars) == {"score", "value"}
+    annotation_bar = colorbars["score"]
+    assert (annotation_bar.norm.vmin, annotation_bar.norm.vmax) == (10, 20)
+    for label, ax in [
+        ("score", annotation.axes[0, 0]),
+        ("value", plotter.heatmap_axes[0, 0]),
+    ]:
+        mesh = next(item for item in ax.collections if isinstance(item, QuadMesh))
+        cell_values = np.asarray(mesh.get_array()).ravel()
+        np.testing.assert_allclose(
+            colorbars[label].mappable.to_rgba(cell_values), mesh.get_facecolors()
+        )

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from matplotlib.collections import PathCollection, QuadMesh
+from matplotlib.colors import ListedColormap
 from matplotlib.patches import PathPatch, Rectangle, Wedge
 
 import cnsplots as cns
@@ -625,6 +626,8 @@ def test_helper_heatmap_internal_coverage(monkeypatch: pytest.MonkeyPatch) -> No
     plotter3.data = cast(Any, np.array([[0, 1], [1, 0]]))
     plotter3.ax = plt.gca()
     plotter3.yticklabels = []
+    plotter3.ax.pcolormesh(plotter3.data2d, cmap=ListedColormap(["red", "blue"]))
+    plotter3.heatmap_axes = np.array([[plotter3.ax]], dtype=object)
     plotter3.collect_legends()
     assert plotter3.legend_list
 
@@ -638,6 +641,8 @@ def test_helper_heatmap_internal_coverage(monkeypatch: pytest.MonkeyPatch) -> No
     plotter4.data = cast(Any, np.array([[0, 1], [1, 0]]))
     plotter4.ax = plt.gca()
     plotter4.yticklabels = []
+    plotter4.ax.pcolormesh(plotter4.data2d, cmap=ListedColormap(["red", "blue"]))
+    plotter4.heatmap_axes = np.array([[plotter4.ax]], dtype=object)
     plotter4.collect_legends()
     assert plotter4.legend_list
 


### PR DESCRIPTION
Heatmap legends now use the rendered cell mapping, correcting inaccurate limits and colors for small values, centered and logarithmic scales, and numeric categories. Closes #233.

Continuous colorbars retain full-precision limits and use the mesh normalization; categorical swatches are sampled at the actual numeric values. Explicit tick formatting is preserved, annotation colorbars retain their own mappings, and constant-valued split panels share the expanded normalization.

Validation: `make test` and `make lint` pass. Added 21 semantic regression cases comparing legend RGBA values with rendered cell facecolors, including split heatmaps, explicit limits, constant data, and shared annotation colormaps.

Risk: corrected legends and constant-valued split panels can change the appearance of figures whose colors were previously inconsistent. No follow-up is required for #233.
