### PR TITLE
🐛 Prevent volcano gene misclassification

### DIFF
--- a/src/cnsplots/plots/_genomics.py
+++ b/src/cnsplots/plots/_genomics.py
@@ -147,7 +147,8 @@ def volcanoplot(
     import adjustText as at
 
     hue = "DEG"
-    de = data.copy()
+    # Keep hit selection independent of duplicate labels in the caller's index.
+    de = data.reset_index(drop=True)
     if transform_y:
         if not pd.api.types.is_numeric_dtype(de[y]):
             raise ValueError(f"[volcanoplot] Column '{y}' must be numeric")

--- a/tests/test_plots_advanced.py
+++ b/tests/test_plots_advanced.py
@@ -1075,6 +1075,78 @@ def test_genomics_plots(
     )
 
 
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.Index([0] * 7, name="symbol"),
+        pd.Index(["a", "b", "a", "b", "a", "b", "a"], name="sample"),
+        pd.MultiIndex.from_tuples([("a", 0)] * 7, names=["sample", "replicate"]),
+    ],
+    ids=["duplicate-integers", "duplicate-strings", "duplicate-multiindex"],
+)
+@pytest.mark.parametrize(
+    ("n_show", "show_list", "selected"),
+    [
+        (1, None, ["UP", "DOWN"]),
+        (0, None, []),
+        (0, ["UP_LOWER", "DOWN_LOWER", "NS"], ["UP_LOWER", "DOWN_LOWER"]),
+        (1, [], []),
+    ],
+    ids=["top-hits", "no-hits", "explicit-hits", "empty-show-list"],
+)
+def test_volcanoplot_selection_ignores_dataframe_index(
+    index: pd.Index,
+    n_show: int,
+    show_list: list[str] | None,
+    selected: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_adjust = types.SimpleNamespace(adjust_text=lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "adjustText", fake_adjust)
+    data = pd.DataFrame(
+        {
+            "log2FoldChange": [2.0, 0.0, -2.0, 1.0, -1.0, 1.0, -1.0],
+            "-log10(adjp)": [5.0, 0.1, 4.0, 3.0, 2.0, 10.0, 8.0],
+            "symbol": [
+                "UP",
+                "NS",
+                "DOWN",
+                "UP_LOWER",
+                "DOWN_LOWER",
+                "UP_TIE",
+                "DOWN_TIE",
+            ],
+        },
+        index=index,
+    )
+    original_show_list = None if show_list is None else show_list.copy()
+
+    for frame in (data.reset_index(drop=True), data):
+        original_data = frame.copy(deep=True)
+        cns.figure(120, 120)
+        ax = cns.volcanoplot(frame, n_show=n_show, show_list=show_list)
+
+        assert [text.get_text() for text in ax.texts] == selected
+        points = ax.collections[0]
+        colors_by_position = {
+            tuple(position): tuple(color)
+            for position, color in zip(
+                np.asarray(points.get_offsets()), np.asarray(points.get_facecolor())
+            )
+        }
+        assert len(colors_by_position) == len(data)
+        for x, y, gene in data.itertuples(index=False, name=None):
+            if gene in selected:
+                expected_color = cns.get_hexcolors_from_apalette(
+                    [1 if x > 0 else 0], "BlueRed"
+                )[0]
+            else:
+                expected_color = "grey" if gene == "NS" else "black"
+            assert colors_by_position[(x, y)] == to_rgba(expected_color)
+        pd.testing.assert_frame_equal(frame, original_data)
+        assert show_list == original_show_list
+
+
 def test_volcanoplot_supports_raw_pvalues_and_custom_thresholds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What changed

Prevent duplicate DataFrame indices from causing `volcanoplot` to color and annotate unrelated genes as selected hits. Assign a unique index to the plot's private data copy so each selected hit updates only its own row.

Add regression coverage for duplicate numeric, string, and multi-level indices. Verify exact labels and point colors against unique-index data, ranking ties, `n_show`, `show_list` precedence, and preservation of caller data and lists.

## How it was tested

- Confirmed the regression failed before the fix, annotating all seven rows instead of the two selected hits.
- `make test` — 1,736 passed, 100% statement coverage.
- `make lint` — passed.

## Risks or follow-ups

Low risk: the change is limited to the internal DataFrame index. Ranking, thresholds, row order, and the public API are unchanged. No follow-ups identified.

## Related issue

Closes #234

## Release Notes Label

`bug`
