### PR TITLE
🐛 Align phyloplot leaves with heatmaps

### DIFF
--- a/src/cnsplots/helpers/_phylo.py
+++ b/src/cnsplots/helpers/_phylo.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from matplotlib.transforms import Affine2D
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from cnsplots._validation import (
@@ -54,6 +55,10 @@ def phyloplot(adata: AnnData, *, ax: Axes | None = None) -> Axes:
         ax.set_axis_off()
     with plt.rc_context({"lines.linewidth": 0.5}):
         Bio.Phylo.draw(tree, label_func=lambda _: "", axes=tree_ax, do_show=False)
+    # Bio.Phylo places leaves at 1, 2, ...; heatmap row centers are 0.5, 1.5, ...
+    tree_transform = Affine2D().translate(0, -0.5) + tree_ax.transData
+    for artist in [*tree_ax.collections, *tree_ax.texts]:
+        artist.set_transform(tree_transform)
     ax = sns.heatmap(
         adata.layers["trisicell_output"],
         ax=heatmap_ax,

--- a/tests/mpl310_ft261.json
+++ b/tests/mpl310_ft261.json
@@ -28,7 +28,7 @@
   "test_visual_regressions.test_visual_lineplot": "28849942761eb084c260c3c8e11eff1d40d5f8c761c80cb889578cd60e3ff80c",
   "test_visual_regressions.test_visual_scatterplot": "52332223a8cf868a235feeb3b762fa61a67f6b80a7f543d1126322fcf7d921fc",
   "test_visual_regressions.test_visual_placeholderplot": "a1197de856707ce31abffa1a1ef5f5421b8349b3ad81d9beb2f77d2fd4ac8ca2",
-  "test_visual_regressions.test_visual_phyloplot": "6d39c8b39131a404409f5be80578f84d42a80e0bf1dc678ad21ca0af2a3e39e0",
+  "test_visual_regressions.test_visual_phyloplot": "039f95514596eaeb5c47e3ae74e87e2d9ffc21790125bff2ff7374f3738672ca",
   "test_visual_regressions.test_visual_qqplot": "495db1d59f18d3c10bb0d6c5dc4d6292280a783a123160cde5de8b1d62ee53c6",
   "test_visual_regressions.test_visual_vennplot": "93682864796888f7bbc16bc33bed2f4a28a62da703f8a205e6b4309f3688a15e"
 }

--- a/tests/test_phylo_alignment.py
+++ b/tests/test_phylo_alignment.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import io
+
+import anndata as ad
+import Bio.Phylo
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.collections import LineCollection, QuadMesh
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize(
+    "newick",
+    [
+        "((cell3:1.3,cell1:2.4)95:0.7,(cell4:3.6,cell2:4.8):0.9);",
+        "(((cell2:1.1,cell4:2.3):0.4,cell1:3.7):0.5,cell3:5.3);",
+        "(cell4:1.2,cell2:2.4,cell3:3.6,cell1:4.8);",
+    ],
+    ids=["balanced", "ladder", "star"],
+)
+@pytest.mark.parametrize("explicit_axes", [False, True], ids=["current", "host"])
+def test_phylo_leaves_align_with_their_heatmap_rows(
+    newick: str, explicit_axes: bool
+) -> None:
+    adata = ad.AnnData(2 * np.eye(4))
+    adata.obs_names = ["cell1", "cell2", "cell3", "cell4"]
+    adata.obs["group"] = ["B", "A", "C", "A"]
+    adata.layers["trisicell_output"] = np.eye(4)
+    adata.uns["tree"] = newick
+    adata = adata[["cell4", "cell1", "cell2", "cell3"]].copy()
+    original = adata.copy()
+    tree = Bio.Phylo.read(io.StringIO(newick), "newick")
+    terminals = tree.get_terminals()
+    terminal_names = [terminal.name for terminal in terminals]
+    depths = tree.depths()
+
+    fig = cns.figure(8, 4, unit="in")
+    if explicit_axes:
+        host_ax, other_ax = fig.subplots(1, 2)
+        plt.sca(other_ax)
+        heatmap_ax = cns.phyloplot(adata, ax=host_ax)
+        assert heatmap_ax is host_ax
+        assert not other_ax.collections
+    else:
+        host_ax = fig.subplots()
+        heatmap_ax = cns.phyloplot(adata)
+        assert heatmap_ax is host_ax
+
+    tree_ax = next(
+        ax
+        for ax in fig.axes
+        if any(isinstance(artist, LineCollection) for artist in ax.collections)
+    )
+    mutation_mesh = next(
+        artist for artist in heatmap_ax.collections if isinstance(artist, QuadMesh)
+    )
+    group_meshes = [
+        artist
+        for ax in fig.axes
+        if ax is not heatmap_ax
+        for artist in ax.collections
+        if isinstance(artist, QuadMesh)
+        and np.asarray(artist.get_array()).shape == (4, 1)
+    ]
+    assert len(group_meshes) == 2
+    ordered = original[terminal_names]
+    np.testing.assert_array_equal(
+        mutation_mesh.get_array(), ordered.layers["trisicell_output"]
+    )
+    expected_groups = ordered.obs["group"].map({"A": 0, "B": 1, "C": 2})
+    for mesh in group_meshes:
+        np.testing.assert_array_equal(
+            np.asarray(mesh.get_array())[:, 0], expected_groups
+        )
+
+    horizontal_branches = [
+        (artist, segment)
+        for artist in tree_ax.collections
+        if isinstance(artist, LineCollection)
+        for segment in artist.get_segments()
+        if segment[0, 1] == segment[1, 1]
+    ]
+    np.testing.assert_allclose(
+        sorted(segment[1, 0] - segment[0, 0] for _, segment in horizontal_branches),
+        sorted(clade.branch_length or 0 for clade in tree.find_clades()),
+    )
+    for size in [(8, 4), (10, 6)]:
+        fig.set_size_inches(*size)
+        fig.canvas.draw()
+        for row, terminal in enumerate(terminals):
+            # Unique terminal depths identify named leaves from rendered branches.
+            leaf_branches = [
+                (artist, segment)
+                for artist, segment in horizontal_branches
+                if np.isclose(segment[1, 0], depths[terminal])
+            ]
+            assert len(leaf_branches) == 1
+            artist, segment = leaf_branches[0]
+            leaf_y = artist.get_transform().transform(segment[1])[1]
+            for mesh in [mutation_mesh, *group_meshes]:
+                coordinates = np.asarray(mesh.get_coordinates())
+                center = coordinates[row : row + 2, :2].mean(axis=(0, 1))
+                row_y = mesh.get_transform().transform(center)[1]
+                assert leaf_y == pytest.approx(row_y, abs=1e-7), terminal.name
+        for clade in tree.find_clades():
+            if clade.confidence is None:
+                continue
+            label = next(text for text in tree_ax.texts if text.get_text() == "95")
+            artist, segment = next(
+                (artist, segment)
+                for artist, segment in horizontal_branches
+                if np.isclose(segment[1, 0], depths[clade])
+            )
+            label_y = label.get_transform().transform(label.get_position())[1]
+            branch_y = artist.get_transform().transform(segment.mean(axis=0))[1]
+            assert label_y == pytest.approx(branch_y, abs=1e-7)
+
+    np.testing.assert_array_equal(adata.X, original.X)
+    np.testing.assert_array_equal(
+        adata.layers["trisicell_output"], original.layers["trisicell_output"]
+    )
+    pd.testing.assert_frame_equal(adata.obs, original.obs)
+    pd.testing.assert_frame_equal(adata.var, original.var)
+    assert adata.uns == original.uns


### PR DESCRIPTION
## What changed

Fix the half-row displacement in `phyloplot` so every tree leaf sits at the center of its corresponding mutation row and both group-annotation rows.

- Translate tree branches and confidence labels upward by half a row in data coordinates, preserving alignment when the figure is resized.
- Preserve terminal-based observation order, branch lengths, and the input AnnData.
- Add six regression cases comparing rendered coordinates across balanced, ladder, and star trees, reordered observations, current and explicit host axes, and two figure sizes.
- Refresh only the phyloplot visual baseline from the pinned Linux CI renderer after inspecting the corrected image; the other 31 visual hashes are unchanged.

## How it was tested

- `make test`: 1,742 passed, 100% coverage.
- `make lint`: passed.
- All six new regression cases fail against the original implementation on the expected half-row displacement and pass with the fix.
- Visually inspected the affected plot before and after the correction.
- GitHub CI passed the full test suites on Python 3.10–3.14, lint, package validation, and macOS/Windows smoke checks before the baseline-only update.
- The initial Linux visual run passed 31 comparisons and produced the expected phyloplot mismatch. The refreshed hash is verified against its rendered PNG from [run 34186139080](https://github.com/faridrashidi/cnsplots/actions/runs/34186139080).

## Risks or follow-ups

The intended visual change moves tree branches and confidence labels upward by half a row. Public API, branch lengths, and data ordering remain unchanged. The updated visual baseline will be checked again by CI on the final commit.

## Related issue

Closes #235
