### PR TITLE
🐛 Preserve FDR for undefined comparisons

### DIFF
--- a/docs/statistical_methods.md
+++ b/docs/statistical_methods.md
@@ -60,7 +60,8 @@ rather than being averaged. Both paired tests require at least two matched
 subjects. Nonfinite matched response values and comparisons in which every
 within-subject difference is zero are rejected. Ties and mixtures of zero and
 nonzero differences otherwise follow SciPy's defaults.
-Nonfinite p-values returned by SciPy are rejected before correction or annotation.
+Nonfinite p-values returned by SciPy raise `ValueError` before correction or
+annotation.
 Matching is performed separately for every contrast, so different comparisons
 can use different subjects. Plot summaries and tick-label counts still use all
 displayed observations and can exceed the matched test counts. Selecting a paired
@@ -164,12 +165,21 @@ use [statsmodels `multipletests`](https://www.statsmodels.org/stable/generated/s
 
 Correction never extends automatically across panels, separate calls, model
 formulas, or an entire study. It does not adjust confidence intervals.
-Categorical annotation behavior comes from statannotations: Bonferroni labels
-show adjusted numerical p-values, while Holm/FDR labels retain raw p-values
-and can add a nonsignificance suffix when correction changes significance.
+For finite categorical comparisons, Bonferroni labels show adjusted numerical
+p-values, while Holm/FDR labels retain raw p-values and can add an `ns` suffix
+when correction changes significance.
 Use `get_comparison_results(ax)["pvalue_adjusted"]` for numerical adjusted
 values for every method. ROC annotations display adjusted values; survival
 annotations show both raw and adjusted pairwise values.
+
+An independent categorical test that returns a nonfinite p-value warns with
+the test and compared groups, suggesting a check of sample sizes and variation.
+Its annotation reads `P unavailable` in every text format.
+`get_comparison_results(ax)` reports `NaN` for `pvalue_raw`, `pvalue_adjusted`,
+and `pvalue_annotation`, and `None` for `significant`. When correction is
+enabled, all resolved comparisons remain in the family: unavailable tests use
+p=1 only during correction. This placeholder is never reported as their
+p-value, and finite comparisons are corrected using the full family size.
 
 ## Summaries, error bars, and regression
 

--- a/src/cnsplots/_utils.py
+++ b/src/cnsplots/_utils.py
@@ -9,6 +9,7 @@ import itertools
 import math
 import os
 import re
+import warnings
 from pathlib import Path
 
 import matplotlib as mpl
@@ -1051,6 +1052,9 @@ class _PValueFormatter(PValueFormat):
         self.p_capitalized = True
 
     def format_data(self, result):
+        if not np.isfinite(result.pvalue):
+            return "P unavailable"
+
         if self._resolved_format == "full":
             text = f"{result.test_short_name} " if self.show_test_name else ""
             return r"${}P = {}{}$".format("{}", self.pvalue_format_string, "{}").format(
@@ -1101,6 +1105,8 @@ def get_comparison_results(ax: Axes | None = None) -> pd.DataFrame:
         ``pvalue_adjusted`` contain raw and corrected p-values; without correction
         they are equal and ``p_adjust`` is None. ``pvalue_annotation``,
         ``significant``, and ``annotation`` describe the exact rendered result.
+        Unavailable tests have NaN in all p-value columns, None in
+        ``significant``, and ``'P unavailable'`` in ``annotation``.
         No effect size is estimated. Returns an empty table with these columns
         if there are no stored comparisons or their annotations were removed.
 
@@ -1117,6 +1123,9 @@ def get_comparison_results(ax: Axes | None = None) -> pd.DataFrame:
     these can differ from its raw category tick counts when stack values are
     missing. Correction covers all resolved pairs in one plot call, including
     all categories for pairs='hue', and does not extend across plot calls.
+    Nonfinite unpaired test p-values emit a warning identifying the comparison.
+    Unavailable comparisons remain in the correction family with a correction-only
+    p-value of 1; this placeholder is never reported as a test result.
 
     Paired tests additionally exclude missing subject identifiers and incomplete
     pairs separately for each contrast. Duplicate subjects within either compared
@@ -1150,21 +1159,40 @@ def _collect_comparison_results(annotator, test, correction, p_adjust, contingen
     """Correct the computed results in place and snapshot them before rendering."""
     annotations = annotator.annotations
     results = [annotation.data for annotation in annotations]
-    raw = np.asarray([result.pvalue for result in results])
-    if test in _PAIRED_TESTS and not np.isfinite(raw).all():
+    raw = np.asarray([result.pvalue for result in results], dtype=float)
+    available = np.isfinite(raw)
+    if test in _PAIRED_TESTS and not available.all():
         raise ValueError("Paired test returned a nonfinite p-value.")
+    raw[~available] = np.nan
     adjusted = raw.copy()
     if correction is not None:
-        adjusted = multipletests(raw, method=p_adjust)[1]
-        if correction.type == 0:
-            for result, pvalue in zip(results, correction(raw)):
-                result.pvalue = pvalue
+        # Keep every requested hypothesis in the family without allowing
+        # unavailable p-values to contaminate estimable comparisons.
+        correction_pvalues = np.where(available, raw, 1.0)
+        adjusted = multipletests(correction_pvalues, method=p_adjust)[1]
+        adjusted[~available] = np.nan
+        display_pvalues = (
+            correction(correction_pvalues)
+            if correction.type == 0
+            else correction_pvalues
+        )
+        for result, pvalue in zip(results, display_pvalues):
+            result.pvalue = pvalue
         correction.apply(results)
 
     rows = []
     for annotation, pvalue_raw, pvalue_adjusted in zip(annotations, raw, adjusted):
         first, second = annotation.structs
         group1, group2 = first["group"], second["group"]
+        if not np.isfinite(pvalue_raw):
+            annotation.data.pvalue = np.nan
+            warnings.warn(
+                f"{test} comparison {group1!r} vs {group2!r} returned a "
+                "nonfinite p-value and is unavailable. Check the groups' "
+                "sample sizes and variation.",
+                UserWarning,
+                stacklevel=4,
+            )
         if contingency is None:
             n1, n2 = len(first["group_data"]), len(second["group_data"])
         else:
@@ -1189,7 +1217,9 @@ def _collect_comparison_results(annotator, test, correction, p_adjust, contingen
                 "pvalue_adjusted": pvalue_adjusted,
                 "p_adjust": p_adjust,
                 "pvalue_annotation": annotation.data.pvalue,
-                "significant": annotation.data.is_significant,
+                "significant": (
+                    annotation.data.is_significant if np.isfinite(pvalue_raw) else None
+                ),
                 "annotation": annotation.text,
             }
         )

--- a/tests/test_unavailable_comparisons.py
+++ b/tests/test_unavailable_comparisons.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any, Literal
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy import stats
+from statannotations.stats.StatResult import StatResult
+from statannotations.stats.StatTest import StatTest
+from statsmodels.stats.multitest import multipletests
+
+import cnsplots as cns
+from cnsplots._utils import _PValueFormatter
+
+_PLOTS = ("boxplot", "violinplot", "barplot", "lollipopplot")
+_ADJUSTMENTS = (None, "bonferroni", "holm", "fdr_bh", "fdr_by")
+_P_VALUE_COLUMNS = ["pvalue_raw", "pvalue_adjusted", "pvalue_annotation"]
+Adjustment = Literal["bonferroni", "holm", "fdr_bh", "fdr_by"] | None
+PValueFormat = Literal["star", "full", "threshold"]
+
+
+@pytest.fixture
+def unavailable_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "group": np.repeat(["A", "B", "C"], 5),
+            "value": [0] * 10 + [1, 2, 3, 4, 5],
+        }
+    )
+
+
+@pytest.fixture
+def unavailable_annotations(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    instances = []
+    original = cns.utils.Annotator
+
+    def capture(*args: Any, **kwargs: Any) -> Any:
+        annotator = original(*args, **kwargs)
+        instances.append(annotator)
+        return annotator
+
+    monkeypatch.setattr(cns.utils, "Annotator", capture)
+    return instances
+
+
+@pytest.mark.parametrize("plot_name", _PLOTS)
+@pytest.mark.parametrize("p_adjust", _ADJUSTMENTS)
+def test_nonfinite_welch_comparison_is_unavailable(
+    plot_name: str,
+    p_adjust: Adjustment,
+    unavailable_df: pd.DataFrame,
+    unavailable_annotations: list[Any],
+) -> None:
+    with (
+        cns.settings.context(pvalue_format="threshold"),
+        warnings.catch_warnings(record=True) as recorded,
+    ):
+        warnings.simplefilter("always", UserWarning)
+        ax = getattr(cns, plot_name)(
+            unavailable_df,
+            x="group",
+            y="value",
+            pairs="all",
+            test="t-test_welch",
+            p_adjust=p_adjust,
+        )
+    results = cns.get_comparison_results(ax)
+    invalid = (results.group1 == "A") & (results.group2 == "B")
+
+    assert len(recorded) == 1
+    assert recorded[0].category is UserWarning
+    warning = str(recorded[0].message)
+    assert "t-test_welch" in warning
+    assert "A" in warning and "B" in warning
+    assert "nonfinite" in warning.lower()
+    assert any(hint in warning.lower() for hint in ("check", "inspect", "review"))
+    assert results.loc[invalid, _P_VALUE_COLUMNS].isna().all().all()
+    assert results.loc[invalid, "significant"].isna().all()
+    assert results.loc[invalid, "annotation"].tolist() == ["P unavailable"]
+    assert results.loc[~invalid, _P_VALUE_COLUMNS].notna().all().all()
+    assert list(zip(results.n1, results.n2)) == [(5, 5)] * 3
+
+    raw = np.asarray(
+        [
+            stats.ttest_ind(
+                unavailable_df.loc[unavailable_df.group == row.group1, "value"],
+                unavailable_df.loc[unavailable_df.group == row.group2, "value"],
+                equal_var=False,
+            ).pvalue
+            for _, row in results.iterrows()
+        ]
+    )
+    correction_family = np.where(np.isfinite(raw), raw, 1.0)
+    expected_adjusted = (
+        raw.copy()
+        if p_adjust is None
+        else multipletests(correction_family, method=p_adjust)[1]
+    )
+    expected_adjusted[invalid] = np.nan
+    np.testing.assert_allclose(results.pvalue_raw, raw, equal_nan=True)
+    np.testing.assert_allclose(
+        results.pvalue_adjusted, expected_adjusted, equal_nan=True
+    )
+    np.testing.assert_allclose(
+        results.pvalue_annotation,
+        expected_adjusted if p_adjust == "bonferroni" else raw,
+        equal_nan=True,
+    )
+    np.testing.assert_array_equal(
+        results.loc[~invalid, "significant"], expected_adjusted[~invalid] <= 0.05
+    )
+    assert results.loc[~invalid, "annotation"].tolist() == ["P < 0.05"] * 2
+    annotations = unavailable_annotations[0].annotations
+    assert results.annotation.tolist() == [item.text for item in annotations]
+    assert results.annotation.tolist() == [text.get_text() for text in ax.texts]
+    np.testing.assert_allclose(
+        results.pvalue_annotation,
+        [item.data.pvalue for item in annotations],
+        equal_nan=True,
+    )
+
+
+@pytest.mark.parametrize("pvalue_format", ["star", "full"])
+@pytest.mark.parametrize("p_adjust", _ADJUSTMENTS)
+def test_nonfinite_comparison_renders_and_exports_all_formats(
+    pvalue_format: PValueFormat,
+    p_adjust: Adjustment,
+    unavailable_df: pd.DataFrame,
+) -> None:
+    with (
+        cns.settings.context(pvalue_format=pvalue_format),
+        pytest.warns(UserWarning, match="t-test_welch"),
+    ):
+        ax = cns.barplot(
+            unavailable_df,
+            x="group",
+            y="value",
+            pairs="all",
+            p_adjust=p_adjust,
+        )
+    results = cns.get_comparison_results(ax)
+    assert results.annotation.tolist() == [text.get_text() for text in ax.texts]
+    exported = pd.read_csv(StringIO(results.to_csv(index=False)))
+    invalid = exported.loc[exported.annotation == "P unavailable"]
+    assert len(invalid) == 1
+    assert invalid[_P_VALUE_COLUMNS + ["significant"]].isna().all().all()
+
+
+@pytest.mark.parametrize("p_adjust", _ADJUSTMENTS)
+def test_all_unavailable_comparisons_remain_missing(
+    p_adjust: Adjustment, unavailable_df: pd.DataFrame
+) -> None:
+    with pytest.warns(UserWarning, match="t-test_welch") as recorded:
+        ax = cns.barplot(
+            unavailable_df.assign(value=0),
+            x="group",
+            y="value",
+            pairs="all",
+            p_adjust=p_adjust,
+        )
+    results = cns.get_comparison_results(ax)
+    assert len(recorded) == 3
+    assert results[_P_VALUE_COLUMNS + ["significant"]].isna().all().all()
+    assert results.annotation.tolist() == ["P unavailable"] * 3
+    assert results.annotation.tolist() == [text.get_text() for text in ax.texts]
+
+
+@pytest.mark.parametrize("pvalue", [np.inf, -np.inf])
+@pytest.mark.parametrize("p_adjust", _ADJUSTMENTS)
+def test_infinite_pvalues_are_normalized_to_missing(
+    pvalue: float,
+    p_adjust: Adjustment,
+    categorical_df: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        StatTest.from_library("Mann-Whitney"),
+        "_func",
+        lambda *args, **kwargs: (0.0, pvalue),
+    )
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always", UserWarning)
+        ax = cns.boxplot(
+            categorical_df,
+            x="group",
+            y="value",
+            pairs=[("A", "B")],
+            p_adjust=p_adjust,
+        )
+    assert len(recorded) == 1
+    assert recorded[0].category is UserWarning
+    assert "Mann-Whitney" in str(recorded[0].message)
+    result = cns.get_comparison_results(ax).iloc[0]
+    assert result[_P_VALUE_COLUMNS].isna().all()
+    assert pd.isna(result.significant)
+    assert result.annotation == "P unavailable"
+    assert [text.get_text() for text in ax.texts] == ["P unavailable"]
+
+
+@pytest.mark.parametrize("pvalue_format", ["star", "full", "threshold"])
+@pytest.mark.parametrize("pvalue", [np.nan, np.inf, -np.inf])
+def test_formatter_does_not_assign_significance_to_nonfinite_pvalues(
+    pvalue_format: PValueFormat, pvalue: float
+) -> None:
+    result = StatResult("Test", "T", None, None, pvalue)
+    assert _PValueFormatter(pvalue_format, 9).format_data(result) == "P unavailable"
+
+
+@pytest.mark.parametrize("pvalue_format", ["star", "full", "threshold"])
+@pytest.mark.parametrize("p_adjust", _ADJUSTMENTS[1:])
+def test_unavailable_comparison_keeps_correction_family_and_ns_suffix(
+    pvalue_format: PValueFormat,
+    p_adjust: Adjustment,
+    unavailable_df: pd.DataFrame,
+) -> None:
+    data = unavailable_df.copy()
+    data.loc[data.group == "C", "value"] = [0, 1, 2, 3, 4]
+    with (
+        cns.settings.context(pvalue_format=pvalue_format),
+        pytest.warns(UserWarning, match="t-test_welch"),
+    ):
+        ax = cns.barplot(
+            data,
+            x="group",
+            y="value",
+            pairs="all",
+            p_adjust=p_adjust,
+        )
+    results = cns.get_comparison_results(ax)
+    finite = results.loc[results.pvalue_raw.notna()]
+    assert (finite.pvalue_raw < 0.05).all()
+    assert (finite.pvalue_adjusted > 0.05).all()
+    assert not finite.significant.any()
+    if p_adjust == "bonferroni":
+        expected = {
+            "star": "ns",
+            "threshold": "P > 0.05",
+            "full": r"$P = 1.4 \times 10^{-1}$",
+        }
+    else:
+        expected = {
+            "star": "* (ns)",
+            "threshold": "P < 0.05 (ns)",
+            "full": r"$P = 4.7 \times 10^{-2}ns$",
+        }
+    assert finite.annotation.tolist() == [expected[pvalue_format]] * 2
+    assert results.annotation.tolist() == [text.get_text() for text in ax.texts]


### PR DESCRIPTION
## What changed

Prevent undefined categorical comparisons from corrupting valid FDR results or being labeled nonsignificant. In the reported Welch example, A–B now displays `P unavailable`, while A–C and B–C retain BH-adjusted p-values of approximately 0.0198534.

- Warn with the failed test, compared groups, and a suggestion to check sample sizes and variation.
- Preserve all requested hypotheses in the correction family using a correction-only p=1 placeholder. Unavailable results retain NaN p-values and missing significance in the results table.
- Document the policy and cover all four affected plots, every correction method, all annotation formats, corrected significance loss, infinities, and exported results.

## How it was tested

- Reproduced the issue with a failing regression before implementing the fix.
- `make test` — 1,808 tests passed, including 66 new regression cases; 100% statement coverage.
- `make lint` — passed.

## Risks or follow-ups

Consumers of `get_comparison_results()` must handle missing `significant` values for unavailable tests. Finite-input annotation behavior and existing paired-test validation are preserved.

## Related issue

Closes #236

## Release Notes Label

`bug`
