### PR TITLE
👷 Require validated release artifacts

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -400,14 +400,24 @@ them through a PR targeting `main`. Do not make release commits directly on
    ```
 
    Pushing a `v*` tag starts the [release workflow](workflows/release-publish.yml).
-   It builds the distributions, checks their metadata with Twine, publishes to
-   PyPI, and then creates a **published GitHub release** with distribution
-   assets and generated release notes. The workflow does not set `draft: true`;
-   there is no manual draft-publication step.
+   It runs the same [test and package validation](workflows/validate-package.yml)
+   used by PR/main CI against the exact tagged commit: the Python test matrix,
+   visual regression checks, distribution build, Twine metadata checks, and a
+   clean installation of the built wheel with import, packaged-data, and
+   dependency checks. A failed test or wheel check blocks publishing. The
+   validated distributions are uploaded once and passed to the publish jobs
+   without rebuilding.
 
-The tag workflow currently does not run tests or check a clean wheel installation;
-the validation above is a maintainer prerequisite. Automated validation gates
-are a separate proposal in [#175](https://github.com/faridrashidi/cnsplots/issues/175).
+   After validation succeeds, the workflow publishes to PyPI and then creates a
+   **published GitHub release** with those distribution assets and generated
+   release notes. The workflow does not set `draft: true`; there is no manual
+   draft-publication step.
+
+These automated checks run for every `v*` tag push, including tags created and
+pushed manually; they do not depend on an earlier PR or branch CI result.
+Maintainers must still follow the branch, review, and local validation steps above.
+The release commit must contain these workflows; older commits retain their
+historical release process.
 
 #### Release Checklist
 
@@ -415,8 +425,9 @@ are a separate proposal in [#175](https://github.com/faridrashidi/cnsplots/issue
 - [ ] The exact merged commit passed `make test` and `make lint`, has a clean
       working tree, and contains the intended version in all three version files.
 - [ ] The `vX.Y.Z` tag points to that commit and only that tag was pushed.
-- [ ] The release workflow succeeded, the version is available on PyPI, and the
-      published GitHub release includes the distribution assets.
+- [ ] The tag workflow's test matrix and clean wheel checks passed before
+      publication, the version is available on PyPI, and the published GitHub
+      release includes the validated distribution assets.
 - [ ] Review the published release's generated PR list and changelog link. Edit
       its notes to add a short human-written summary under `Added`, `Changed`,
       and `Fixed` as appropriate; this edits an already published release.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -135,7 +135,7 @@ After installation, you can use the following commands:
 | `make doc`                           | Build documentation and exit           |
 | `make doc-serve`                     | Build and preview documentation on port 8080 |
 | `make doc-linkcheck`                 | Check documentation links              |
-| `make release [patch\|minor\|major]` | Bump the package version for a release |
+| `make release [patch\|minor\|major]` | Bump, commit, and tag a version; see [Release Process](#release-process) to defer tagging until after merge |
 | `make clean`                         | Clean build artifacts                  |
 
 `make doc` now exits with the build status locally and in CI; `CI=true make doc` remains valid. To use the previous build-and-preview workflow, run `make doc-serve`, open `http://localhost:8080`, and press Ctrl+C to stop the server. Documentation builds clean only `docs/build`, stage generated sources there, and preserve unrelated coverage, test, and package-build artifacts. To remove generated documentation output explicitly, use `make -C docs clean`.
@@ -335,23 +335,91 @@ Maintainers: apply exactly one release label before merge:
 
 ### Release Process
 
-Maintainers can create a release on the main branch (no PR needed) with:
+Follow [AGENTS.md](../AGENTS.md): prepare release changes on a branch and merge
+them through a PR targeting `main`. Do not make release commits directly on
+`main`. In the commands below, replace `X.Y.Z` with the intended version.
 
-```bash
-make release patch
-```
+1. Start from a clean working tree and an up-to-date `main`, then create the
+   release branch:
 
-You can replace `patch` with `minor` or `major` as needed. This bumps the
-package version, creates the release tag, and prepares the release commit.
-After pushing the commit and tag, GitHub Actions will:
+   ```bash
+   git switch main
+   git pull --ff-only origin main
+   git switch -c chore/release-X.Y.Z
+   BUMPVERSION_TAG=false make release patch
+   ```
 
-- publish the package to PyPI
-- create a draft GitHub release for the new tag
-- generate release notes from merged PRs since the previous tag
+   Replace `patch` with `minor` or `major` as needed. The release target updates
+   `pyproject.toml`, `src/cnsplots/__init__.py`, and `uv.lock`, and creates the
+   release commit. By default it also creates a local `vX.Y.Z` tag. The
+   `BUMPVERSION_TAG=false` override defers tagging until after merge so the tag
+   can point to the merged commit, including when the PR is squash-merged.
 
-Before publishing the draft release, add a short human-written summary under
-the `Added`, `Changed`, and `Fixed` headings, then verify the generated PR list
-and changelog link.
+2. Review the version changes and run both required checks after the final
+   changes are in place:
+
+   ```bash
+   make test
+   make lint
+   ```
+
+   Fix failures that are in scope; otherwise stop and report them. If validation
+   changes files, review and commit those changes and rerun the checks. Push only
+   the branch:
+
+   ```bash
+   git push --no-follow-tags -u origin chore/release-X.Y.Z
+   ```
+
+   Open a draft PR against `main` following the [PR process](#pull-request-process)
+   and `AGENTS.md`, including exactly one release label (`maintenance` for a
+   version-only bump). Have the PR reviewed and merged before creating the tag.
+
+3. Fetch the merged result and check out the exact commit to release, replacing
+   `MERGED_RELEASE_COMMIT` with the merged PR's commit SHA. Use a detached
+   checkout to validate it without making changes on `main`:
+
+   ```bash
+   git fetch origin
+   git switch --detach MERGED_RELEASE_COMMIT
+   git merge-base --is-ancestor HEAD origin/main
+   make test
+   make lint
+   git status --short
+   ```
+
+   Proceed only if the commit is on `origin/main`, both checks pass, the working
+   tree is clean, and the version matches `X.Y.Z`. Any fixes must go through
+   another branch and PR; then validate the resulting merged commit again.
+
+4. Create the tag on that validated commit and push only that tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Release X.Y.Z" HEAD
+   git push --no-follow-tags origin refs/tags/vX.Y.Z
+   ```
+
+   Pushing a `v*` tag starts the [release workflow](workflows/release-publish.yml).
+   It builds the distributions, checks their metadata with Twine, publishes to
+   PyPI, and then creates a **published GitHub release** with distribution
+   assets and generated release notes. The workflow does not set `draft: true`;
+   there is no manual draft-publication step.
+
+The tag workflow currently does not run tests or check a clean wheel installation;
+the validation above is a maintainer prerequisite. Automated validation gates
+are a separate proposal in [#175](https://github.com/faridrashidi/cnsplots/issues/175).
+
+#### Release Checklist
+
+- [ ] Release changes were reviewed and merged into `main` through a PR.
+- [ ] The exact merged commit passed `make test` and `make lint`, has a clean
+      working tree, and contains the intended version in all three version files.
+- [ ] The `vX.Y.Z` tag points to that commit and only that tag was pushed.
+- [ ] The release workflow succeeded, the version is available on PyPI, and the
+      published GitHub release includes the distribution assets.
+- [ ] Review the published release's generated PR list and changelog link. Edit
+      its notes to add a short human-written summary under `Added`, `Changed`,
+      and `Fixed` as appropriate; this edits an already published release.
 
 ## Community
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run lint
         run: make lint
 
+      - name: Validate workflow contracts
+        run: uv run --locked --extra lint pytest tests/test_release_workflow.py --no-cov
+
   validation:
     uses: ./.github/workflows/validate-package.yml
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -28,64 +28,8 @@ jobs:
       - name: Run lint
         run: make lint
 
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    runs-on: ubuntu-latest
-    env:
-      MPLBACKEND: Agg
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Sync dependencies
-        run: uv sync --locked --extra test
-
-      - name: Install mutool
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mupdf-tools
-
-      - name: Verify export renderers
-        run: |
-          mutool -v
-          google-chrome --version
-
-      - name: Run tests
-        id: tests
-        run: make test
-
-      - name: Upload export regression results
-        if: ${{ always() && steps.tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: export-results-linux-python-${{ matrix.python-version }}
-          path: mpl-results/export-pipeline/
-          if-no-files-found: warn
-
-      - name: Run visual regression tests
-        if: ${{ matrix.python-version == '3.12' }}
-        id: visual_tests
-        env:
-          CNSPLOTS_REQUIRE_VISUAL_ENV: "1"
-        run: make test-visual
-
-      - name: Upload visual regression results
-        if: ${{ always() && steps.visual_tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: mpl-results-python-3.12
-          path: mpl-results/
-          if-no-files-found: warn
+  validation:
+    uses: ./.github/workflows/validate-package.yml
 
   platform-smoke:
     name: Smoke / ${{ matrix.os }} / Python 3.12
@@ -166,34 +110,3 @@ jobs:
 
       - name: Check docs links
         run: make doc-linkcheck
-  package:
-    name: package-validation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Install packaging tools
-        run: python -m pip install --upgrade pip build twine
-
-      - name: Build distributions
-        run: python -m build
-
-      - name: Check distribution metadata
-        run: python -m twine check dist/*
-
-      - name: Install wheel in a clean virtualenv
-        run: |
-          python -m venv .pkg-venv
-          . .pkg-venv/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip install dist/*.whl
-          python -c "import cnsplots; print(cnsplots.__version__)"
-          python -c "from importlib.resources import files; assert files('cnsplots').joinpath('py.typed').is_file()"
-          python -c "from importlib.resources import files; root = files('cnsplots.datasets').joinpath('_data'); image = root.joinpath('showcase').joinpath('image1.webp'); assert root.joinpath('iris.csv').is_file(); assert image.read_bytes()[:4] == b'RIFF'"
-          python -c "import cnsplots; assert cnsplots.datasets.load_dataset('iris').shape == (150, 5)"
-          python -m pip check

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,35 +6,12 @@ on:
       - "v*"
 
 jobs:
-  build:
-    name: Build distribution
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Install build
-        run: pip install build twine
-
-      - name: Build package
-        run: python -m build
-
-      - name: Check distribution metadata
-        run: python -m twine check dist/*
-
-      - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
+  validation:
+    uses: ./.github/workflows/validate-package.yml
 
   publish:
     name: Publish to PyPI
-    needs: build
+    needs: validation
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/validate-package.yml
+++ b/.github/workflows/validate-package.yml
@@ -1,0 +1,110 @@
+name: Validate tests and distributions
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    runs-on: ubuntu-latest
+    env:
+      MPLBACKEND: Agg
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync dependencies
+        run: uv sync --locked --extra test
+
+      - name: Install mutool
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mupdf-tools
+
+      - name: Verify export renderers
+        run: |
+          mutool -v
+          google-chrome --version
+
+      - name: Run tests
+        id: tests
+        run: make test
+
+      - name: Upload export regression results
+        if: ${{ always() && steps.tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: export-results-linux-python-${{ matrix.python-version }}
+          path: mpl-results/export-pipeline/
+          if-no-files-found: warn
+
+      - name: Run visual regression tests
+        if: ${{ matrix.python-version == '3.12' }}
+        id: visual_tests
+        env:
+          CNSPLOTS_REQUIRE_VISUAL_ENV: "1"
+        run: make test-visual
+
+      - name: Upload visual regression results
+        if: ${{ always() && steps.visual_tests.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mpl-results-python-3.12
+          path: mpl-results/
+          if-no-files-found: warn
+
+  package:
+    name: package-validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install packaging tools
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Install wheel in a clean virtualenv
+        run: |
+          python -m venv .pkg-venv
+          . .pkg-venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -I -c "import cnsplots; print(cnsplots.__version__)"
+          python -I -c "from importlib.resources import files; assert files('cnsplots').joinpath('py.typed').is_file()"
+          python -I -c "from importlib.resources import files; root = files('cnsplots.datasets').joinpath('_data'); image = root.joinpath('showcase').joinpath('image1.webp'); assert root.joinpath('iris.csv').is_file(); assert image.read_bytes()[:4] == b'RIFF'"
+          python -I -c "import cnsplots; assert cnsplots.datasets.load_dataset('iris').shape == (150, 5)"
+          python -m pip check
+
+      - name: Upload validated distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -3,7 +3,11 @@
 from pathlib import Path
 import shlex
 
-import yaml
+import pytest
+
+yaml = pytest.importorskip(
+    "yaml", reason="Workflow checks require PyYAML from the lint extra"
+)
 
 
 WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,107 @@
+"""Guard the release gate's SHA, failure, and artifact handoff contracts."""
+
+from pathlib import Path
+import shlex
+
+import yaml
+
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+VALIDATION = "./.github/workflows/validate-package.yml"
+
+
+def _workflow(name):
+    # BaseLoader preserves GitHub's `on` key instead of treating it as YAML 1.1 True.
+    return yaml.load((WORKFLOWS / name).read_text(), Loader=yaml.BaseLoader)
+
+
+def _action_steps(job, action):
+    return [
+        step for step in job["steps"] if step.get("uses", "").split("@")[0] == action
+    ]
+
+
+def test_release_requires_shared_validation_before_publication():
+    release = _workflow("release-publish.yml")["jobs"]
+    ci = _workflow("ci-tests.yml")["jobs"]
+
+    assert release["validation"]["uses"] == ci["validation"]["uses"] == VALIDATION
+    assert release["publish"]["needs"] == "validation"
+    assert release["github-release"]["needs"] == "publish"
+    for job_name in ("validation", "publish", "github-release"):
+        assert "if" not in release[job_name]
+        assert "continue-on-error" not in release[job_name]
+    assert release["publish"]["permissions"]["id-token"] == "write"
+
+
+def test_tag_validation_uses_the_event_sha_without_branch_or_check_lookups():
+    release = _workflow("release-publish.yml")
+    validation = _workflow("validate-package.yml")
+
+    # Ordinary releases and tags pushed manually both enter through this trigger.
+    # No branch name, previous CI run, or caller-provided ref selects the checkout.
+    assert release["on"] == {"push": {"tags": ["v*"]}}
+    assert validation["on"] == {"workflow_call": ""}
+    assert "with" not in release["jobs"]["validation"]
+    for job in validation["jobs"].values():
+        checkouts = _action_steps(job, "actions/checkout")
+        assert len(checkouts) == 1
+        assert checkouts[0]["with"]["ref"] == "${{ github.sha }}"
+
+
+def test_required_validation_cannot_ignore_test_or_package_failures():
+    jobs = _workflow("validate-package.yml")["jobs"]
+    test_job = jobs["test"]
+    package_job = jobs["package"]
+
+    for job in (test_job, package_job):
+        assert "if" not in job
+        assert "continue-on-error" not in job
+        for step in job["steps"]:
+            assert "continue-on-error" not in step
+
+    test_steps = [step for step in test_job["steps"] if step.get("run") == "make test"]
+    assert len(test_steps) == 1
+    assert "if" not in test_steps[0]
+    for step in package_job["steps"]:
+        assert "if" not in step
+
+
+def test_publishing_downloads_the_same_distributions_after_wheel_validation():
+    package_job = _workflow("validate-package.yml")["jobs"]["package"]
+    release = _workflow("release-publish.yml")["jobs"]
+    steps = package_job["steps"]
+    uploads = _action_steps(package_job, "actions/upload-artifact")
+
+    assert len(uploads) == 1
+    upload = uploads[0]
+    assert upload["with"]["if-no-files-found"] == "error"
+    assert upload["with"]["path"].rstrip("/") == "dist"
+    smoke_steps = [
+        step for step in steps if "pip install dist/*.whl" in step.get("run", "")
+    ]
+    assert len(smoke_steps) == 1
+    commands = [shlex.split(line) for line in smoke_steps[0]["run"].splitlines()]
+    imports = [command for command in commands if "-c" in command]
+    assert ["python", "-m", "venv", ".pkg-venv"] in commands
+    assert [".", ".pkg-venv/bin/activate"] in commands
+    assert imports
+    # Isolated Python excludes the source checkout and PYTHONPATH from imports.
+    assert all(command[:3] == ["python", "-I", "-c"] for command in imports)
+    smoke_index = steps.index(smoke_steps[0])
+    assert smoke_index < steps.index(upload)
+    assert any("python -m build" in step.get("run", "") for step in steps[:smoke_index])
+    assert any(
+        "twine check dist/*" in step.get("run", "") for step in steps[:smoke_index]
+    )
+    # A second build or mutation after the smoke test would publish untested bytes.
+    assert steps[smoke_index + 1 :] == [upload]
+
+    for job_name in ("publish", "github-release"):
+        downloads = _action_steps(release[job_name], "actions/download-artifact")
+        assert len(downloads) == 1
+        assert downloads[0]["with"]["name"] == upload["with"]["name"]
+        assert downloads[0]["with"]["path"].rstrip("/") == "dist"
+        assert "run-id" not in downloads[0]["with"]
+        assert "repository" not in downloads[0]["with"]
+        assert not any("run" in step for step in release[job_name]["steps"])


### PR DESCRIPTION
## What changed

Require each release tag's tests and built wheel to pass validation before publishing. Previously, a tag push could publish after building and checking distribution metadata, without testing that commit or installing its wheel.

PR/main CI and tag releases now share the existing Python test matrix and package checks through a reusable workflow. Both jobs check out the triggering SHA. The package job installs the built wheel in a clean environment, checks imports, bundled data, and dependencies, then uploads the distributions. Publishing waits for successful validation and consumes those same artifacts without rebuilding; PyPI trusted publishing stays in the existing workflow and environment.

Align the contributor instructions and release checklist with this process: prepare version changes through a reviewed PR, defer tagging until the merged commit passes local validation, push only the intended tag, and review the automatically published GitHub release notes afterward.

## How it was tested

- `make test` — 1,812 passed; 100% coverage.
- `make lint`
- Actionlint 1.7.12 passed for all three affected workflows.
- Added four regression tests for publication dependencies, tag-event SHA selection, failure handling, isolated wheel checks, and artifact handoff. They rejected all eight deliberately broken workflow configurations tested in temporary copies.
- `uv run --locked --extra lint pytest tests/test_release_workflow.py --no-cov` — all four passed. CI runs these checks with the declared lint tools; verified that test-only environments without the optional YAML parser skip this module cleanly.
- Built wheel and sdist on Python 3.11; both passed Twine. Installed the wheel in a fresh environment; all workflow smoke commands and `pip check` passed. Removing the installed `iris.csv` made the smoke check fail; restoring it restored success.
- Verified in isolated Git repositories that `BUMPVERSION_TAG=false` preserves the release commit and all version updates while omitting the tag.

## Risks or follow-ups

Release publishing now waits for the test matrix and clean wheel checks. The gate applies to commits containing the updated workflows; older commits retain their historical workflow behavior. Existing tag triggers, PyPI environment, trusted publishing, and automatic GitHub release publication are preserved.

## Related issues

Closes #175
Closes #180

## Release Notes Label

`maintenance`
