### PR TITLE
🐛 Fix hidden and unfilled boxplots

### DIFF
--- a/src/cnsplots/plots/_distribution.py
+++ b/src/cnsplots/plots/_distribution.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from numbers import Real
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import matplotlib as mpl
 import matplotlib.patches  # noqa: F401  # ensure submodule is importable for isinstance checks
@@ -14,6 +14,7 @@ import scipy as sp
 import seaborn as sns
 from matplotlib.axes import Axes
 from matplotlib.typing import ColorType
+from seaborn.categorical import BoxPlotContainer
 
 import cnsplots._utils as utils
 from cnsplots._comparison_types import HueComparisons
@@ -163,7 +164,7 @@ def boxplot(
         "showbox": True,
         "linewidth": 0.8,
         "whis": whis,
-        "boxprops": {"edgecolor": "none"},
+        "boxprops": {"edgecolor": "none"} if kwargs.get("fill", True) else {},
         "medianprops": {"color": "white"},
         "whiskerprops": {"color": "black"},
         "capprops": {"color": "none"},
@@ -189,32 +190,40 @@ def boxplot(
     data = utils._prepare_categorical_plot_data(plotting)
     if ax is None:
         ax = plt.gca()
+    existing_containers = len(ax.containers)
+    existing_patches = set(ax.patches)
     ax = sns.boxplot(ax=ax, **plotting)
 
-    box_patches = [
-        patch for patch in ax.patches if isinstance(patch, mpl.patches.PathPatch)
-    ]
-    if len(box_patches) == 0:
-        box_patches = ax.artists
-    num_patches = len(box_patches)
-    lines_per_boxplot = len(ax.lines) // num_patches
-    for i, patch in enumerate(box_patches):
-        col = patch.get_facecolor()
-        patch.set_edgecolor("None")
-        patch.set_facecolor(col)
-        for j, line in enumerate(
-            ax.lines[i * lines_per_boxplot : (i + 1) * lines_per_boxplot]
-        ):
-            if j != 2:
-                line.set_color(col)
-                line.set_mfc(col)
-                line.set_mec(col)
-            else:
-                line.set_color("white")
-                line.set_mfc("white")
-                line.set_mec("white")
+    # Seaborn groups each box with its own lines, including optional artists.
+    for container in ax.containers[existing_containers:]:
+        for artists in cast(BoxPlotContainer, container):
+            patch = artists.box
+            if not isinstance(patch, mpl.patches.PathPatch) or not patch.get_fill():
+                continue
+            col = patch.get_facecolor()
+            patch.set_edgecolor("none")
+            for line in [
+                *artists.whiskers,
+                *artists.caps,
+                artists.median,
+                *([artists.fliers] if artists.fliers else []),
+                *([artists.mean] if artists.mean else []),
+            ]:
+                color = "white" if line is artists.median else col
+                line.set_color(color)
+                line.set_mfc(color)
+                line.set_mec(color)
 
-    utils._remove_edge_from_legend_items(ax)
+    handles, labels = ax.get_legend_handles_labels()
+    for handle in handles:
+        if (
+            plotting.get("fill", True)
+            and isinstance(handle, mpl.patches.Patch)
+            and handle not in existing_patches
+            and handle.get_fill()
+        ):
+            handle.set_edgecolor("none")
+    ax.legend(handles, labels)
     whis_str = (
         "minimum and maximum values"
         if whis == (0, 100)

--- a/tests/test_boxplot_artists.py
+++ b/tests/test_boxplot_artists.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+from matplotlib.artist import Artist
+from matplotlib.colors import to_rgba
+from matplotlib.lines import Line2D
+from matplotlib.patches import PathPatch, Rectangle
+from matplotlib.path import Path
+
+import cnsplots as cns
+
+
+@pytest.mark.parametrize("explicit_ax", [False, True])
+@pytest.mark.parametrize("existing_artist", [False, True])
+def test_boxplot_without_boxes_returns_target_axes(
+    categorical_df: pd.DataFrame, explicit_ax: bool, existing_artist: bool
+) -> None:
+    _, (target_ax, other_ax) = plt.subplots(1, 2)
+    artist = Artist()
+    artist.set_alpha(0.6)
+    if existing_artist:
+        target_ax.add_artist(artist)
+    plt.sca(other_ax if explicit_ax else target_ax)
+
+    result = cns.boxplot(
+        categorical_df,
+        x="group",
+        y="value",
+        showbox=False,
+        add_count=True,
+        **({"ax": target_ax} if explicit_ax else {}),
+    )
+
+    assert result is target_ax
+    assert not target_ax.patches
+    assert len(target_ax.lines) == 9
+    if existing_artist:
+        assert artist in target_ax.artists
+    assert artist.get_alpha() == 0.6
+    assert target_ax.get_xticklabels()[0].get_text() == "A\n(n=4)"
+    assert not other_ax.lines
+    assert not other_ax.patches
+    target_ax.figure.canvas.draw()
+
+
+def test_boxplot_preserves_existing_artists(categorical_df: pd.DataFrame) -> None:
+    _, ax = plt.subplots()
+    cns.boxplot(categorical_df, x="group", y="value", color="red", ax=ax)
+    ax.plot([0, 1], [1, 2], color="purple", marker="o", mfc="yellow", mec="green")
+    patch = PathPatch(
+        Path([(0, 0), (1, 0), (1, 1), (0, 0)]),
+        facecolor="orange",
+        edgecolor="purple",
+        label="Existing path",
+    )
+    ax.add_patch(patch)
+    ax.add_patch(
+        Rectangle(
+            (0, 0), 1, 1, facecolor="yellow", edgecolor="green", label="Existing area"
+        )
+    )
+    ax.legend()
+    existing_lines = [
+        (
+            item,
+            item.get_color(),
+            item.get_markerfacecolor(),
+            item.get_markeredgecolor(),
+        )
+        for item in ax.lines
+    ]
+    existing_patches = [
+        (item, item.get_facecolor(), item.get_edgecolor()) for item in ax.patches
+    ]
+
+    cns.boxplot(categorical_df, x="group", y="value", color="blue", ax=ax)
+
+    for item, color, mfc, mec in existing_lines:
+        assert item in ax.lines
+        assert item.get_color() == color
+        assert item.get_markerfacecolor() == mfc
+        assert item.get_markeredgecolor() == mec
+    for item, facecolor, edgecolor in existing_patches:
+        assert item in ax.patches
+        assert item.get_facecolor() == facecolor
+        assert item.get_edgecolor() == edgecolor
+    legend = ax.get_legend()
+    assert legend is not None
+    legend_handles = dict(
+        zip([text.get_text() for text in legend.get_texts()], legend.legend_handles)
+    )
+    for label, color in [("Existing path", "purple"), ("Existing area", "green")]:
+        handle = legend_handles[label]
+        assert isinstance(handle, Rectangle)
+        assert handle.get_edgecolor() == to_rgba(color)
+
+
+@pytest.mark.parametrize("horizontal", [False, True])
+@pytest.mark.parametrize("showcaps", [False, True])
+def test_filled_boxplot_colors_follow_each_hue(
+    categorical_df: pd.DataFrame, horizontal: bool, showcaps: bool
+) -> None:
+    _, ax = plt.subplots()
+    palette = {"H1": "#d95f02", "H2": "#1b9e77"}
+
+    cns.boxplot(
+        categorical_df,
+        x="value" if horizontal else "group",
+        y="group" if horizontal else "value",
+        hue="hue",
+        hue_order=["H2", "H1"],
+        palette=palette,
+        saturation=1,
+        showcaps=showcaps,
+        showmeans=showcaps,
+        showoutliers=True,
+        ax=ax,
+    )
+
+    assert len(ax.containers) == 2
+    for container, hue in zip(ax.containers, ["H2", "H1"]):
+        container = cast(Any, container)
+        color = to_rgba(palette[hue])
+        assert len(container.boxes) == 3
+        for box in container.boxes:
+            assert isinstance(box, PathPatch)
+            assert box.get_fill()
+            assert box.get_facecolor() == pytest.approx(color)
+            assert box.get_edgecolor()[-1] == 0
+        for line in [
+            *container.whiskers,
+            *container.caps,
+            *container.fliers,
+            *container.means,
+        ]:
+            assert to_rgba(line.get_color()) == pytest.approx(color)
+            assert to_rgba(line.get_mfc()) == pytest.approx(color)
+            assert to_rgba(line.get_mec()) == pytest.approx(color)
+        for median in container.medians:
+            assert to_rgba(median.get_color()) == to_rgba("white")
+
+
+@pytest.mark.parametrize("boxprops", [None, {"color": "red"}])
+def test_unfilled_boxplot_keeps_visible_line_boxes(
+    categorical_df: pd.DataFrame, boxprops: dict[str, Any] | None
+) -> None:
+    _, ax = plt.subplots()
+
+    result = cns.boxplot(
+        categorical_df,
+        x="group",
+        y="value",
+        fill=False,
+        ax=ax,
+        **({"boxprops": boxprops} if boxprops is not None else {}),
+    )
+
+    assert result is ax
+    boxes = [box for container in ax.containers for box in cast(Any, container).boxes]
+    assert len(boxes) == 3
+    for box in boxes:
+        assert isinstance(box, Line2D)
+        assert to_rgba(box.get_color())[-1] > 0
+        if boxprops is not None:
+            assert to_rgba(box.get_color()) == to_rgba("red")
+    ax.figure.canvas.draw()
+
+
+def test_unfilled_boxplot_keeps_hue_legend_outlines(
+    categorical_df: pd.DataFrame,
+) -> None:
+    _, ax = plt.subplots()
+
+    cns.boxplot(categorical_df, x="group", y="value", hue="hue", fill=False, ax=ax)
+
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [text.get_text() for text in legend.get_texts()] == ["H1", "H2"]
+    for handle in legend.legend_handles:
+        assert isinstance(handle, Rectangle)
+        assert to_rgba(handle.get_facecolor())[-1] == 0
+        assert to_rgba(handle.get_edgecolor())[-1] > 0
+
+
+@pytest.mark.parametrize("edgecolor", [None, "red"])
+def test_boxplot_preserves_unfilled_patch_outlines(
+    categorical_df: pd.DataFrame, edgecolor: str | None
+) -> None:
+    _, ax = plt.subplots()
+    boxprops: dict[str, Any] = {"fill": False}
+    if edgecolor is not None:
+        boxprops["edgecolor"] = edgecolor
+
+    cns.boxplot(categorical_df, x="group", y="value", boxprops=boxprops, ax=ax)
+
+    assert len(ax.patches) == 3
+    for box in ax.patches:
+        assert not box.get_fill()
+        assert to_rgba(box.get_edgecolor())[-1] > 0
+        if edgecolor is not None:
+            assert box.get_edgecolor() == to_rgba(edgecolor)
+    ax.figure.canvas.draw()

--- a/tests/test_internal_coverage.py
+++ b/tests/test_internal_coverage.py
@@ -17,12 +17,11 @@ import pandas as pd
 import pytest
 from matplotlib.collections import PathCollection, QuadMesh
 from matplotlib.colors import ListedColormap
-from matplotlib.patches import PathPatch, Rectangle, Wedge
+from matplotlib.patches import Rectangle, Wedge
 
 import cnsplots as cns
 from cnsplots import _methods, _setup, _svg, _utils, _validation
 from cnsplots.helpers import _heatmap as helper_heatmap, _phylo, _sankey
-from cnsplots.plots import _distribution as dist_mod
 from cnsplots.plots import _genomics as genomics_mod
 from cnsplots.plots import _heatmap as heatmap_mod
 from cnsplots.plots import _sets as sets_mod
@@ -960,60 +959,6 @@ def test_plot_internal_coverage(
         [wedge.theta2 - wedge.theta1 for wedge in donut_wedges], [120] * 3
     )
     assert [wedge.width for wedge in donut_wedges] == pytest.approx([0.4] * 3)
-
-    class FakeArtist:
-        def __init__(self) -> None:
-            self.facecolor: object = (1, 0, 0, 1)
-            self.edgecolor: object = None
-
-        def get_facecolor(self) -> object:
-            return self.facecolor
-
-        def set_edgecolor(self, value: object) -> None:
-            self.edgecolor = value
-
-        def set_facecolor(self, value: object) -> None:
-            self.facecolor = value
-
-    class FakeLine:
-        def __init__(self) -> None:
-            self.color: object = None
-            self.marker_facecolor: object = None
-            self.marker_edgecolor: object = None
-
-        def set_color(self, value: object) -> None:
-            self.color = value
-
-        def set_mfc(self, value: object) -> None:
-            self.marker_facecolor = value
-
-        def set_mec(self, value: object) -> None:
-            self.marker_edgecolor = value
-
-    class FakeAxes:
-        def __init__(self) -> None:
-            self.patches: list[PathPatch] = []
-            self.artists = [FakeArtist()]
-            self.lines = [FakeLine() for _ in range(5)]
-
-        def get_legend_handles_labels(self) -> tuple[list[object], list[str]]:
-            return [], []
-
-        def legend(self, handles: list[object], labels: list[str]) -> None:
-            return None
-
-    monkeypatch.setattr(dist_mod.sns, "boxplot", lambda **kwargs: FakeAxes())
-    monkeypatch.setattr(cns.utils, "_remove_edge_from_legend_items", lambda ax: None)
-    box_ax = cast(Any, cns.boxplot(categorical_df, x="group", y="value"))
-    assert box_ax.artists[0].edgecolor == "None"
-    assert box_ax.artists[0].facecolor == (1, 0, 0, 1)
-    assert [line.color for line in box_ax.lines] == [
-        (1, 0, 0, 1),
-        (1, 0, 0, 1),
-        "white",
-        (1, 0, 0, 1),
-        (1, 0, 0, 1),
-    ]
 
     cns.figure(120, 120)
     hist_ax = cns.histplot(


### PR DESCRIPTION
## What changed

Fix boxplot styling so `showbox=False` returns the requested axes without dividing by zero. Style only the new Seaborn box containers and legend handles, preserving existing lines, patches, and legend outlines.

Allow `fill=False` without incompatible patch properties and retain outlines for unfilled boxes. Associate medians, whiskers, caps, means, and outliers with their own boxes. Replace the obsolete artist-fallback coverage with 14 regression cases using real Matplotlib artists.

## How it was tested

- `make test` — 1,826 tests passed with 100% coverage.
- `make lint` — all checks passed.
- Eight before/after raster comparisons matched byte for byte for normal filled boxes across both orientations, with and without hue and outliers.

## Risks or follow-ups

Default filled-box appearance is unchanged. With optional caps enabled, the median now stays white and the caps match their box color. No dependency changes or known follow-ups.

## Related issue

Closes #134

## Release Notes Label

`bug`
